### PR TITLE
fix source content readonly editing

### DIFF
--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -2758,7 +2758,7 @@ namespace IDE.ui
 				return;
 			}
 
-            if (mIsReadOnly)
+            if (CheckReadOnly())
             {
                 base.KeyChar(keyChar);
                 return;


### PR DESCRIPTION
Fixes triggering source content specific funtionality for readonly. Like:
autcompletion insert of different proposal (sometimes)
'/\*' + '\*' comment completion
selection + '(' wrap
selection + '{' insert block
..and possibly some more

Most of the stuff in the function doesnt seem like it would be needed when you arent able to edit anything anyways (although i cant say in detail), so the early-out seems to work just fine.