### PR TITLE
Fix close of inactive IDE tab without closing pane

### DIFF
--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -6588,6 +6588,9 @@ namespace IDE
 							nextTab = checkTab;
 	                });
 			}
+			else {
+				nextTab = tabbedView.GetActiveTab();
+			}
 
 			tabbedView.RemoveTab(tabButton);
 			if (nextTab != null)


### PR DESCRIPTION
When you close an inactive IDE tab, the 'nextTab' is null instead of the
already active one. This then results in the entire pane closing even
with tabs remaining. Ensuring nextTab is always valid keeps the pane open.

This may fix issue #619 as the behavior described is similar.