### PR TITLE
Make Debugger only attempt to allocate hot heap when hot swapping is enabled

### DIFF
--- a/IDE/src/Debugger/DebugManager.bf
+++ b/IDE/src/Debugger/DebugManager.bf
@@ -140,7 +140,7 @@ namespace IDE.Debugger
 		static extern bool Debugger_OpenMiniDump(char8* filename);
 
 		[CallingConvention(.Stdcall),CLink]
-		static extern bool Debugger_OpenFile(char8* launchPath, char8* targetPath, char8* args, char8* workingDir, void* envBlockPtr, int32 envBlockLen);
+		static extern bool Debugger_OpenFile(char8* launchPath, char8* targetPath, char8* args, char8* workingDir, void* envBlockPtr, int32 envBlockLen, bool hotSwapEnabled);
 
 		[CallingConvention(.Stdcall),CLink]
 		static extern bool Debugger_Attach(int32 processId, AttachFlags attachFlags);
@@ -429,7 +429,7 @@ namespace IDE.Debugger
 
 			mIsRunningCompiled = isCompiled;
 			mIsRunningWithHotSwap = hotSwapEnabled;
-			return Debugger_OpenFile(launchPath, targetPath, args, workingDir, envBlock.Ptr, (int32)envBlock.Length);
+			return Debugger_OpenFile(launchPath, targetPath, args, workingDir, envBlock.Ptr, (int32)envBlock.Length, hotSwapEnabled);
 		}
 
 		public void SetSymSrvOptions(String symCacheDir, String symSrvStr, SymSrvFlags symSrvFlags)

--- a/IDEHelper/DebugManager.cpp
+++ b/IDEHelper/DebugManager.cpp
@@ -745,7 +745,7 @@ BF_EXPORT int BF_CALLTYPE Debugger_GetAddrSize()
 	return gDebugger->GetAddrSize();
 }
 
-BF_EXPORT bool BF_CALLTYPE Debugger_OpenFile(const char* launchPath, const char* targetPath, const char* args, const char* workingDir, void* envBlockPtr, int envBlockSize)
+BF_EXPORT bool BF_CALLTYPE Debugger_OpenFile(const char* launchPath, const char* targetPath, const char* args, const char* workingDir, void* envBlockPtr, int envBlockSize, bool hotSwapEnabled)
 {
 	BF_ASSERT(gDebugger == NULL);
 
@@ -775,7 +775,7 @@ BF_EXPORT bool BF_CALLTYPE Debugger_OpenFile(const char* launchPath, const char*
 			envBlock.Insert(0, (uint8*)envBlockPtr, envBlockSize);
 	}
 
-	gDebugger->OpenFile(launchPath, targetPath, args, workingDir, envBlock);
+	gDebugger->OpenFile(launchPath, targetPath, args, workingDir, envBlock, hotSwapEnabled);
 	return true;
 }
 

--- a/IDEHelper/DebugTarget.cpp
+++ b/IDEHelper/DebugTarget.cpp
@@ -82,7 +82,7 @@ static bool PathEquals(const String& pathA, String& pathB)
 
 void DebugTarget::SetupTargetBinary()
 {
-	bool wantsHotHeap = mDebugger->mDbgProcessId == 0;
+	bool wantsHotHeap = (mDebugger->mHotSwapEnabled == true && mDebugger->mDbgProcessId == 0);
 
 #ifdef BF_DBG_32
 	if (wantsHotHeap)

--- a/IDEHelper/Debugger.h
+++ b/IDEHelper/Debugger.h
@@ -257,7 +257,7 @@ public:
 	virtual void OutputRawMessage(const StringImpl& msg) = 0;
 	virtual int GetAddrSize() = 0;
 	virtual bool CanOpen(const StringImpl& fileName, DebuggerResult* outResult) = 0;
-	virtual void OpenFile(const StringImpl& launchPath, const StringImpl& targetPath, const StringImpl& args, const StringImpl& workingDir, const Array<uint8>& envBlock) = 0;
+	virtual void OpenFile(const StringImpl& launchPath, const StringImpl& targetPath, const StringImpl& args, const StringImpl& workingDir, const Array<uint8>& envBlock, bool hotSwapEnabled) = 0;
 	virtual bool Attach(int processId, BfDbgAttachFlags attachFlags) = 0;
 	virtual void Run() = 0;
 	virtual void HotLoad(const Array<String>& objectFiles, int hotIdx) = 0;

--- a/IDEHelper/WinDebugger.cpp
+++ b/IDEHelper/WinDebugger.cpp
@@ -1003,7 +1003,7 @@ bool WinDebugger::CanOpen(const StringImpl& fileName, DebuggerResult* outResult)
 	return canRead;
 }
 
-void WinDebugger::OpenFile(const StringImpl& launchPath, const StringImpl& targetPath, const StringImpl& args, const StringImpl& workingDir, const Array<uint8>& envBlock)
+void WinDebugger::OpenFile(const StringImpl& launchPath, const StringImpl& targetPath, const StringImpl& args, const StringImpl& workingDir, const Array<uint8>& envBlock, bool hotSwapEnabled)
 {
 	BF_ASSERT(!mIsRunning);
 	mLaunchPath = launchPath;
@@ -1011,6 +1011,7 @@ void WinDebugger::OpenFile(const StringImpl& launchPath, const StringImpl& targe
 	mArgs = args;
 	mWorkingDir = workingDir;
 	mEnvBlock = envBlock;
+	mHotSwapEnabled = hotSwapEnabled;
 	mDebugTarget = new DebugTarget(this);
 }
 

--- a/IDEHelper/WinDebugger.h
+++ b/IDEHelper/WinDebugger.h
@@ -427,6 +427,7 @@ public:
 	String mTargetPath;
 	String mArgs;
 	String mWorkingDir;
+	bool mHotSwapEnabled;
 	Array<uint8> mEnvBlock;	
 	DebugTarget* mEmptyDebugTarget;
 	DebugTarget* mDebugTarget;
@@ -617,7 +618,7 @@ public:
 	virtual void OutputRawMessage(const StringImpl& msg) override;
 	virtual int GetAddrSize() override;
 	virtual bool CanOpen(const StringImpl& fileName, DebuggerResult* outResult) override;
-	virtual void OpenFile(const StringImpl& launchPath, const StringImpl& targetPath, const StringImpl& args, const StringImpl& workingDir, const Array<uint8>& envBlock) override;
+	virtual void OpenFile(const StringImpl& launchPath, const StringImpl& targetPath, const StringImpl& args, const StringImpl& workingDir, const Array<uint8>& envBlock, bool hotSwapEnabled) override;
 	virtual bool Attach(int processId, BfDbgAttachFlags attachFlags) override;
 	virtual void Run() override;
 	virtual void HotLoad(const Array<String>& objectFiles, int hotIdx) override;	


### PR DESCRIPTION
We are using a DLL based build and have hot swapping disabled, but every time we run in the debugger we get "Failed to reserve memory for hot swapping." This PR simply plumbs the flag through to `WinDebugger` and adds it to the `wantsHotHeap` condition in `DebugTarget::SetupTargetBinary()`.