### PR TITLE
Array CopyTo for spans

### DIFF
--- a/BeefLibs/corlib/src/Array.bf
+++ b/BeefLibs/corlib/src/Array.bf
@@ -274,12 +274,12 @@ namespace System
 			Internal.MemCpy(destination.Ptr, &GetRef(0), strideof(T) * mLength, alignof(T));
 		}
 
-		public void CopyTo(Span<T> destination, int srcOffset, int length)
+		public void CopyTo(Span<T> destination, int srcOffset)
 		{
-			Debug.Assert(length >= 0);
-			Debug.Assert((uint)srcOffset + (uint)length <= (uint)mLength);
-			Debug.Assert((uint)length <= (uint)destination.Length);
-			Internal.MemCpy(destination.Ptr, &GetRef(srcOffset), strideof(T) * length, alignof(T));
+			Debug.Assert(destination.Length >= mLength);
+			Debug.Assert((uint)srcOffset <= (uint)mLength);
+
+			Internal.MemCpy(destination.Ptr, &GetRef(srcOffset), strideof(T) * (mLength - srcOffset), alignof(T));
 		}
 
 		public Span<T>.Enumerator GetEnumerator()

--- a/BeefLibs/corlib/src/Array.bf
+++ b/BeefLibs/corlib/src/Array.bf
@@ -268,6 +268,20 @@ namespace System
 				arrayTo.GetRef(i + dstOffset) = (T2)GetRef(i + srcOffset);
 		}
 
+		public void CopyTo(Span<T> destination)
+		{
+			Debug.Assert(destination.Length >= mLength);
+			Internal.MemCpy(destination.Ptr, &GetRef(0), strideof(T) * mLength, alignof(T));
+		}
+
+		public void CopyTo(Span<T> destination, int srcOffset, int length)
+		{
+			Debug.Assert(length >= 0);
+			Debug.Assert((uint)srcOffset + (uint)length <= (uint)mLength);
+			Debug.Assert((uint)length <= (uint)destination.Length);
+			Internal.MemCpy(destination.Ptr, &GetRef(srcOffset), strideof(T) * length, alignof(T));
+		}
+
 		public Span<T>.Enumerator GetEnumerator()
 		{
 			return .(this);

--- a/BeefLibs/corlib/src/Array.bf
+++ b/BeefLibs/corlib/src/Array.bf
@@ -270,16 +270,18 @@ namespace System
 
 		public void CopyTo(Span<T> destination)
 		{
-			Debug.Assert(destination.Length >= mLength);
+			Debug.Assert(destination.[Friend]mPtr != null);
+			Debug.Assert(destination.[Friend]mLength >= mLength);
+
 			Internal.MemCpy(destination.Ptr, &GetRef(0), strideof(T) * mLength, alignof(T));
 		}
 
 		public void CopyTo(Span<T> destination, int srcOffset)
 		{
-			Debug.Assert(destination.Length >= mLength);
-			Debug.Assert((uint)srcOffset <= (uint)mLength);
+			Debug.Assert(destination.[Friend]mPtr != null);
+			Debug.Assert((uint)destination.[Friend]mLength - (uint)srcOffset < (uint)mLength);
 
-			Internal.MemCpy(destination.Ptr, &GetRef(srcOffset), strideof(T) * (mLength - srcOffset), alignof(T));
+			Internal.MemCpy(destination.Ptr, &GetRef(srcOffset), strideof(T) * (destination.Length - srcOffset), alignof(T));
 		}
 
 		public Span<T>.Enumerator GetEnumerator()


### PR DESCRIPTION
CopyTo, allows copying memory from an array to a span.