### PR TITLE
Comptime crash fixes

### DIFF
--- a/IDEHelper/Compiler/CeMachine.cpp
+++ b/IDEHelper/Compiler/CeMachine.cpp
@@ -4627,7 +4627,13 @@ bool CeContext::Execute(CeFunction* startFunction, uint8* startStackPtr, uint8* 
 					_Fail("Invalid method instance");
 					return false;
 				}
-				
+
+				if (paramIdx < 0 || paramIdx > methodInstance->mParams.mSize)
+				{
+					_Fail("paramIdx is out of range");
+					return false;
+				}
+
 				addr_ce stringAddr = GetString(methodInstance->GetParamName(paramIdx));
 				_FixVariables();
 				*(int32*)(stackPtr + 0) = methodInstance->GetParamType(paramIdx)->mTypeId;

--- a/IDEHelper/Compiler/CeMachine.cpp
+++ b/IDEHelper/Compiler/CeMachine.cpp
@@ -4628,7 +4628,7 @@ bool CeContext::Execute(CeFunction* startFunction, uint8* startStackPtr, uint8* 
 					return false;
 				}
 
-				if (paramIdx < 0 || paramIdx > methodInstance->mParams.mSize)
+				if (paramIdx < 0 || paramIdx >= methodInstance->mParams.mSize)
 				{
 					_Fail("paramIdx is out of range");
 					return false;

--- a/IDEHelper/Compiler/CeMachine.cpp
+++ b/IDEHelper/Compiler/CeMachine.cpp
@@ -2951,19 +2951,21 @@ BfError* CeContext::Fail(const CeFrame& curFrame, const StringImpl& str)
 				err += mCeMachine->mCeModule->MethodToString(ceFunction->mCeInnerFunctionInfo->mOwner->mMethodInstance, BfMethodNameFlag_OmitParams);
 			}
 		}
-		 
+		
 		if ((emitEntry != NULL) && (emitEntry->mFile != -1))
+		{
 			err += StrFormat(" at line% d:%d in %s", emitEntry->mLine + 1, emitEntry->mColumn + 1, ceFunction->mFiles[emitEntry->mFile].c_str());
 
-		auto moreInfo = passInstance->MoreInfo(err, mCeMachine->mCeModule->mCompiler->GetAutoComplete() != NULL);
-		if ((moreInfo != NULL) && (emitEntry != NULL))
-		{
-			BfErrorLocation* location = new BfErrorLocation();
-			location->mFile = ceFunction->mFiles[emitEntry->mFile];
-			location->mLine = emitEntry->mLine;
-			location->mColumn = emitEntry->mColumn;
-			moreInfo->mLocation = location;
-		}		
+			auto moreInfo = passInstance->MoreInfo(err, mCeMachine->mCeModule->mCompiler->GetAutoComplete() != NULL);
+			if ((moreInfo != NULL))
+			{
+				BfErrorLocation* location = new BfErrorLocation();
+				location->mFile = ceFunction->mFiles[emitEntry->mFile];
+				location->mLine = emitEntry->mLine;
+				location->mColumn = emitEntry->mColumn;
+				moreInfo->mLocation = location;
+			}
+		}
 	}
 
 	return bfError;


### PR DESCRIPTION
should fix two crashes. One attempted to access mFiles at index -1, so i just moved that block inside the if statement checking for it just before (don't know why that happened anymore, was a crash while editing something i think).

The second one arises when passing invalid indices into ComptimeMethodInfo.GetPraram*(). paramIdx is never validated and can crash, most commonly on array access. Thing is, before, it was theoretically possible to get the target at -1 (would just crash on trying to get param name on static methods though). I left that out for now since there's no public api to check for "does this have a 'this'?" on the beef side. Also, didn't really seem intended, is it?