### PR TITLE
Remove unnecessary delete statements

### DIFF
--- a/BeefySysLib/FileHandleStream.cpp
+++ b/BeefySysLib/FileHandleStream.cpp
@@ -13,8 +13,7 @@ FileHandleStream::FileHandleStream()
 
 FileHandleStream::~FileHandleStream()
 {
-	if (mCacheBuffer != NULL)
-		delete mCacheBuffer;
+	delete mCacheBuffer;
 	if (mFileHandle != NULL)	
 		::CloseHandle_File(mFileHandle);	
 }

--- a/BeefySysLib/FileStream.cpp
+++ b/BeefySysLib/FileStream.cpp
@@ -16,8 +16,7 @@ FileStream::FileStream()
 
 FileStream::~FileStream()
 {
-	if (mCacheBuffer != NULL)
-		delete mCacheBuffer;
+	delete mCacheBuffer;
 	if (mFP != NULL)
 		fclose(mFP);
 }

--- a/BeefySysLib/img/PSDReader.cpp
+++ b/BeefySysLib/img/PSDReader.cpp
@@ -176,8 +176,7 @@ PSDReader::PSDReader()
 
 PSDReader::~PSDReader()
 {
-	if (mFS != NULL)
-		delete mFS;
+	delete mFS;
 	for (int i = 0; i < (int) mPSDLayerInfoVector.size(); i++)
 		delete mPSDLayerInfoVector[i];
 	PSDPatternMap::iterator itr = mPSDPatternMap.begin();

--- a/BeefySysLib/platform/win/DSoundManager.cpp
+++ b/BeefySysLib/platform/win/DSoundManager.cpp
@@ -417,11 +417,10 @@ void DSoundManager::ReleaseSounds()
 void DSoundManager::ReleaseChannels()
 {
 	for (int i = 0; i < MAX_CHANNELS; i++)
-		if (mPlayingSounds[i] != NULL)
-		{
-			delete mPlayingSounds[i];
-			mPlayingSounds[i] = NULL;
-		}
+	{
+		delete mPlayingSounds[i];
+		mPlayingSounds[i] = NULL;
+	}
 }
 
 void DSoundManager::ReleaseFreeChannels()

--- a/BeefySysLib/util/BSpline.cpp
+++ b/BeefySysLib/util/BSpline.cpp
@@ -31,11 +31,8 @@ BSpline2D::~BSpline2D()
 
 void BSpline2D::AddPt(float x, float y)
 {
-	if (mUVals != NULL)
-	{
-		delete mUVals;
-		mUVals = NULL;
-	}
+	delete mUVals;
+	mUVals = NULL;
 
 	Point2D pt;
 	pt.mX = x;

--- a/IDEHelper/Compiler/BfContext.cpp
+++ b/IDEHelper/Compiler/BfContext.cpp
@@ -925,11 +925,8 @@ void BfContext::RebuildType(BfType* type, bool deleteOnDemandTypes, bool rebuild
 	}
 	else
 	{
-		if (typeInst->mHotTypeData != NULL)
-		{
-			delete typeInst->mHotTypeData;
-			typeInst->mHotTypeData = NULL;
-		}
+		delete typeInst->mHotTypeData;
+		typeInst->mHotTypeData = NULL;
 	}
 
 	auto typeDef = typeInst->mTypeDef;	
@@ -1009,12 +1006,9 @@ void BfContext::RebuildType(BfType* type, bool deleteOnDemandTypes, bool rebuild
 	typeInst->mTypeWarned = false;		
 	typeInst->mIsSplattable = false;
 	typeInst->mHasPackingHoles = false;
-	typeInst->mWantsGCMarking = false;	
-	if (typeInst->mTypeInfoEx != NULL)
-	{
-		delete typeInst->mTypeInfoEx;
-		typeInst->mTypeInfoEx = NULL;
-	}
+	typeInst->mWantsGCMarking = false;
+	delete typeInst->mTypeInfoEx;
+	typeInst->mTypeInfoEx = NULL;
 
 	if (typeInst->IsGenericTypeInstance())
 	{

--- a/IDEHelper/Compiler/BfDefBuilder.cpp
+++ b/IDEHelper/Compiler/BfDefBuilder.cpp
@@ -1583,8 +1583,7 @@ void BfDefBuilder::Visit(BfTypeDeclaration* typeDeclaration)
 
 			if (prevRevisionTypeDef->mDefState == BfTypeDef::DefState_AwaitingNewVersion)
 			{
-				if (prevRevisionTypeDef->mNextRevision != NULL)
-					delete prevRevisionTypeDef->mNextRevision;
+				delete prevRevisionTypeDef->mNextRevision;
 				prevRevisionTypeDef->mNextRevision = mCurTypeDef;
 				BF_ASSERT(mCurTypeDef->mSystem != NULL);
 				mCurActualTypeDef = prevRevisionTypeDef;

--- a/IDEHelper/Compiler/BfModuleTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfModuleTypeUtils.cpp
@@ -6028,8 +6028,8 @@ BfType* BfModule::ResolveGenericType(BfType* unspecializedType, BfTypeVector* ty
 			delegateType = dlgType;			
 		}
 
-		if (delegateType->mTypeDef != NULL)
-			delete delegateType->mTypeDef;
+		delete delegateType->mTypeDef;
+		delegateType->mTypeDef = NULL;
 		BfDelegateInfo* delegateInfo = delegateType->GetDelegateInfo();
 		delegateInfo->mParams.Clear();
 		

--- a/IDEHelper/Compiler/BfParser.cpp
+++ b/IDEHelper/Compiler/BfParser.cpp
@@ -3403,8 +3403,7 @@ BF_EXPORT void BF_CALLTYPE BfParser_SetSource(BfParser* bfParser, const char* da
 
 BF_EXPORT void BF_CALLTYPE BfParser_SetCharIdData(BfParser* bfParser, uint8* data, int length)
 {
-	if (bfParser->mParserData->mCharIdData != NULL)
-		delete bfParser->mParserData->mCharIdData;
+	delete bfParser->mParserData->mCharIdData;
 	bfParser->mParserData->mCharIdData = new uint8[length];
 	memcpy(bfParser->mParserData->mCharIdData, data, length);
 }

--- a/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
@@ -1878,8 +1878,7 @@ BfGenericTypeInfo::~BfGenericTypeInfo()
 {
 	for (auto genericParamInstance : mGenericParams)
 		genericParamInstance->Release();
-	if (mGenericExtensionInfo != NULL)
-		delete mGenericExtensionInfo;
+	delete mGenericExtensionInfo;
 }
 
 BfGenericTypeInfo::GenericParamsVector* BfTypeInstance::GetGenericParamsVector(BfTypeDef* declaringTypeDef)

--- a/IDEHelper/Compiler/BfSource.cpp
+++ b/IDEHelper/Compiler/BfSource.cpp
@@ -38,8 +38,7 @@ BfSource::~BfSource()
 {
 	int sourceCount = gSourceCount--;	
 
-	if (mSourceData != NULL)
-		delete mSourceData;
+	delete mSourceData;
 
 	if (mSrcAllocSize >= 0)
 		delete mSrc;	

--- a/IDEHelper/Compiler/BfSystem.cpp
+++ b/IDEHelper/Compiler/BfSystem.cpp
@@ -694,8 +694,7 @@ void BfTypeDef::PopulateMemberSets()
 BfTypeDef::~BfTypeDef()
 {
 	BfLogSysM("BfTypeDef::~BfTypeDef %08X\n", this);
-	if (mNextRevision != NULL)
-		delete mNextRevision;
+	delete mNextRevision;
 	FreeMembers();
 
 	if (mSource != NULL)
@@ -3139,8 +3138,7 @@ void BfSystem::RemoveDeletedParsers()
 		}
 
 		BfLogSys(this, "Removing Queued Parser: %p\n", bfParser);
-		if (bfParser != NULL)
-			delete bfParser;
+		delete bfParser;
 		CheckLockYield();
 	}
 }


### PR DESCRIPTION
If a value is null, the C++ delete statement will do nothing, so there is bo need to explicitly check if the value is null.