### PR TITLE
use llvm-11.0.0.src.tar.xz if it exists

### DIFF
--- a/extern/llvm_build.sh
+++ b/extern/llvm_build.sh
@@ -2,6 +2,11 @@
 set -e
 
 if [ ! -d llvm-project_11_0_0 ]; then
+  if [ -f llvm-11.0.0.src.tar.xz ]; then # if user downloaded llvm-11.0.0.src.tar.xz then use it instead
+	tar -xf llvm-11.0.0.src.tar.xz
+	mkdir llvm-project_11_0_0
+	mv llvm-11.0.0.src llvm-project_11_0_0/llvm
+  else # git clone llvm repo if llvm-11.0.0.src.tar.xz does not exists 
 	git clone https://github.com/llvm/llvm-project.git llvm-project_11_0_0
 
 	if [ -d llvm-project_11_0_0 ]; then
@@ -9,8 +14,8 @@ if [ ! -d llvm-project_11_0_0 ]; then
  		git checkout llvmorg-11.0.0
 		cd ..
 	fi 
-
-fi
+  fi
+fi #end if llvm-project_11_0_0 exists
 
 if [ ! -d llvm_linux_11_0_0 ]; then
 	mkdir llvm_linux_11_0_0	


### PR DESCRIPTION
User can download llvm-11.0.0.src.tar.xz into extern directory so the build will not git clone LLVM repo.