### PR TITLE
build.sh check for llvm 8 instead of 11

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -20,7 +20,7 @@ if [ ! -f ../BeefySysLib/third_party/libffi/Makefile ]; then
 	cd $SCRIPTPATH
 fi
 
-if [ ! -d ../extern/llvm_linux_8_0_0/bin ]; then
+if [ ! -d ../extern/llvm_linux_11_0_0/bin ]; then
 	echo Building LLVM...
 	cd ../extern
 	./llvm_build.sh


### PR DESCRIPTION
It is fine in build.bat but not fine in build.sh.  
The script llvm_build.sh work with llvm 11 and not 8