### PR TITLE
Allow secondary windows to be maximized

### DIFF
--- a/BeefLibs/Beefy2D/src/widgets/TabbedView.bf
+++ b/BeefLibs/Beefy2D/src/widgets/TabbedView.bf
@@ -237,7 +237,7 @@ namespace Beefy.widgets
                             300, 500,
                             BFWindowBase.Flags.Border | BFWindowBase.Flags.ThickFrame | BFWindowBase.Flags.Resizable | BFWindowBase.Flags.SysMenu |
                             BFWindowBase.Flags.Caption | BFWindowBase.Flags.Minimize | BFWindowBase.Flags.ToolWindow | BFWindowBase.Flags.TopMost |
-                            BFWindowBase.Flags.UseParentMenu,
+                            BFWindowBase.Flags.UseParentMenu | BFWindowBase.Flags.Maximize,
                             subFrame);
                         Dock(subFrame, null, DockingFrame.WidgetAlign.Top);
                         //subFrame.AddDockedWidget(fourthTabbedView, null, DockingFrame.WidgetAlign.Left, false);


### PR DESCRIPTION
Prior to this change, secondary windows could be minimized by
right-clicking on the title bar, but not maximized. Maximizing is
very useful for multi-monitor setups. The popup menu includes restore
as well. To enable these actions directly from the titlebar without
navigating a popup, the 'ToolWindow' style would have to be removed
because it inhibits the standard system buttons.