### PR TITLE
Fixed gray colors being switched in ConsoleColor.bf

### DIFF
--- a/BeefLibs/corlib/src/ConsoleColor.bf
+++ b/BeefLibs/corlib/src/ConsoleColor.bf
@@ -40,9 +40,9 @@ namespace System
 				return 5;
 			case .DarkYellow:
 				return 6;
-			case .DarkGray:
-				return 7;
 			case .Gray:
+				return 7;
+			case .DarkGray:
 				return 8;
 			case .Blue:
 				return 9;

--- a/BeefLibs/corlib/src/Result.bf
+++ b/BeefLibs/corlib/src/Result.bf
@@ -114,7 +114,7 @@ namespace System
 			case .Ok(var val): return val;
 			case .Err(var err):
 				{
-					Internal.FatalError(scope String()..AppendF("Unhandled error in result:\n ", err), 2);
+					Internal.FatalError(scope String()..AppendF("Unhandled error in result:\n {}", err), 2);
 				}
 			}
 		}


### PR DESCRIPTION
I had switched dark gray and normal gray colors, but fixed now :)

I fixed Result<T, TErr> so it shows the error too on unhandled result.