### PR TITLE
Added String formatting constructor

### DIFF
--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -86,6 +86,12 @@ namespace System
 		    mAllocSizeAndFlags = (uint_strsize)bufferSize + (int_strsize)sizeof(char8*);
 		    mLength = 0;
 		}
+		
+		[AllowAppend]
+		public this(StringView format, params Object[] args) : this()
+		{
+			AppendF(format, params args);
+		}
 
 		[AllowAppend]
 		public this(String str)


### PR DESCRIPTION
Added constructor to String that formats arguments based on pattern on creation based on existing code.
This allows to set formatted string values without introducing additional variable.

Solution collides with `[AllowAppend]public this(params String[] strs)` constructor, so formatting based on String values only is not possible. This is intentional.