### PR TITLE
Hooked up NumberFormatter calls for all int type ToString methods

### DIFF
--- a/BeefLibs/corlib/src/Int16.bf
+++ b/BeefLibs/corlib/src/Int16.bf
@@ -41,12 +41,14 @@ namespace System
 
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
 		{
-			if ((format != null) && (format.StartsWith("X")))
+			if(format == null || format.IsEmpty)
 			{
-				((uint64)this).ToString(outString, format, formatProvider);
-				return;
+				ToString(outString);
 			}
-			((int64)this).ToString(outString, format, formatProvider);
+			else
+			{
+				NumberFormatter.NumberToString(format, (int32)this, formatProvider, outString);
+			}
 		}
 	}
 }

--- a/BeefLibs/corlib/src/Int32.bf
+++ b/BeefLibs/corlib/src/Int32.bf
@@ -104,27 +104,14 @@ namespace System
 
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
 		{
-			int minNumerals = -1;
-
-			//TOTAL HACK:
-			if (format != null)
+			if(format == null || format.IsEmpty)
 			{
-				if (format.StartsWith("X"))
-				{
-					((UInt64)(uint32)this).ToString(outString, format, formatProvider);
-					return;
-				}
-
-				if ((format.Length > 0) && (format[0] == '0'))
-				{
-					if (Int32.Parse(format) case .Ok(let wantLen))
-					{
-						minNumerals = wantLen;
-					}
-				}
+				ToString(outString);
 			}
-
-			ToString(outString, minNumerals);
+			else
+			{
+				NumberFormatter.NumberToString(format, (int32)this, formatProvider, outString);
+			}
 		}
 
 		public static Result<int32, ParseError> Parse(StringView val, NumberStyles style)

--- a/BeefLibs/corlib/src/Int64.bf
+++ b/BeefLibs/corlib/src/Int64.bf
@@ -55,13 +55,14 @@ namespace System
 		static String sHexLowerChars = "0123456789abcdef";
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
 		{
-			if ((format != null) && (!format.IsEmpty))
+			if(format == null || format.IsEmpty)
 			{
-				((UInt64)this).ToString(outString, format, formatProvider);
-				return;
+				ToString(outString);
 			}
-
-			ToString(outString);
+			else
+			{
+				NumberFormatter.NumberToString(format, (int64)this, formatProvider, outString);
+			}
 		}
 
 		public override void ToString(String strBuffer)

--- a/BeefLibs/corlib/src/Int8.bf
+++ b/BeefLibs/corlib/src/Int8.bf
@@ -41,12 +41,14 @@ namespace System
 
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
 		{
-			if ((format != null) && (format.StartsWith("X")))
+			if(format == null || format.IsEmpty)
 			{
-				((uint64)this).ToString(outString, format, formatProvider);
-				return;
+				ToString(outString);
 			}
-			((int64)this).ToString(outString, format, formatProvider);
+			else
+			{
+				NumberFormatter.NumberToString(format, (int32)this, formatProvider, outString);
+			}
 		}
 	}
 }

--- a/BeefLibs/corlib/src/UInt16.bf
+++ b/BeefLibs/corlib/src/UInt16.bf
@@ -41,12 +41,14 @@ namespace System
 
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
 		{
-			if ((format != null) && (format.StartsWith("X")))
+			if(format == null || format.IsEmpty)
 			{
-				((uint64)this).ToString(outString, format, formatProvider);
-				return;
+				ToString(outString);
 			}
-			((int64)this).ToString(outString, format, formatProvider);
+			else
+			{
+				NumberFormatter.NumberToString(format, (uint32)this, formatProvider, outString);
+			}
 		}
 	}
 }

