### PR TITLE
OpenFileName struct: Change default extension type (char8* -> char16*)

### DIFF
--- a/BeefLibs/corlib/src/IO/OpenFileDialog.bf
+++ b/BeefLibs/corlib/src/IO/OpenFileDialog.bf
@@ -425,7 +425,7 @@ namespace System.IO
 			ofn.mCustData = (int)Internal.UnsafeCastToPtr(this);
 	        ofn.mFlagsEx = Windows.OFN_USESHELLITEM;
 	        if (mDefaultExt != null && AddExtension)
-	            ofn.mDefExt = mDefaultExt;
+	            ofn.mDefExt = mDefaultExt.ToScopedNativeWChar!::();
 
 			DeleteContainerAndItems!(mFileNames);
 			mFileNames = null;

--- a/BeefLibs/corlib/src/Windows.bf
+++ b/BeefLibs/corlib/src/Windows.bf
@@ -120,7 +120,7 @@ namespace System
 			public int32 mFlags;
 			public int16 mFileOffset = 0;
 			public int16 mFileExtension = 0;
-			public char8* mDefExt;
+			public char16* mDefExt;
 			public int mCustData = 0;
 			public WndProc mHook;
 			public char16* mTemplateName = null;


### PR DESCRIPTION
When using OpenFileDialog with the following options
( **AddExtension = true, CheckFileExists = false, DefaultExt = "txt"** )

Then the returned path from the OS will contain mixed character types (char8 and wide chars).
(Path type: char16, Extension type: char8)

![charError](https://user-images.githubusercontent.com/6961586/113515368-651bd580-9574-11eb-9650-907706afe47a.PNG)

In memory:
![charError2](https://user-images.githubusercontent.com/6961586/113515246-9fd13e00-9573-11eb-806c-79ebf86ad785.PNG)

This occurs because the `OpenFileName struct` defines the default extension field as char8*
`public char8* mDefExt;`

Interestingly, on top of the MSDN page 
( https://docs.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamea )
it states that it should be char8* type (LPCSTR), but below in the detailed section it's written as LPCTSTR (wide char).

By changing the OpenFileName struct's mDefExt field type to char16* (and using it as such where it's used)
the problem gets fixed.

Sample code to reproduce the problem:

```
OpenFileDialog file = scope OpenFileDialog();
file.AddExtension = true;
file.CheckFileExists = false;
file.DefaultExt = "txt";
file.ShowDialog();

DialogResult res;
if((res = file.ShowDialog()) case .OK){
	for(String name in file.FileNames){
		Console.WriteLine(name);
	}
}
```
