### PR TITLE
Update llvm_build.bat

### DIFF
--- a/extern/llvm_build.bat
+++ b/extern/llvm_build.bat
@@ -1,7 +1,7 @@
 PUSHD %~dp0
 
 @IF EXIST llvm-project_11_0_0 GOTO LLVM_HAS
-git clone --depth 1 --branch llvmorg-11.0.0 https://github.com/llvm/llvm-project.git llvm-project_11_0_0
+git clone --depth 1 --branch llvmorg-11.0.0 --config core.autocrlf=false https://github.com/llvm/llvm-project.git llvm-project_11_0_0
 pushd llvm-project_11_0_0
 
 :LLVM_HAS

--- a/extern/llvm_build.bat
+++ b/extern/llvm_build.bat
@@ -1,20 +1,15 @@
 PUSHD %~dp0
 
 @IF EXIST llvm-project_11_0_0 GOTO LLVM_HAS
-git clone --config core.autocrlf=false https://github.com/llvm/llvm-project.git llvm-project_11_0_0
+git clone --depth 1 --branch llvmorg-11.0.0 https://github.com/llvm/llvm-project.git llvm-project_11_0_0
 pushd llvm-project_11_0_0
-
-pushd llvm-project_11_0_0
-git pull origin master
-git checkout llvmorg-11.0.0
-popd
 
 :LLVM_HAS
 
 @IF EXIST llvm_win64_11_0_0 GOTO HAS_CONFIG
 mkdir llvm_win64_11_0_0
 cd llvm_win64_11_0_0
-cmake ../llvm-project_11_0_0/llvm -G"Visual Studio 16 2019" -Ax64 -Thost=x64 -DLLVM_USE_CRT_DEBUG:STRING="MTd" -DLLVM_USE_CRT_RELEASE:STRING="MT"
+cmake ../llvm-project_11_0_0/llvm -G"Visual Studio 16 2019" -Ax64 -Thost=x64 -DLLVM_USE_CRT_DEBUG:STRING="MTd" -DLLVM_USE_CRT_RELEASE:STRING="MT" -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86;WebAssembly"
 @GOTO DOBUILD
 
 :HAS_CONFIG
@@ -22,8 +17,8 @@ cd llvm_win64_11_0_0
 @GOTO DOBUILD
 
 :DOBUILD
-cmake --build . --config Debug 
-cmake --build . --config Release
+cmake --build . -t $(cat ../llvm_targets.txt) --config Debug
+cmake --build . -t $(cat ../llvm_targets.txt) --config Release
 
 :SUCCESS
 @ECHO SUCCESS!


### PR DESCRIPTION
Hi,

.bat to be like .sh
Not implemented the "llvm-11.0.0.src.tar.xz" because there is no default tar file support in windows, should we use unrar or 7zip ? .... that is a question of another day.

Kind regards