--- a/BeefLibs/corlib/src/UInt32.bf
+++ b/BeefLibs/corlib/src/UInt32.bf
@@ -97,27 +97,14 @@ namespace System
 
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
 		{
-			int minNumerals = -1;
-
-			//TOTAL HACK:
-			if (format != null)
+			if(format == null || format.IsEmpty)
 			{
-				if (format.StartsWith("X"))
-				{
-					((UInt64)(uint32)this).ToString(outString, format, formatProvider);
-					return;
-				}
-
-				if ((format.Length > 0) && (format[0] == '0'))
-				{
-					if (Int32.Parse(format) case .Ok(let wantLen))
-					{								
-						minNumerals = wantLen;
-					}
-				}
+				ToString(outString);
 			}
-
-			ToString(outString, minNumerals);
+			else
+			{
+				NumberFormatter.NumberToString(format, (uint32)this, formatProvider, outString);
+			}
 		}
 
 		public static Result<uint32, ParseError> Parse(StringView val)

--- a/BeefLibs/corlib/src/UInt64.bf
+++ b/BeefLibs/corlib/src/UInt64.bf
@@ -47,73 +47,14 @@ namespace System
 		static String sHexLowerChars = "0123456789abcdef";
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
 		{
-			if (format != null)
+			if(format == null || format.IsEmpty)
 			{
-				if (format == "P")
-				{
-					String hexChars = (format == "p") ? sHexLowerChars : sHexUpperChars;
-
-					const int bufLen = 18;
-					char8* strChars = scope:: char8[bufLen]* (?);
-					int32 curLen = 0;
-					uint64 valLeft = (uint64)this;
-					while (valLeft > 0)
-					{
-						if (curLen == 8)
-							strChars[bufLen - curLen++ - 1] = '\'';
-					    strChars[bufLen - curLen++ - 1] = hexChars[(int)(valLeft & 0xF)];
-					    valLeft >>= 4;
-					}
-
-					while (curLen < 10)
-					{
-						if (curLen == 8)
-							strChars[bufLen - curLen++ - 1] = '\'';
-						strChars[bufLen - curLen++ - 1] = '0';
-					}
-
-					char8* char8Ptr = &strChars[bufLen - curLen];
-					outString.Append(char8Ptr, curLen);
-
-					return;
-				}
-
-				if (format.StartsWith("X", StringComparison.OrdinalIgnoreCase))
-				{
-					String hexChars = (format == "x") ? sHexLowerChars : sHexUpperChars;
-
-					const int bufLen = 18;
-					char8* strChars = scope:: char8[bufLen]* (?);
-					int32 curLen = 0;
-					uint64 valLeft = (uint64)this;
-					while (valLeft > 0)
-					{
-					    strChars[bufLen - curLen - 1] = hexChars[(int)(valLeft & 0xF)];
-					    valLeft >>= 4;
-					    curLen++;
-					}
-
-					int32 minChars = 1;
-					if (format.Length > 0)
-					{
-						if (Int32.Parse(StringView(format, 1)) case .Ok(out minChars))
-						   minChars = Math.Max(1, minChars);
-					}
-
-					while (curLen < minChars)
-					{
-						strChars[bufLen - curLen - 1] = '0';
-						curLen++;
-					}
-
-					char8* char8Ptr = &strChars[bufLen - curLen];
-					outString.Append(char8Ptr, curLen);
-
-					return;
-				}
+				ToString(outString);
 			}
-
-			ToString(outString);
+			else
+			{
+				NumberFormatter.NumberToString(format, (uint64)this, formatProvider, outString);
+			}
 		}
 
 		public override void ToString(String strBuffer)

--- a/BeefLibs/corlib/src/UInt8.bf
+++ b/BeefLibs/corlib/src/UInt8.bf
@@ -41,12 +41,14 @@ namespace System
 
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
 		{
-			if ((format != null) && (format.StartsWith("X")))
+			if(format == null || format.IsEmpty)
 			{
-				((uint64)this).ToString(outString, format, formatProvider);
-				return;
+				ToString(outString);
 			}
-			((int64)this).ToString(outString, format, formatProvider);
+			else
+			{
+				NumberFormatter.NumberToString(format, (uint32)this, formatProvider, outString);
+			}
 		}
 	}
 }


### PR DESCRIPTION
All int types (int8, int16, int32, int64, uint8, uint16, uint32, uint64) now call NumberFormatter.NumberToString in their ToString methods. This should fix format codes being wrong for int types, as well as fix some other internal ToString functions in corlib (for example the K format specifier in DateTime was printing incorrect-formatted UTC offsets)