### PR TITLE
Changed mention of 'stack' to 'scope' in error msg

### DIFF
--- a/IDEHelper/Compiler/BfExprEvaluator.cpp
+++ b/IDEHelper/Compiler/BfExprEvaluator.cpp
@@ -6812,7 +6812,7 @@ BfTypedValue BfExprEvaluator::MatchMethod(BfAstNode* targetSrc, BfMethodBoundExp
 		{
 			if ((!resolvedTypeInstance->IsStruct()) && (!resolvedTypeInstance->IsTypedPrimitive()))
 			{
-				mModule->Fail("Objects must be allocated through 'new' or 'stack'", targetSrc);
+				mModule->Fail("Objects must be allocated through 'new' or 'scope'", targetSrc);
 				return BfTypedValue();
 			}
 			


### PR DESCRIPTION
I noticed that an error message was mentioning the use of the 'stack' keyword to allocate an object. Using it doesn't seem to work. I assume stack allocations used to be made with the 'stack' keyword, before it got changed to 'scope'?

If this is the case, this PR updates the error message.