### PR TITLE
[Enhancement] Add rebuild workspace menu item

### DIFF
--- a/IDE/src/Commands.bf
+++ b/IDE/src/Commands.bf
@@ -234,6 +234,7 @@ namespace IDE
 			Add("Open Workspace", new => gApp.OpenWorkspace);
 			Add("Profile", new => gApp.[Friend]DoProfile);
 			Add("Quick Info", new => gApp.Cmd_QuickInfo);
+			Add("Rebuild Workspace", new => gApp.[Friend]CleanAndCompile);
 			Add("Recent File Next", new => gApp.ShowRecentFileNext);
 			Add("Recent File Prev", new => gApp.ShowRecentFilePrev);
 			Add("Reformat Document", new => gApp.Cmd_ReformatDocument);

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -752,6 +752,7 @@ namespace IDE
 				Add("Open File", "Ctrl+O");
 				Add("Open Workspace", "Ctrl+Shift+O");
 				Add("Quick Info", "Ctrl+K, Ctrl+I");
+				Add("Rebuild Workspace", "F8");
 				Add("Recent File Next", "Ctrl+Tab");
 				Add("Recent File Prev", "Shift+Ctrl+Tab");
 				Add("Reformat Document", "Ctrl+K, Ctrl+D");


### PR DESCRIPTION
Copies most of the behaviour from clean and compile.

+ Add CleanAndCompile IDECommand
+ Add "Rebuild Workspace" menu item
+ Add F8 keybind to the "Rebuild Workspace" menu item

1> Make sure the required projects are loaded and we're not compiling or running
2> Set the mWantsClean bool to true
3> Run the compile command without hotpatch support (hotpatch is not supported due to the clean)

The check for the mWantsClean bool (and performing the actual cleaning) is handled in IDE.IDEApp.Compile(..)