### PR TITLE
Builtin attribs fix

### DIFF
--- a/IDEHelper/Compiler/BfAst.cpp
+++ b/IDEHelper/Compiler/BfAst.cpp
@@ -1195,6 +1195,23 @@ bool BfTypeReference::IsTypeDefTypeReference()
 	return IsA<BfNamedTypeReference>() || IsA<BfDirectStrTypeReference>() || IsA<BfDirectTypeDefReference>();
 }
 
+String BfTypeReference::ToCleanAttributeString()
+{
+	// ToString might return something like "System.InlineAttribute", which we want to clean before we test for "Inline"
+	auto typeRefName = ToString();
+	if (typeRefName.EndsWith("Attribute"))
+	{
+		int attribNameStart = (int)typeRefName.LastIndexOf('.');
+		if (attribNameStart != -1)
+			typeRefName.Remove(0, attribNameStart + 1);
+
+		if (typeRefName.EndsWith("Attribute"))
+			typeRefName.RemoveFromEnd(9);
+	}
+
+	return typeRefName;
+}
+
 //////////////////////////////////////////////////////////////////////////
 
 BfPropertyMethodDeclaration* BfPropertyDeclaration::GetMethod(const StringImpl& findName)
@@ -1262,6 +1279,10 @@ bool BfAttributeDirective::Contains(const StringImpl& findName)
 			return true;
 		if (name.EndsWith("Attribute"))
 		{
+			int attribNameStart = (int)name.LastIndexOf('.');
+			if (attribNameStart != -1)
+				name.Remove(0, attribNameStart + 1);
+
 			name.RemoveToEnd(name.length() - 9);
 			if (findName == name)
 				return true;

--- a/IDEHelper/Compiler/BfAst.h
+++ b/IDEHelper/Compiler/BfAst.h
@@ -2329,6 +2329,7 @@ public:
 
 	bool IsNamedTypeReference();
 	bool IsTypeDefTypeReference();
+	String ToCleanAttributeString();
 
 };	BF_AST_DECL(BfTypeReference, BfAstNode);
 

