### PR TITLE
Fix for Workspace Explorer panel with no workspace

### DIFF
--- a/IDE/src/ui/ProjectPanel.bf
+++ b/IDE/src/ui/ProjectPanel.bf
@@ -181,9 +181,10 @@ namespace IDE.ui
 		{
 			base.FocusForKeyboard();
 			SetFocus();
-			if (mListView.GetRoot().FindFocusedItem() == null)
+			let root = mListView.GetRoot();
+			if (root.IsOpen && root.FindFocusedItem() == null)
 			{
-				mListView.GetRoot().GetChildAtIndex(0).Focused = true;
+				root.GetChildAtIndex(0).Focused = true;
 			}
 		}
 


### PR DESCRIPTION
Don't give focus to a non-existent child. Previously any hide/show
of the Workspace Explorer without a workspace loaded would crash.