### PR TITLE
Fix ToString() for int32.MinValue and int64.MinValue

### DIFF
--- a/BeefLibs/corlib/src/Int32.bf
+++ b/BeefLibs/corlib/src/Int32.bf
@@ -54,15 +54,15 @@ namespace System
 	        char8[] strChars = scope:: char8[16];
 	        int32 char8Idx = 14;
 	        int32 valLeft = (int32)this;
-			bool isNeg = false;
-			if (valLeft < 0)
+			bool isNeg = true;
+			if (valLeft >= 0)
 			{
 				valLeft = -valLeft;
-				isNeg = true;
+				isNeg = false;
 			}
-	        while (valLeft > 0)
+	        while (valLeft < 0)
 	        {
-	            strChars[char8Idx] = (char8)('0' + (valLeft % 10));
+	            strChars[char8Idx] = (char8)('0' - (valLeft % 10));
 	            valLeft /= 10;
 	            char8Idx--;
 			}			
@@ -80,16 +80,16 @@ namespace System
 		    char8[] strChars = scope:: char8[16];
 		    int32 char8Idx = 14;
 		    int32 valLeft = (int32)this;
-			bool isNeg = false;
+			bool isNeg = true;
 			int minNumeralsLeft = minNumerals;
-			if (valLeft < 0)
+			if (valLeft >= 0)
 			{
 				valLeft = -valLeft;
-				isNeg = true;
+				isNeg = false;
 			}
-		    while ((valLeft > 0) || (minNumeralsLeft > 0))
+		    while ((valLeft < 0) || (minNumeralsLeft > 0))
 		    {
-		        strChars[char8Idx] = (char8)('0' + (valLeft % 10));
+		        strChars[char8Idx] = (char8)('0' - (valLeft % 10));
 		        valLeft /= 10;
 		        char8Idx--;
 				minNumeralsLeft--;

--- a/BeefLibs/corlib/src/Int32.bf
+++ b/BeefLibs/corlib/src/Int32.bf
@@ -11,8 +11,8 @@ namespace System
 			case InvalidChar(int32 partialResult);
 		}
 
-	    public const int32 MaxValue = 0x7FFFFFFF;
-	    public const int32 MinValue = -0x80000000;
+		public const int32 MaxValue = 0x7FFFFFFF;
+		public const int32 MinValue = -0x80000000;
 
 		public static int operator<=>(Self a, Self b)
 		{
@@ -48,38 +48,38 @@ namespace System
 			}
 		}
 
-	    public override void ToString(String strBuffer)
-	    {
-	        // Dumb, make better.
-	        char8[] strChars = scope:: char8[16];
-	        int32 char8Idx = 14;
-	        int32 valLeft = (int32)this;
+		public override void ToString(String strBuffer)
+		{
+			// Dumb, make better.
+			char8[] strChars = scope:: char8[16];
+			int32 char8Idx = 14;
+			int32 valLeft = (int32)this;
 			bool isNeg = true;
 			if (valLeft >= 0)
 			{
 				valLeft = -valLeft;
 				isNeg = false;
 			}
-	        while (valLeft < 0)
-	        {
-	            strChars[char8Idx] = (char8)('0' - (valLeft % 10));
-	            valLeft /= 10;
-	            char8Idx--;
-			}			
-	        if (char8Idx == 14)
-	            strChars[char8Idx--] = '0';
+			while (valLeft < 0)
+			{
+				strChars[char8Idx] = (char8)('0' - (valLeft % 10));
+				valLeft /= 10;
+				char8Idx--;
+			}
+			if (char8Idx == 14)
+				strChars[char8Idx--] = '0';
 			if (isNeg)
 				strChars[char8Idx--] = '-';
-	        char8* char8Ptr = &strChars[char8Idx + 1];
-	        strBuffer.Append(char8Ptr);
-	    }
+			char8* char8Ptr = &strChars[char8Idx + 1];
+			strBuffer.Append(char8Ptr);
+		}
 
 		void ToString(String strBuffer, int minNumerals)
 		{
-		    // Dumb, make better.
-		    char8[] strChars = scope:: char8[16];
-		    int32 char8Idx = 14;
-		    int32 valLeft = (int32)this;
+			// Dumb, make better.
+			char8[] strChars = scope:: char8[16];
+			int32 char8Idx = 14;
+			int32 valLeft = (int32)this;
 			bool isNeg = true;
 			int minNumeralsLeft = minNumerals;
 			if (valLeft >= 0)
@@ -87,19 +87,19 @@ namespace System
 				valLeft = -valLeft;
 				isNeg = false;
 			}
-		    while ((valLeft < 0) || (minNumeralsLeft > 0))
-		    {
-		        strChars[char8Idx] = (char8)('0' - (valLeft % 10));
-		        valLeft /= 10;
-		        char8Idx--;
+			while ((valLeft < 0) || (minNumeralsLeft > 0))
+			{
+				strChars[char8Idx] = (char8)('0' - (valLeft % 10));
+				valLeft /= 10;
+				char8Idx--;
 				minNumeralsLeft--;
-			}			
-		    if (char8Idx == 14)
-		        strChars[char8Idx--] = '0';
+			}
+			if (char8Idx == 14)
+				strChars[char8Idx--] = '0';
 			if (isNeg)
 				strChars[char8Idx--] = '-';
