### PR TITLE
Add functions to System.IO.Stream

### DIFF
--- a/BeefLibs/corlib/src/IO/Stream.bf
+++ b/BeefLibs/corlib/src/IO/Stream.bf
@@ -115,6 +115,22 @@ namespace System.IO
 			return .Ok;
 		}
 
+		//Reads null terminated ASCII string from the stream. Null terminator is read from stream but isn't appended to output string
+		public Result<void> ReadNullTerminatedString(String output)
+		{
+			Result<char8> char0;
+			while(true)
+			{
+				char0 = Read<char8>();
+				if(char0 == .Err)
+					return .Err;
+				if(char0.Value == '\0')
+					return .Ok;
+				
+				output.Append(char0.Value);
+			}
+		}
+
 		public Result<T> Read<T>() where T : struct
 		{
 			T val = ?;

--- a/BeefLibs/corlib/src/IO/Stream.bf
+++ b/BeefLibs/corlib/src/IO/Stream.bf
@@ -81,24 +81,24 @@ namespace System.IO
 			Seek(Position + count, .Absolute);
 		}
 
-		//Write count null bytes to stream
-		public void WriteNullBytes(int64 count)
+		//Write count bytes to stream
+		public void Write(uint8 byte, int64 count)
 		{
 			if(count <= 0)
 				return;
 
 			int64 nullBytesRemaining = count;
-			int64 emptyData = 0;
+			uint8[8] writeData = .(byte, byte, byte, byte, byte, byte, byte, byte);
 			while (nullBytesRemaining > 0)
 			{
-				int64 writeSize = Math.Min(nullBytesRemaining, sizeof(decltype(emptyData)));
-				TryWrite(.((uint8*)&emptyData, (int)writeSize));
+				int64 writeSize = Math.Min(nullBytesRemaining, writeData.Count * sizeof(uint8));
+				TryWrite(.(&writeData[0], (int)writeSize));
 				nullBytesRemaining -= writeSize;
 			}
 		}
 
 		//Read sized string from stream
-		public Result<void> ReadSizedString(int64 size, String output)
+		public Result<void> ReadStrSized32(int64 size, String output)
 		{
 			if (size <= 0)
 				return .Err;
@@ -116,7 +116,7 @@ namespace System.IO
 		}
 
 		//Reads null terminated ASCII string from the stream. Null terminator is read from stream but isn't appended to output string
-		public Result<void> ReadNullTerminatedString(String output)
+		public Result<void> ReadStrC(String output)
 		{
 			Result<char8> char0;
 			while(true)


### PR DESCRIPTION
These are some functions I needed when dealing with binary file formats. I think they would be useful additions to the class. Lemme know if you'd rather have these split into separate PRs.

- `Peek<T>()`: Reads a value from the stream without changing the stream position. If it fails to read T the stream position will still be unchanged.
- `Skip(int64 count)`: Moves the stream position forward `count` bytes. This is just `Seek(Position + count, .Absolute);` but a bit more convenient and clear what is going on for anyone reading the code.
- `WriteNullBytes(int64 count)`: Writes `count` null bytes to the stream.
- `ReadSizedString(int64 size, String output)`: Reads a string with `size` characters into `output`.
- `ReadNullTerminatedString(String output)`: Reads a null terminated string into `output`. The null terminator is read from the stream but not appended onto `output`.

The while loop at line 92 of Stream.bf is something I copied from Stream.Align to have similar style as existing corlib code. From what I understand it's supposed to be faster than writing a single null byte repeatedly. Correct me if I'm wrong.