### PR TITLE
Corlib additions

### DIFF
--- a/BeefLibs/corlib/src/Collections/Dictionary.bf
+++ b/BeefLibs/corlib/src/Collections/Dictionary.bf
@@ -267,7 +267,11 @@ namespace System.Collections
 			}
 			else
 			{
-				//TODO: IMPORTANT!
+				for (int_cosize i = 0; i < mCount; i++)
+				{
+					if (mEntries[i].mHashCode >= 0 && mEntries[i].mValue == value) return true;
+				}
+				//TODO: comparison
 				/*EqualityComparer<TValue> c = EqualityComparer<TValue>.Default;
 				for (int i = 0; i < count; i++)
 				{

--- a/BeefLibs/corlib/src/Collections/List.bf
+++ b/BeefLibs/corlib/src/Collections/List.bf
@@ -930,6 +930,59 @@ namespace System.Collections
 		}
 	}
 
+	extension List<T> where T : String
+	{
+		public bool Contains(T item, StringComparison comparison)
+		{
+			if (item == null)
+			{
+			    for (int i = 0; i < mSize; i++)
+			        if (mItems[i] == null)
+			    		return true;
+			    return false;
+			}
+			else
+			{
+				for (int i = 0; i < mSize; i++)
+					if (mItems[i].Equals(item, comparison))
+						return true;
+			    return false;
+			}
+		}
+
+		public int IndexOf(T item, StringComparison comparison)
+		{
+			for (int i = 0; i < mSize; i++)
+				if (mItems[i].Equals(item, comparison))
+					return i;
+			return -1;
+		}
+
+		public int IndexOf(T item, int index, StringComparison comparison)
+		{
+			for (int i = index; i < mSize; i++)
+				if (mItems[i].Equals(item, comparison))
+					return i;
+			return -1;
+		}
+
+		public int IndexOf(T item, int index, int count, StringComparison comparison)
+		{
+			for (int i = index; i < index + count; i++)
+				if (mItems[i].Equals(item, comparison))
+					return i;
+			return -1;
+		}
+
+		public int LastIndexOf(T item, StringComparison comparison)
+		{
+			for (int i = mSize - 1; i >= 0; i--)
+				if (mItems[i].Equals(item, comparison))
+					return i;
+			return -1;
+		}
+	}
+
 	class ListWithAlloc<T> : List<T>
 	{
 		IRawAllocator mAlloc;

--- a/BeefLibs/corlib/src/Diagnostics/Check.bf
+++ b/BeefLibs/corlib/src/Diagnostics/Check.bf
@@ -1,6 +1,6 @@
 namespace System.Diagnostics
 {
-	class Check
+	static class Check
 	{
 
 		[Unchecked, SkipCall]

--- a/BeefLibs/corlib/src/Diagnostics/Contracts/Contracts.bf
+++ b/BeefLibs/corlib/src/Diagnostics/Contracts/Contracts.bf
@@ -1,6 +1,6 @@
 namespace System.Diagnostics.Contracts
 {
-    class Contract
+    static class Contract
     {
         public enum ContractFailureKind
         {

--- a/BeefLibs/corlib/src/Diagnostics/Debug.bf
+++ b/BeefLibs/corlib/src/Diagnostics/Debug.bf
@@ -1,6 +1,6 @@
 namespace System.Diagnostics
 {
-	class Debug
+	static class Debug
 	{
 #if !DEBUG
 		[SkipCall]

--- a/BeefLibs/corlib/src/IO/File.bf
+++ b/BeefLibs/corlib/src/IO/File.bf
@@ -23,7 +23,7 @@ namespace System.IO
 		case FileReadError(FileReadError);
 	}
 
-	class File
+	static class File
 	{
 		public static Result<void, FileError> ReadAll(StringView path, List<uint8> outData)
 		{

--- a/BeefLibs/corlib/src/Runtime.bf
+++ b/BeefLibs/corlib/src/Runtime.bf
@@ -6,7 +6,7 @@ using System.Threading;
 namespace System
 {
 	[StaticInitPriority(100)]
-	class Runtime
+	static class Runtime
 	{
 		const int32 cVersion = 8;
 

--- a/BeefLibs/corlib/src/System.bf
+++ b/BeefLibs/corlib/src/System.bf
@@ -227,6 +227,26 @@ static
 		}
 	}
 
+	public static mixin DeleteContainerAndDisposeItems(var container)
+	{
+		if (container != null)
+		{
+			for (var value in container)
+				value.Dispose();
+			delete container;
+		}
+	}
+
+	public static mixin ClearAndDisposeItems(var container)
+	{
+		if (container != null)
+		{
+			for (var value in container)
+				value.Dispose();
+			container.Clear();
+		}
+	}
+
 	public static mixin DeleteAndNullify(var val)
 	{
 		delete val;

--- a/BeefLibs/corlib/src/Text/UTF16.bf
+++ b/BeefLibs/corlib/src/Text/UTF16.bf
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 namespace System.Text
 {
-	public class UTF16
+	public static class UTF16
 	{
 		public enum EncodeError
 		{

--- a/BeefLibs/corlib/src/Text/UTF8.bf
+++ b/BeefLibs/corlib/src/Text/UTF8.bf
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 namespace System.Text
 {
-	class UTF8
+	static class UTF8
 	{
 		public const int8[256] sTrailingBytesForUTF8 =
 		.(


### PR DESCRIPTION
I've added some List<String> specialized functions. They are overloads of existing methods but take in StringComparison.
Also, mixins for collections with IDisposable (structs, probably) and static modifiers for classes that have no obvious reason to not be static. I was slightly afraid it might break something, but it doesnt seem to. Dictionary.ContainsValue (i dont think anyone has ever used that function) at least works for non null values now. Key also has no settable comparison yet, so i just used == for now, just like is done for keys when when inserting entries.

I'll probably do more corelib maintaining for a bit when something jumps at me. Feedback is appreciated in case i *did* break something here or you don't want some of the changes.