-		    char8* char8Ptr = &strChars[char8Idx + 1];
-		    strBuffer.Append(char8Ptr);
+			char8* char8Ptr = &strChars[char8Idx + 1];
+			strBuffer.Append(char8Ptr);
 		}
 
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
@@ -118,7 +118,7 @@ namespace System
 				if ((format.Length > 0) && (format[0] == '0'))
 				{
 					if (Int32.Parse(format) case .Ok(let wantLen))
-					{								
+					{
 						minNumerals = wantLen;
 					}
 				}
@@ -127,8 +127,8 @@ namespace System
 			ToString(outString, minNumerals);
 		}
 
-	    public static Result<int32, ParseError> Parse(StringView val, NumberStyles style)
-	    {
+		public static Result<int32, ParseError> Parse(StringView val, NumberStyles style)
+		{
 			if (val.IsEmpty)
 				return .Err(.NoValue);
 
@@ -136,7 +136,7 @@ namespace System
 			int32 result = 0;
 
 			int32 radix = style.HasFlag(.AllowHexSpecifier) ? 0x10 : 10;
-						
+
 			for (int32 i = 0; i < val.Length; i++)
 			{
 				char8 c = val[i];
@@ -181,7 +181,7 @@ namespace System
 			}
 
 			return isNeg ? -result : result;
-	    }
+		}
 
 		public static Result<int32, ParseError> Parse(StringView val)
 		{

--- a/BeefLibs/corlib/src/Int64.bf
+++ b/BeefLibs/corlib/src/Int64.bf
@@ -71,16 +71,16 @@ namespace System
 		    char8[] strChars = scope:: char8[22];
 			int32 char8Idx = 20;
 			int64 valLeft = (int64)this;
-			bool isNeg = false;
+			bool isNeg = true;
 			int minNumeralsLeft = 0;
-			if (valLeft < 0)
+			if (valLeft >= 0)
 			{
 				valLeft = -valLeft;
-				isNeg = true;
+				isNeg = false;
 			}
-			while ((valLeft > 0) || (minNumeralsLeft > 0))
+			while ((valLeft < 0) || (minNumeralsLeft > 0))
 			{
-			    strChars[char8Idx] = (char8)('0' + (valLeft % 10));
+			    strChars[char8Idx] = (char8)('0' - (valLeft % 10));
 			    valLeft /= 10;
 			    char8Idx--;
 				minNumeralsLeft--;

--- a/BeefLibs/corlib/src/Int64.bf
+++ b/BeefLibs/corlib/src/Int64.bf
@@ -11,9 +11,9 @@ namespace System
 			case InvalidChar(int64 partialResult);
 		}
 
-	    public const int64 MaxValue = 0x7FFFFFFFFFFFFFFFL;
-	    //public const long MinValue = -0x8000000000000000L;
-	    public const int64 MinValue = -0x7FFFFFFFFFFFFFFFL; //TODO: Should be one lower!
+		public const int64 MaxValue = 0x7FFFFFFFFFFFFFFFL;
+		//public const long MinValue = -0x8000000000000000L;
+		public const int64 MinValue = -0x7FFFFFFFFFFFFFFFL; //TODO: Should be one lower!
 
 		public static int operator<=>(Int64 a, Int64 b)
 		{
@@ -67,8 +67,8 @@ namespace System
 
 		public override void ToString(String strBuffer)
 		{
-		    // Dumb, make better.
-		    char8[] strChars = scope:: char8[22];
+			// Dumb, make better.
+			char8[] strChars = scope:: char8[22];
 			int32 char8Idx = 20;
 			int64 valLeft = (int64)this;
 			bool isNeg = true;
@@ -80,13 +80,13 @@ namespace System
 			}
 			while ((valLeft < 0) || (minNumeralsLeft > 0))
 			{
-			    strChars[char8Idx] = (char8)('0' - (valLeft % 10));
-			    valLeft /= 10;
-			    char8Idx--;
+				strChars[char8Idx] = (char8)('0' - (valLeft % 10));
+				valLeft /= 10;
+				char8Idx--;
 				minNumeralsLeft--;
-			}			
+			}
 			if (char8Idx == 20)
-			    strChars[char8Idx--] = '0';
+				strChars[char8Idx--] = '0';
 			if (isNeg)
 				strChars[char8Idx--] = '-';
 			char8* char8Ptr = &strChars[char8Idx + 1];
@@ -104,7 +104,7 @@ namespace System
 			int64 result = 0;
 
 			int64 radix = style.HasFlag(.AllowHexSpecifier) ? 0x10 : 10;
-						
+
 			for (int32 i = 0; i < val.Length; i++)
 			{
 				char8 c = val[i];
@@ -143,7 +143,7 @@ namespace System
 				else
 					return .Err(.InvalidChar(result));
 			}
-			
+
 			return isNeg ? -result : result;
 		}
 


### PR DESCRIPTION
Before this PR `ToString()` returned `"-0"` for `-0x80000000` (in case of `int32`) and for `-0x8000000000000000` (in case of `int64`). After this PR `ToString()` returns correct values