### PR TITLE
fix thiscall crash for real

### DIFF
--- a/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
@@ -1227,8 +1227,7 @@ void BfMethodInstance::GetIRFunctionInfo(BfModule* module, BfIRType& returnType,
 				{
 					checkType = GetParamType(0);
 
-					//TODO(BCF): Breaks tests
-					//hasExplicitThis = true;
+					hasExplicitThis = true;
 				}
 				else
 					checkType = GetOwner();				
@@ -1236,7 +1235,7 @@ void BfMethodInstance::GetIRFunctionInfo(BfModule* module, BfIRType& returnType,
 		}
 		else
 		{
-			if (hasExplicitThis)
+			if (hasExplicitThis && paramIdx == 0)
 			{
 				// We already looked at this
 				hasExplicitThis = false;

--- a/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
@@ -1209,7 +1209,6 @@ void BfMethodInstance::GetIRFunctionInfo(BfModule* module, BfIRType& returnType,
 		returnType = module->mBfIRBuilder->MapType(mReturnType);
 	}	
 
-	bool hasExplicitThis = false;
 	for (int paramIdx = -1; paramIdx < GetParamCount(); paramIdx++)
 	{
 		BfType* checkType = NULL;
@@ -1224,23 +1223,15 @@ void BfMethodInstance::GetIRFunctionInfo(BfModule* module, BfIRType& returnType,
 			else
 			{
 				if (HasExplicitThis())
-				{
 					checkType = GetParamType(0);
-
-					hasExplicitThis = true;
-				}
 				else
 					checkType = GetOwner();				
 			}
 		}
 		else
 		{
-			if (hasExplicitThis && paramIdx == 0)
-			{
-				// We already looked at this
-				hasExplicitThis = false;
-				continue;
-			}
+			if ((paramIdx == 0) && (mMethodDef->mHasExplicitThis))
+				continue; // Skip over the explicit 'this'
 
 			checkType = GetParamType(paramIdx);
 		}
@@ -1354,9 +1345,6 @@ void BfMethodInstance::GetIRFunctionInfo(BfModule* module, BfIRType& returnType,
 
 		if (checkType2 != NULL)
 			_AddType(checkType2);
-
-		if ((paramIdx == -1) && (mMethodDef->mHasExplicitThis))
-			paramIdx++; // Skip over the explicit 'this'
 	}
 
 	if ((!module->mIsComptimeModule) && (GetStructRetIdx(forceStatic) == 1))

--- a/IDEHelper/Tests/src/Functions.bf
+++ b/IDEHelper/Tests/src/Functions.bf
@@ -130,6 +130,22 @@ namespace Tests
 			}
 		}
 
+		[CRepr]
+		struct StructCRepr
+		{
+			public int32 something = 1;
+
+			bool Run() => something == 1;
+
+			public static void Test()
+			{
+				StructCRepr sc = .();
+				function bool(StructCRepr this) func = => Run;
+
+				Test.Assert(func(sc));
+			}
+		}
+
 		public static int UseFunc0<T>(function int (T this, float f) func, T a, float b)
 		{
 			return func(a, b);

--- a/IDEHelper/Tests/src/Functions.bf
+++ b/IDEHelper/Tests/src/Functions.bf
@@ -198,6 +198,8 @@ namespace Tests
 					UseFunc0(func2, sa, 100.0f);
 					true
 				});
+
+			StructCRepr.Test();
 		}
 	}
 }


### PR DESCRIPTION
As it turns out, there thankfully wasn't another issue, but i was just being incompentent. There was already a check in place at the end of the loop to skip index 0 on explicit this, but this case just continue;'d past it, so i now moved that check to where the old fix was. I also included a test that crashed before, but doesnt now.

Building LibC for tests required me to dig up and install windows SDK 10.0.18362.0 very insistantly, but i wasn't really prepared for what came after, i mean- beefperf??? ide scripts?? i had no idea that existed (need to look at it at some point i guess) :D are ide scripts just for internal testing, what are their capabilities?

Anyways, should fix #1000 for real this time.