### PR TITLE
Fix error tooltip position on multi-screen systems

### DIFF
--- a/BeefySysLib/platform/win/WinBFApp.cpp
+++ b/BeefySysLib/platform/win/WinBFApp.cpp
@@ -1131,7 +1131,19 @@ void WinBFApp::GetDesktopResolution(int& width, int& height)
 void WinBFApp::GetWorkspaceRect(int& x, int& y, int& width, int& height)
 {
 	RECT desktopRect;
-	::SystemParametersInfo(SPI_GETWORKAREA, NULL, &desktopRect, NULL);
+
+	if (::GetSystemMetrics(SM_CMONITORS) > 1) 
+	{
+		desktopRect.left = ::GetSystemMetrics(SM_XVIRTUALSCREEN);
+		desktopRect.right = ::GetSystemMetrics(SM_CXVIRTUALSCREEN);
+		desktopRect.top = ::GetSystemMetrics(SM_YVIRTUALSCREEN);
+		desktopRect.bottom = ::GetSystemMetrics(SM_CYVIRTUALSCREEN);
+	}
+	else
+	{
+		::SystemParametersInfo(SPI_GETWORKAREA, NULL, &desktopRect, NULL);	
+	}
+
 	x = desktopRect.left;
 	y = desktopRect.top;
 	width = desktopRect.right - desktopRect.left;


### PR DESCRIPTION
Fixes #113 

SPI_GETWORKAREA retrieves the size of the work area on the primary display monitor only. On multi-screen setup, this was causing the desired position of the HoverWatch to be wrongly calculated (width was ending up negative).