### PR TITLE
Fixes for incorrect SecondaryAllowClose logic

### DIFF
--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -5560,30 +5560,32 @@ namespace IDE
                 });
         }
 
-        public void WithDocumentTabbedViews(delegate void(DarkTabbedView) func)
-        {
-            for (int32 windowIdx = 0; windowIdx < mWindows.Count; windowIdx++)
-            {
-                var window = mWindows[windowIdx];
-                var widgetWindow = window as WidgetWindow;
-                if (widgetWindow != null)
-                {
-                    var darkDockingFrame = widgetWindow.mRootWidget as DarkDockingFrame;
-                    if (widgetWindow == mMainWindow)
-                        darkDockingFrame = mDockingFrame;
+		public void WithDocumentTabbedViewsOf(BFWindow window, delegate void(DarkTabbedView) func)
+		{
+			var widgetWindow = window as WidgetWindow;
+			if (widgetWindow != null)
+			{
+			    var darkDockingFrame = widgetWindow.mRootWidget as DarkDockingFrame;
+			    if (widgetWindow == mMainWindow)
+			        darkDockingFrame = mDockingFrame;
 
-                    if (darkDockingFrame != null)
-                    {
-                        darkDockingFrame.WithAllDockedWidgets(scope (dockedWidget) =>
-                            {
-                                var tabbedView = dockedWidget as DarkTabbedView;
-                                if (tabbedView != null)
-                                    func(tabbedView);
-                            });
-                    }
-                }
-            }
-        }
+			    if (darkDockingFrame != null)
+			    {
+			        darkDockingFrame.WithAllDockedWidgets(scope (dockedWidget) =>
+			            {
+			                var tabbedView = dockedWidget as DarkTabbedView;
+			                if (tabbedView != null)
+			                    func(tabbedView);
+			            });
+			    }
+			}
+		}
+
+		public void WithDocumentTabbedViews(delegate void(DarkTabbedView) func)
+		{
+			for (let window in mWindows)
+				WithDocumentTabbedViewsOf(window, func);
+		}
 
         public void EnsureDocumentArea()
         {
@@ -5682,13 +5684,19 @@ namespace IDE
 		    return null;
 		}
         
-        public void WithTabs(delegate void(TabbedView.TabButton) func)
-        {
-            WithDocumentTabbedViews(scope (documentTabbedView) =>
-                {
-                    documentTabbedView.WithTabs(func);
-                });
-        }
+		public void WithTabsOf(BFWindow window, delegate void(TabbedView.TabButton) func)
+		{
+			WithDocumentTabbedViewsOf(window, scope (documentTabbedView) =>
+				{
+				    documentTabbedView.WithTabs(func);
+				});
+		}
+
+		public void WithTabs(delegate void(TabbedView.TabButton) func)
+		{
+			for (let window in mWindows)
+				WithTabsOf(window, func);
+		}
 
         public TabbedView.TabButton GetTab(Widget content)
         {
@@ -5701,15 +5709,21 @@ namespace IDE
             return tab;
         }        
 
-        public void WithSourceViewPanels(delegate void(SourceViewPanel) func)
-        {            
-            WithTabs(scope (tab) =>
-                {
-                    var sourceViewPanel = tab.mContent as SourceViewPanel;
-                    if (sourceViewPanel != null)
-                        func(sourceViewPanel);
-                });
-        }
+		public void WithSourceViewPanelsOf(BFWindow window, delegate void(SourceViewPanel) func)
+		{
+			WithTabsOf(window, scope (tab) =>
+				{
+				    var sourceViewPanel = tab.mContent as SourceViewPanel;
+				    if (sourceViewPanel != null)
+				        func(sourceViewPanel);
+				});
+		}
+
+		public void WithSourceViewPanels(delegate void(SourceViewPanel) func)
+		{
+			for (let window in mWindows)
+				WithSourceViewPanelsOf(window, func);
+		}
 
 		TabbedView.TabButton SetupTab(TabbedView tabView, String name, float width, Widget content, bool ownsContent) // 2
 		{

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -1241,6 +1241,19 @@ namespace IDE
 			if (mRunningTestScript)
 				return true;
 
+			void CloseTabs()
+			{
+				WithDocumentTabbedViewsOf(window, scope (tabbedView) => {
+					tabbedView.CloseTabs(false, true);
+				});
+			}
+
+			void CloseWindow()
+			{
+				mMainWindow.SetForeground();
+				window.Close(true);
+			}
+
             List<String> changedList = scope List<String>();
 			defer ClearAndDeleteItems(changedList);
             WithSourceViewPanelsOf(window, scope (sourceViewPanel) =>
@@ -1252,8 +1265,11 @@ namespace IDE
                         changedList.Add(fileName);
 					}
                 });
-            if (changedList.Count == 0)
+
+            if (changedList.Count == 0) {
+				CloseTabs();
                 return true;
+			}
             var aDialog = QuerySaveFiles(changedList, (WidgetWindow)window);
             aDialog.mDefaultButton = aDialog.AddButton("Save", new (evt) =>
             {
@@ -1268,8 +1284,8 @@ namespace IDE
                     });
                 if (hadError)
                     return;
-                mMainWindow.SetForeground();
-                window.Close(true);                
+				CloseTabs();
+				CloseWindow();
             });
             aDialog.AddButton("Don't Save", new (evt) =>
             {
@@ -1279,8 +1295,8 @@ namespace IDE
 						if (sourceViewPanel.HasUnsavedChanges())
 							_this.RevertSourceViewPanel(sourceViewPanel);
 				    });
-                mMainWindow.SetForeground();
-                window.Close(true);                
+				CloseTabs();
+				CloseWindow();
             });
 
             aDialog.mEscButton = aDialog.AddButton("Cancel");

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -1243,9 +1243,9 @@ namespace IDE
 
             List<String> changedList = scope List<String>();
 			defer ClearAndDeleteItems(changedList);
-            WithSourceViewPanels(scope (sourceViewPanel) =>
+            WithSourceViewPanelsOf(window, scope (sourceViewPanel) =>
                 {
-                    if ((sourceViewPanel.mWidgetWindow == window) && (sourceViewPanel.HasUnsavedChanges()))
+                    if (sourceViewPanel.HasUnsavedChanges())
 					{
 						var fileName = new String();
 						Path.GetFileName(sourceViewPanel.mFilePath, fileName);
@@ -1260,9 +1260,9 @@ namespace IDE
                 bool hadError = false;
 				// We use a close delay after saving so the user can see we actually saved before closing down
 				var _this = this;
-                WithSourceViewPanels(scope [&] (sourceViewPanel) =>
+                WithSourceViewPanelsOf(window, scope [&] (sourceViewPanel) =>
                 	{
-                        if ((!hadError) && (sourceViewPanel.mWidgetWindow == window) && (sourceViewPanel.HasUnsavedChanges()))
+                        if ((!hadError) && (sourceViewPanel.HasUnsavedChanges()))
                             if (!_this.SaveFile(sourceViewPanel))
                                 hadError = true;
                     });


### PR DESCRIPTION
Existing logic relies on mWidgetWindow matching which doesn't work for inactive tabs.  Also the existing `dont save` logic is incomplete.  These commits fix several issues related to this. 