### PR TITLE
Add Ctrl+C handler to Console.bf

### DIFF
--- a/BeefLibs/corlib/src/Console.bf
+++ b/BeefLibs/corlib/src/Console.bf
@@ -234,9 +234,9 @@ namespace System
 #endif
 		}
 
-		public static void RemoveCancelKeyPressCallback(ConsoleCancelEventHandler handler)
+		public static void RemoveCancelKeyPressCallback(ConsoleCancelEventHandler handler, bool deleteDelegate = false)
 		{
-			_cancelKeyPress.Remove(handler);
+			_cancelKeyPress.Remove(handler, deleteDelegate);
 			
 #if BF_PLATFORM_WINDOWS
 			if (_cancelKeyPress.Count == 0 && WindowsConsole.CtrlHandlerAdded)

--- a/BeefLibs/corlib/src/ConsoleCancelEvent.bf
+++ b/BeefLibs/corlib/src/ConsoleCancelEvent.bf
@@ -1,0 +1,40 @@
+namespace System
+{
+	/// Specifies combinations of modifier and console keys that can interrupt the current process.
+	public enum ConsoleSpecialKey
+	{
+		/// The Control modifier key plus the C console key.
+		ControlC,
+		/// The Control modifier key plus the BREAK console key.
+		ControlBreak
+	}
+
+	public sealed class ConsoleCancelEventArgs : EventArgs
+	{
+		private ConsoleSpecialKey _type;
+		private bool _cancel;
+
+		private this() {}
+
+		public this(ConsoleSpecialKey type)
+		{
+			_type = type;
+			_cancel = false;
+		}
+
+		/// Gets or sets a value that indicates whether simultaneously pressing the Control modifier key and the C console key (Ctrl+C) or the Ctrl+Break keys terminates the current process.
+		/// The default is false, which terminates the current process.
+		public bool Cancel
+		{
+			get { return _cancel; }
+			set { _cancel = value; }
+		}
+
+		public ConsoleSpecialKey SpecialKey
+		{
+			get { return _type; }
+		}
+	}
+
+	public delegate void ConsoleCancelEventHandler(Object sender, ConsoleCancelEventArgs e);
+}


### PR DESCRIPTION
I did notice that BfCallAllStaticDtors is called before this event is handled, not too sure where/how to resolve that issue.