### PR TITLE
No need of the 2.2GB full LLVM git clone

### DIFF
--- a/extern/llvm_build.sh
+++ b/extern/llvm_build.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 set -e
 
+# LLVM source code, zip file 25MB : https://releases.llvm.org/download.html#11.0.0
+#https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-11.0.0.src.tar.xz 
+
 if [ ! -d llvm-project_11_0_0 ]; then
-	git clone https://github.com/llvm/llvm-project.git llvm-project_11_0_0
-
-	if [ -d llvm-project_11_0_0 ]; then
-		cd llvm-project_11_0_0
- 		git checkout llvmorg-11.0.0
-		cd ..
-	fi 
-
+	tar -xf llvm-11.0.0.src.tar.xz
+	mkdir llvm-project_11_0_0
+	mv llvm-11.0.0.src llvm-project_11_0_0/llvm
 fi
 
 if [ ! -d llvm_linux_11_0_0 ]; then


### PR DESCRIPTION
I make sure to keep everything at same location "llvm-project_11_0_0/llvm" so existing files are not affected.

1. extract llvm-11.0.0.src.tar.xz
2. create directory llvm-project_11_0_0
3. rename llvm-11.0.0.src to llvm and move llvm to llvm-project_11_0_0/llvm
Now everything work fine as same as git clone but it is much more light weight (25MB zip file)

Everything else remain the same. 


Please note I am not doing wget or curl to download file llvm-11.0.0.src.tar.xz before starting the process.
Because I want you to copy it in Beef repo in extern directory.
When user download Beef code, llvm-11.0.0.src.tar.xz 25MB file should already be there in extern directory.

Can download here : Click on "LLVM source code" at https://releases.llvm.org/download.html#11.0.0
Direct link : https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-11.0.0.src.tar.xz

If accepted these changes would need to be done in windows bat file too "llvm_build.bat"


More detail on the why this was a problem and this change resolved at issue [#679 : 25MB LLVM source code zip file instead of full LLVM git clone](https://github.com/beefytech/Beef/issues/679)  