--- a/IDEHelper/Compiler/BfDefBuilder.cpp
+++ b/IDEHelper/Compiler/BfDefBuilder.cpp
@@ -555,7 +555,7 @@ BfMethodDef* BfDefBuilder::CreateMethodDef(BfMethodDeclaration* methodDeclaratio
 		{
 			if (attributes->mAttributeTypeRef != NULL)
 			{
-				auto typeRefName = attributes->mAttributeTypeRef->ToString();
+				auto typeRefName = attributes->mAttributeTypeRef->ToCleanAttributeString();
 
 				if (typeRefName == "StdCall")
 					methodDef->mCallingConvention = BfCallingConvention_Stdcall;
@@ -788,7 +788,7 @@ void BfDefBuilder::ParseAttributes(BfAttributeDirective* attributes, BfMethodDef
 	{		
 		if (attributes->mAttributeTypeRef != NULL)
 		{
-			auto typeRefName = attributes->mAttributeTypeRef->ToString();
+			auto typeRefName = attributes->mAttributeTypeRef->ToCleanAttributeString();
 
 			if (typeRefName == "CLink")
 				methodDef->mCLink = true;
@@ -874,7 +874,7 @@ void BfDefBuilder::ParseAttributes(BfAttributeDirective* attributes, BfTypeDef* 
 	{		
 		if (attributes->mAttributeTypeRef != NULL)
 		{
-			auto typeRefName = attributes->mAttributeTypeRef->ToString();
+			auto typeRefName = attributes->mAttributeTypeRef->ToCleanAttributeString();
 
 			if (typeRefName == "AlwaysInclude")
 				typeDef->mIsAlwaysInclude = true;
@@ -2098,7 +2098,7 @@ void BfDefBuilder::FinishTypeDef(bool wantsToString)
 				{
 					if (attributes->mAttributeTypeRef != NULL)
 					{
-						auto typeRefName = attributes->mAttributeTypeRef->ToString();
+						auto typeRefName = attributes->mAttributeTypeRef->ToCleanAttributeString();
 
 						if (typeRefName == "ThreadStatic")
 							hasThreadStatics = true;

--- a/IDEHelper/Compiler/BfMangler.cpp
+++ b/IDEHelper/Compiler/BfMangler.cpp
@@ -2367,7 +2367,7 @@ void BfMangler::HandleParamCustomAttributes(BfAttributeDirective* attributes, bo
 	{
 		if (attributes->mAttributeTypeRef != NULL)
 		{
-			auto typeRefName = attributes->mAttributeTypeRef->ToString();
+			auto typeRefName = attributes->mAttributeTypeRef->ToCleanAttributeString();
 			if (typeRefName == "MangleConst")
 				isConst = true;
 		}

--- a/IDEHelper/Compiler/BfModule.cpp
+++ b/IDEHelper/Compiler/BfModule.cpp
@@ -11367,7 +11367,7 @@ void BfModule::GetCustomAttributes(BfCustomAttributes* customAttributes, BfAttri
 				{
 					if (prevCustomAttribute.mType == attrTypeInst)
 					{
-						Fail(StrFormat("Duplicate '%s' attribute", attributesDirective->mAttributeTypeRef->ToString().c_str()), attributesDirective->mAttributeTypeRef); // CS0579						
+						Fail(StrFormat("Duplicate '%s' attribute", attributesDirective->mAttributeTypeRef->ToCleanAttributeString().c_str()), attributesDirective->mAttributeTypeRef); // CS0579						
 					}
 				}
 			}

--- a/IDEHelper/Compiler/BfModuleTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfModuleTypeUtils.cpp
@@ -5158,7 +5158,7 @@ void BfModule::DoTypeInstanceMethodProcessing(BfTypeInstance* typeInstance)
 			{
 				if (attributes->mAttributeTypeRef != NULL)
 				{
-					auto typeRefName = attributes->mAttributeTypeRef->ToString();
+					auto typeRefName = attributes->mAttributeTypeRef->ToCleanAttributeString();
 
 					if (typeRefName == "AlwaysInclude")
 						implRequired = true;

--- a/IDEHelper/Tests/src/Program.bf
+++ b/IDEHelper/Tests/src/Program.bf
@@ -1,19 +1,10 @@
 namespace Tests
 {
-	typealias DDDDAttribute = System.InlineAttribute;
-
 	class Program
 	{
-		
 		public static void Main()
 		{
-			A();
-		}
-
-		[DDDD]
-		public static void A()
-		{
-			int i = 1 + 2;
+			
 		}
 	}
 }

--- a/IDEHelper/Tests/src/Program.bf
+++ b/IDEHelper/Tests/src/Program.bf
@@ -1,10 +1,19 @@
 namespace Tests
 {
+	typealias DDDDAttribute = System.InlineAttribute;
+
 	class Program
 	{
+		
 		public static void Main()
 		{
+			A();
+		}
 
+		[DDDD]
+		public static void A()
+		{
+			int i = 1 + 2;
 		}
 	}
 }


### PR DESCRIPTION
stuff like [System.InlineAttribute] wont actually work, but is sometimes more or less needed if you're emitting code.

I was also today years old when i learned that builtin attributes actually just do nothing when typealiased. I mean, i guess there is mostly no use in it, but it also means that this didn't work for half a year and i somehow never noticed.
```
[AttributeUsage(.Method)]
struct DebugCallAttribute : Attribute {} // Useless, basically

#if DEBUG
typealias DebugOnlyAttribute = DebugCallAttribute;
#else
typealias DebugOnlyAttribute = SkipCallAttribute;
#endif
```
still, arguably, this is one of the very few sensical applications of typealiasing builtin attributes.