### PR TITLE
System.Threading.Parallel (experimental)

### DIFF
--- a/BeefLibs/corlib/src/Threading/Parallel.bf
+++ b/BeefLibs/corlib/src/Threading/Parallel.bf
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace System.Threading {
+	public function void InvokeFunction();
+	public function void ForFunctionLong(int64 idx);
+	public function void ForFunctionInt(int32 idx);
+
+	public sealed class Parallel {
+		static extern void InvokeInternal(void* func1, int count);
+
+		public static void Invoke(InvokeFunction[] funcs)
+		{
+		    InvokeInternal(funcs.CArray(), funcs.Count);	
+		}
+
+		static extern void ForInternal(int64 from, int64 to, void* func);
+		static extern void ForInternal(int32 from, int32 to, void* func);
+
+		public static void For(int64 from, int64 to, ForFunctionLong func)
+		{
+			ForInternal(from, to, (void*)func);
+		}
+
+		public static void For(int32 from, int32 to, ForFunctionInt func)
+		{
+			ForInternal(from, to, (void*)func);
+		}
+
+		static extern void ForeachInternal(void* arrOfPointers, int count, void* func);
+
+		// TODO: Make this generic after ICollection is available
+		public static void Foreach<T>(List<T> arr, function void(T item) func)
+		{
+			List<void*> lv=scope List<void*>();
+
+			for(ref T i in ref arr){
+			    lv.Add(&i);
+			}
+
+			ForeachInternal(lv.Ptr, arr.Count, (void*)func);
+		}
+
+		public static void Foreach<T>(T[] arr, function void(T item) func)
+		{
+			List<void*> lv=scope List<void*>();
+
+			for(ref T i in ref arr){
+			    lv.Add(&i);
+			}
+
+			ForeachInternal(lv.Ptr, arr.Count, (void*)func);
+		}
+	}
+}

--- a/BeefRT/rt/Parallel.cpp
+++ b/BeefRT/rt/Parallel.cpp
@@ -1,0 +1,56 @@
+#include "Parallel.h"
+
+// parallel_invoke can accept 2-10 params, this is used to simplify the calling
+#define PAR_INVOKE(...) concurrency::parallel_invoke(__VA_ARGS__)
+
+// This is used to simplify the switch...case part
+#define PAR_FUNCS_CASE(num,...) \
+case num:                       \
+PAR_INVOKE(__VA_ARGS__);        \
+break
+
+using namespace bf::System::Threading;
+
+void Parallel::InvokeInternal(void* funcs, int count)
+{
+	BF_ASSERT((count > 1));
+
+	PInvokeFunc* pFuncs = (PInvokeFunc*)funcs;
+	switch (count)
+	{
+		PAR_FUNCS_CASE(2, pFuncs[0], pFuncs[1]);
+		PAR_FUNCS_CASE(3, pFuncs[0], pFuncs[1], pFuncs[2]);
+		PAR_FUNCS_CASE(4, pFuncs[0], pFuncs[1], pFuncs[2], pFuncs[3]);
+		PAR_FUNCS_CASE(5, pFuncs[0], pFuncs[1], pFuncs[2], pFuncs[3], pFuncs[4]);
+		PAR_FUNCS_CASE(6, pFuncs[0], pFuncs[1], pFuncs[2], pFuncs[3], pFuncs[4], pFuncs[5]);
+		PAR_FUNCS_CASE(7, pFuncs[0], pFuncs[1], pFuncs[2], pFuncs[3], pFuncs[4], pFuncs[5], pFuncs[6]);
+		PAR_FUNCS_CASE(8, pFuncs[0], pFuncs[1], pFuncs[2], pFuncs[3], pFuncs[4], pFuncs[5], pFuncs[6], pFuncs[7]);
+		PAR_FUNCS_CASE(9, pFuncs[0], pFuncs[1], pFuncs[2], pFuncs[3], pFuncs[4], pFuncs[5], pFuncs[6], pFuncs[7], pFuncs[8]);
+		PAR_FUNCS_CASE(10, pFuncs[0], pFuncs[1], pFuncs[2], pFuncs[3], pFuncs[4], pFuncs[5], pFuncs[6], pFuncs[7], pFuncs[8], pFuncs[9]);
+
+	default:
+		// TODO: Implement invoking 10+ functions with std::thread
+		break;
+	}
+}
+
+void Parallel::ForInternal(long long from, long long to, void* func)
+{
+	// According to C#, `from` is inclusive, `to` is exclusive 
+	to -= 1;
+	concurrency::parallel_for(from, to, (PForFuncLong)func);
+}
+
+void Parallel::ForInternal(int from, int to, void* func)
+{
+	// According to C#, `from` is inclusive, `to` is exclusive 
+	to -= 1;
+	concurrency::parallel_for(from, to, (PForFuncInt)func);
+}
+
+void Parallel::ForeachInternal(void* arrOfPointers, int count, void* func)
+{
+	// I must cast it to an int** here, because a void** cannot be used as a iterater
+	int** refArr = (int**)arrOfPointers;
+	concurrency::parallel_for_each(refArr, refArr + count, (PForeachFunc)func);
+}

--- a/BeefRT/rt/Parallel.h
+++ b/BeefRT/rt/Parallel.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <ppl.h>
+#include <vector>
+
+#include "BeefySysLib/Common.h"
+#include "BfObjects.h"
+
+namespace bf
+{
+	namespace System
+	{
+		namespace Threading
+		{
+			class Parallel : public Object
+			{
+			public:
+				BF_DECLARE_CLASS(Parallel, Object);
+
+				typedef void (*PInvokeFunc)();
+
+				BFRT_EXPORT static void InvokeInternal(void* funcs, int count);
+
+				typedef void (*PForFuncLong)(long long idx);
+				typedef void (*PForFuncInt)(int idx);
+
+				BFRT_EXPORT static void ForInternal(long long from, long long to, void* func);
+				BFRT_EXPORT static void ForInternal(int from, int to, void* func);
+
+				typedef void (*PForeachFunc)(void* item);
+
+				BFRT_EXPORT static void ForeachInternal(void* arrOfPointers, int count, void* func);
+			};
+		}
+	}
+}


### PR DESCRIPTION
A PPL implemention of System.Threading.Parallel, untested, may have bugs. 
The only problem that cannot be solved is that I cannot get the pointer to every member of an IEnumerable. Otherwise, I can make Parallel.Foreach generic. 