### PR TITLE
Hoverwatch comptime errors fix & fleeting fix.

### DIFF
--- a/IDE/src/ui/HoverWatch.bf
+++ b/IDE/src/ui/HoverWatch.bf
@@ -259,6 +259,8 @@ namespace IDE.ui
         float mOrigY;
 		float mOrigScreenX;
 		float mOrigScreenY;
+		float mTaskbarXOffset;
+		float mTaskbarYOffset;
         bool mIsShown;
 		bool mCreatedWindow;
 		bool mClosed;
@@ -1078,6 +1080,9 @@ namespace IDE.ui
 				WidgetWindow.sOnKeyDown.Add(new => HandleKeyDown);
 
 				widgetWindow.mOnWindowClosed.Add(new (window) => Close());
+
+				mTaskbarXOffset = mOrigScreenX - widgetWindow.mNormX;
+				mTaskbarYOffset = mOrigScreenY - widgetWindow.mNormY;
 			}
             else
 			{
@@ -1090,7 +1095,7 @@ namespace IDE.ui
 
 				if (autocomplete != null)
 					autocomplete.SetIgnoreMove(true);
-                mWidgetWindow.Resize((int32)(mWidgetWindow.mNormX + minX), (int32)(mWidgetWindow.mNormY + minY), (int32)(maxX - minX), (int32)(maxY - minY));
+                mWidgetWindow.Resize((int32)(mOrigScreenX - mTaskbarXOffset + minX), (int32)(mOrigScreenY - mTaskbarYOffset + minY), (int32)(maxX - minX), (int32)(maxY - minY));
 				if (autocomplete != null)
 					autocomplete.SetIgnoreMove(false);
 			}
@@ -1293,6 +1298,7 @@ namespace IDE.ui
 					actualMaxWidth = Math.Max(actualMaxWidth, fontMetrics.mMaxWidth);
 
 					float addHeight = nameHeight - listViewItem.mSelfHeight;
+					listViewItem.mSelfHeight = nameHeight;
 					height += addHeight;
 				}
 

--- a/IDEHelper/Compiler/BfAutoComplete.cpp
+++ b/IDEHelper/Compiler/BfAutoComplete.cpp
@@ -2336,6 +2336,8 @@ bool BfAutoComplete::GetMethodInfo(BfMethodInstance* methodInst, StringImpl* sho
 
 			if (!isInterface)
 				impl += "override ";
+			else if (methodDef->mIsStatic)
+				impl += "static ";
 
 			BfType* propType = methodInst->mReturnType;
 			if (methodDef->mMethodType == BfMethodType_PropertySetter)

--- a/IDEHelper/Compiler/BfPrinter.cpp
+++ b/IDEHelper/Compiler/BfPrinter.cpp
@@ -1816,8 +1816,11 @@ void BfPrinter::Visit(BfDeleteStatement* deleteStmt)
 	Visit(deleteStmt->ToBase());
 
 	VisitChild(deleteStmt->mDeleteToken);
+	VisitChild(deleteStmt->mTargetTypeToken);
+	VisitChild(deleteStmt->mAllocExpr);
 	ExpectSpace();
 	VisitChild(deleteStmt->mExpression);
+	
 
 	VisitChild(deleteStmt->mTrailingSemicolon);
 }


### PR DESCRIPTION
Fixes fleeting of the hoverwatch window introduced by #961. This fleeting only occurs when hoverwatch would be outside of the screen (so it expands in the opposite direction, that is when this fleeting occurs). This solution is somewhat hacky, but works.

Fix for #1029 - Problem is that the `WatchListViewItem` has wrong height when it contains text that needs to be wrapped which should be fixed with this PR.

Fix for fixits not creating proper signature for static interface properties.

Fix autoformat deleting allocator info from delete.  (#992, possibly #994)
