### PR TITLE
Fix Add From Installed project import bug

### DIFF
--- a/IDE/src/ui/InstalledProjectDialog.bf
+++ b/IDE/src/ui/InstalledProjectDialog.bf
@@ -177,7 +177,6 @@ namespace IDE.ui
 				let entry = mFilteredList[idx];
 
 				VerSpec verSpec = .SemVer(new .("*"));
-				defer verSpec.Dispose();
 
 				let project = gApp.mProjectPanel.ImportProject(entry.mPath, verSpec);
 				if (project == null)


### PR DESCRIPTION
Removed VerSpec Dispose() from `DoImport()` in `InstalledProjectDialog`. This was not a necessary call as the project disposes the VerSpec automatically upon destruction. Disposing it here causes an access violation when trying to save and serialize the workspace later.