### PR TITLE
Fix a thread safety issue in TimeZoneInfo

### DIFF
--- a/BeefLibs/corlib/src/TimeZoneInfo.bf
+++ b/BeefLibs/corlib/src/TimeZoneInfo.bf
@@ -253,7 +253,10 @@ namespace System {
 					if (rule != null)
 						rule = rule.Clone();
                     oneYearLocFromUtc = new OffsetAndRule(year, currentYear.BaseUtcOffset, rule);
-                    m_oneYearLocalFromUtc = oneYearLocFromUtc;
+                    if (Interlocked.CompareExchange(ref m_oneYearLocalFromUtc, null, oneYearLocFromUtc) != null) {
+                        delete oneYearLocFromUtc;
+                        oneYearLocFromUtc = m_oneYearLocalFromUtc;
+                    }
                 }
                 return oneYearLocFromUtc;
             }


### PR DESCRIPTION
Fixes #1056

This is the fix that I suggested in the issue #1056.

Basically, before exchanging the value it checks if the value already was changed by another thread and if it was, we just pick it and delete what we constructed in the current thread.