### PR TITLE
Update String.bf to replace all occurrences of char even as lastChar

### DIFF
--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -1937,7 +1937,7 @@ namespace System
 			{
 				// Optimized version for single-character replacements
 				char8 findC = find[0];
-				while (inIdx < mLength - find.mLength)
+				while (inIdx < mLength)
 				{
 					if (ptr[inIdx] == findC)
 					{


### PR DESCRIPTION
If we had said string:
```
			@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
			@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
			@@@@@@@@@@@@@@@@@@#(//////(//#,@@@@@@@@@
			@@@@@@@@@@@@@@@@*&(((((// %%((((/@@@@@@@
			@@@@@@@@@@@@@@@@(#((((((/&&/((((%%%@@@@@
			@@@@@@@@@@@@@@@@*(((((((((//%&%%%%%%@@@@
			@@@@@@@@@@@@@@@@%(((((((((/#%%%&%%%%@@@@
			@@@@@@@@@@@@@#*&(((((((((((/.@@@&&&#@@@@
			@@@@@@@@.%%%%%(//////////((#&@@@*&(@@@@@
			@@#@@(&%%((((((((((((((((((((.@@@@@@@@@@
			@ #((%&&#((((((#(((((((((((##.@@@@@@@@@@
			@@@#&##&&&&%##((((((((((####&@@@@@@@@@@@
			@@@@@@@.%###%&&############.@@@@@@@@@@@@
			@@@@@@@@@@@., .&&&&&%*&&&(/.,&/@@@@@@@@@
			@@@@@@@@@.%%%%%%%%%%%%#&&&&&%%%/@@@@@@@@
			@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
			@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
```
And we call:
```
var logo = scope String(khaLogo);
logo.Replace("@","\x20");
```
The last occurrence of char wouldn't be replaced i.e:
![image](https://user-images.githubusercontent.com/29337013/81088825-8938e780-8ec9-11ea-9f97-136d4c2e69c1.png)

This pull request fixes this for when the find string is of one char.