### PR TITLE
Tool window resize offset fix

### DIFF
--- a/IDE/src/ui/AutoComplete.bf
+++ b/IDE/src/ui/AutoComplete.bf
@@ -556,7 +556,7 @@ namespace IDE.ui
 					mIgnoreMove++;
 					if (mAutoComplete.mInvokeWidget != null)
 						mAutoComplete.mInvokeWidget.mIgnoreMove++;
-					mWidgetWindow.Resize(mWidgetWindow.mX, mWidgetWindow.mY, windowWidth, windowHeight);
+					mWidgetWindow.Resize(mWidgetWindow.mNormX, mWidgetWindow.mNormY, windowWidth, windowHeight);
 					mScrollContent.mWidth = mWidth;
 					//Resize(0, 0, mWidgetWindow.mClientWidth, mWidgetWindow.mClientHeight);
 					mIgnoreMove--;

--- a/IDE/src/ui/HoverWatch.bf
+++ b/IDE/src/ui/HoverWatch.bf
@@ -1090,7 +1090,7 @@ namespace IDE.ui
 
 				if (autocomplete != null)
 					autocomplete.SetIgnoreMove(true);
-                mWidgetWindow.Resize((int32)(mOrigScreenX + minX), (int32)(mOrigScreenY + minY), (int32)(maxX - minX), (int32)(maxY - minY));
+                mWidgetWindow.Resize((int32)(mWidgetWindow.mNormX + minX), (int32)(mWidgetWindow.mNormY + minY), (int32)(maxX - minX), (int32)(maxY - minY));
 				if (autocomplete != null)
 					autocomplete.SetIgnoreMove(false);
 			}


### PR DESCRIPTION
Demonstration of the issue & explaination (happens when task bar is on the side):
Autocomplete: [Discord#bugs message](https://discord.com/channels/670260150656827422/703607007277744150/820561445015650324)
HoverWatch: [Discord#bugs message](https://discord.com/channels/670260150656827422/703607007277744150/820947404953878569)

Fusion came up with the mNormX fix for autocomplete and i also tried to fix Hoverwatch with it. Both seem to work fine. Especially in the second commit i'm not sure if there's a nicer fix for it though.