### PR TITLE
fixed crash when writing static unary operator

### DIFF
--- a/IDEHelper/Compiler/BfModule.cpp
+++ b/IDEHelper/Compiler/BfModule.cpp
@@ -18586,17 +18586,20 @@ void BfModule::ProcessMethod(BfMethodInstance* methodInstance, bool isInlineDup)
 		{
 			if (methodDef->mIsStatic)
 			{
-				auto checkParam0 = mCurMethodInstance->GetParamType(0);
-				if ((checkParam0->IsRef()) && (!checkParam0->IsOut()))
-					checkParam0 = checkParam0->GetUnderlyingType();
-
 				if (methodDef->mParams.size() != 1)
 				{
 					Fail("Unary operators must declare one parameter", paramErrorRefNode);
 				}
-				else if ((checkParam0 != mCurTypeInstance) && (!checkParam0->IsSelf()))
+				else
 				{
-					Fail("The parameter of a unary operator must be the containing type", paramErrorRefNode);
+					auto checkParam0 = mCurMethodInstance->GetParamType(0);
+					if ((checkParam0->IsRef()) && (!checkParam0->IsOut()))
+						checkParam0 = checkParam0->GetUnderlyingType();
+
+					if ((checkParam0 != mCurTypeInstance) && (!checkParam0->IsSelf()))
+					{
+						Fail("The parameter of a unary operator must be the containing type", paramErrorRefNode);
+					}
 				}
 
 				if (((operatorDef->mOperatorDeclaration->mUnaryOp == BfUnaryOp_Increment) ||


### PR DESCRIPTION
When writing a static unary operator, say

``public static Something operator++``

it would immediatly look for the first arg (it checked for "has it exactly one arg", but just after that) and crash on the array lookup.