### PR TITLE
fix import project from installed

### DIFF
--- a/IDE/src/ui/InstalledProjectDialog.bf
+++ b/IDE/src/ui/InstalledProjectDialog.bf
@@ -128,6 +128,7 @@ namespace IDE.ui
 		    mEditWidget.GetText(filterString);
 		    filterString.Trim();
 
+			mFilteredList.Clear();
 		    for (var installedProject in mInstalledProjectList)
 		    {
 				if ((!filterString.IsEmpty) && (installedProject.mName.IndexOf(filterString, true) == -1))


### PR DESCRIPTION
searching a project in the import for installed dialogue would display filtered results, but still select from the unfiltered list on click, because refiltering didn't clear the filtered list before adding.