### PR TITLE
attempt to fix explicit thiscall crash

### DIFF
--- a/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
@@ -1208,7 +1208,8 @@ void BfMethodInstance::GetIRFunctionInfo(BfModule* module, BfIRType& returnType,
 	{
 		returnType = module->mBfIRBuilder->MapType(mReturnType);
 	}	
-	
+
+	bool hasExplicitThis = false;
 	for (int paramIdx = -1; paramIdx < GetParamCount(); paramIdx++)
 	{
 		BfType* checkType = NULL;
@@ -1223,13 +1224,23 @@ void BfMethodInstance::GetIRFunctionInfo(BfModule* module, BfIRType& returnType,
 			else
 			{
 				if (HasExplicitThis())
+				{
 					checkType = GetParamType(0);
+					hasExplicitThis = true;
+				}
 				else
 					checkType = GetOwner();				
 			}
 		}
 		else
 		{
+			if (hasExplicitThis)
+			{
+				// We already looked at this
+				hasExplicitThis = false;
+				continue;
+			}
+
 			checkType = GetParamType(paramIdx);
 		}
 


### PR DESCRIPTION
an attempt to fix #1000

As far as I could tell, the issue arised because GenIRFunctionInfo - used to get the number of args as well - will on index -1 get the info of the 0th arg if it's an explicit "this" and treating it like that, but then processing it again on index 0. Consequently, SetupIRMethod thinks the function has two args, and does an out of bounds array access.

My usual projects compile fine and Beef also bootstraps normally (nothing caught fire), though, you know, i really dont have omnisense in this codebase and am in fact not exactly a compiler pro.