### PR TITLE
Fix misc bugs w/ IDE build in folders with a space

### DIFF
--- a/Debugger64/BeefProj.toml
+++ b/Debugger64/BeefProj.toml
@@ -10,7 +10,7 @@ TargetDirectory = "$(WorkspaceDir)/../IDE/dist"
 TargetName = "IDEHelper64_d.dll"
 BuildCommandsOnCompile = "IfFilesChanged"
 BuildCommandsOnRun = "IfFilesChanged"
-PostBuildCmds = ["\"$(WorkspaceDir)\\..\\bin\\msbuild.bat\" \"$(WorkspaceDir)\\..\\Debugger64\\Debugger64.vcxproj\" /p:Configuration=Debug /p:Platform=X64 /p:SolutionDir=$(Slash \"$(WorkspaceDir)\\\\..\\\\\") /v:m"]
+PostBuildCmds = ["\"$(WorkspaceDir)\\..\\bin\\msbuild.bat\" $(Slash \"$(WorkspaceDir)\\\\..\\\\Debugger64\\\\Debugger64.vcxproj\") /p:Configuration=Debug /p:Platform=X64 /p:SolutionDir=$(Slash \"$(WorkspaceDir)\\\\..\\\\\") /v:m"]
 OptimizationLevel = "O0"
 
 [Configs.Debug.Win32]

--- a/IDE/BeefProj.toml
+++ b/IDE/BeefProj.toml
@@ -24,8 +24,8 @@ OtherLinkFlags = ""
 TargetDirectory = "$(WorkspaceDir)/dist"
 TargetName = "BeefIDE_d"
 OtherLinkFlags = "$(LinkFlags) Comdlg32.lib kernel32.lib user32.lib advapi32.lib shell32.lib IDEHelper64_d.lib"
-DebugCommandArguments = "-proddir=C:\\Beef\\IDEHelper\\Tests"
-DebugWorkingDirectory = "c:\\Beef"
+DebugCommandArguments = "-proddir=\"$(WorkspaceDir)\\..\\IDEHelper\\Tests\""
+DebugWorkingDirectory = "$(WorkspaceDir)\\.."
 EnvironmentVars = ["_NO_DEBUG_HEAP=1"]
 
 [Configs.Release.Win32]

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -7801,10 +7801,13 @@ namespace IDE
 			else if (runFlags.HasFlag(.ShellCommand))
 			{
 				String shellArgs = scope .();
+				shellArgs.Append("/s ");
 				shellArgs.Append("/c ");
+				shellArgs.Append("\"");
 				IDEUtils.AppendWithOptionalQuotes(shellArgs, fileName);
 				shellArgs.Append(" ");
 				shellArgs.Append(args);
+				shellArgs.Append("\"");
 				startInfo.SetFileName("cmd.exe");
 				startInfo.SetArguments(shellArgs);
 			}

--- a/IDE/src/IDEUtils.bf
+++ b/IDE/src/IDEUtils.bf
@@ -19,10 +19,13 @@ namespace IDE
 
 		public static void AppendWithOptionalQuotes(String targetStr, String srcFileName)
 		{
-		    if (!srcFileName.Contains(' '))
-			    targetStr.Append(srcFileName);
-			else
+			bool hasSpace = srcFileName.Contains(' ');
+			bool alreadyQuoted = (srcFileName.Length > 0 && srcFileName[0] == '"' && srcFileName[srcFileName.Length - 1] == '"');
+
+			if (hasSpace && !alreadyQuoted)
 				targetStr.Append("\"", srcFileName, "\"");
+			else
+			    targetStr.Append(srcFileName);
 		}
 
         public static bool FixFilePath(String filePath, char8 wantSlash, char8 otherSlash)

--- a/IDEHelper/BeefProj.toml
+++ b/IDEHelper/BeefProj.toml
@@ -17,7 +17,7 @@ TargetDirectory = "$(WorkspaceDir)/../IDE/dist"
 TargetName = "IDEHelper64_d.dll"
 BuildCommandsOnCompile = "IfFilesChanged"
 BuildCommandsOnRun = "IfFilesChanged"
-PostBuildCmds = ["\"$(WorkspaceDir)\\..\\bin\\msbuild.bat\" \"$(WorkspaceDir)\\..\\IDEHelper\\IDEHelper.vcxproj\" /p:Configuration=Debug /p:Platform=X64 /p:SolutionDir=$(Slash \"$(WorkspaceDir)\\\\..\\\\\") /v:m"]
+PostBuildCmds = ["\"$(WorkspaceDir)\\..\\bin\\msbuild.bat\" $(Slash \"$(WorkspaceDir)\\\\..\\\\IDEHelper\\\\IDEHelper.vcxproj\") /p:Configuration=Debug /p:Platform=X64 /p:SolutionDir=$(Slash \"$(WorkspaceDir)\\\\..\\\\\") /v:m"]
 
 [Configs.Release.Win32]
 TargetDirectory = "$(WorkspaceDir)/../IDE/dist"

--- a/bin/msbuild.bat
+++ b/bin/msbuild.bat
@@ -1,10 +1,10 @@
 @echo off
 
-for /f "usebackq tokens=*" %%i in (`%~dp0\vswhere -prerelease -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
-  set VcInstallDir=%%i
+for /f "usebackq tokens=*" %%i in (`"%~dp0\vswhere" -prerelease -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
+  set "VcInstallDir=%%i"
 )
 
-SET VsBuildDir=%VcInstallDir%\MSBuild\15.0
+SET "VsBuildDir=%VcInstallDir%\MSBuild\15.0"
 @IF EXIST "%VcInstallDir%\MSBuild\Current" SET VsBuildDir=%VcInstallDir%\MSBuild\Current
 
 "%VsBuildDir%\Bin\MSBuild.exe" %*


### PR DESCRIPTION
- Add quotes to bin/msbuild.bat paths
- Tweak PostBuildCmds in Debugger64 and IDEHelper
- Tweak Debug paths in IDE project to be relative to Workspace
- Modify AppendWithOptionalQuotes to not add more quotes if source string already in quotes
- Modify quoting behavior in build shell command construction