### PR TITLE
Fixed segfault in Environment.GetEnvironmentVariables on POSIX

### DIFF
--- a/BeefySysLib/platform/posix/PosixCommon.cpp
+++ b/BeefySysLib/platform/posix/PosixCommon.cpp
@@ -658,6 +658,9 @@ BFP_EXPORT void BFP_CALLTYPE BfpSystem_GetEnvironmentStrings(char* outStr, int* 
     while (true)
     {
         char* envStr = *envPtr;
+        if (envStr == NULL)
+            break;
+
         env.Append(envStr, strlen(envStr) + 1);
         ++envPtr;
     }


### PR DESCRIPTION
The end condition on `endStr` was not checked causing segfault in `strlen()`.