### PR TITLE
Allow Spans to be created from null Arrays

### DIFF
--- a/BeefLibs/corlib/src/Span.bf
+++ b/BeefLibs/corlib/src/Span.bf
@@ -16,18 +16,35 @@ namespace System
 
 		public this(T[] array)
 		{
+			if (array == null)
+			{
+				this = default;
+				return;
+			}
 			mPtr = &array.[Friend]GetRef(0);
 			mLength = array.[Friend]mLength;
 		}
 
 		public this(T[] array, int index)
 		{
+			if (array == null)
+			{
+				Debug.Assert(index == 0);
+				this = default;
+				return;
+			}
 			mPtr = &array[index];
 			mLength = array.[Friend]mLength - index;
 		}
 
 		public this(T[] array, int index, int length)
 		{
+			if (array == null)
+			{
+				Debug.Assert(index == 0 && length == 0);
+				this = default;
+				return;
+			}
 			if (length == 0)
 				mPtr = null;
 			else
@@ -48,9 +65,6 @@ namespace System
 
 		public static implicit operator Span<T> (T[] array)
 		{
-			if (array == null)
-				return default;
-			
 			return Span<T>(array);
 		}
 		

--- a/BeefLibs/corlib/src/Span.bf
+++ b/BeefLibs/corlib/src/Span.bf
@@ -48,6 +48,9 @@ namespace System
 
 		public static implicit operator Span<T> (T[] array)
 		{
+			if (array == null)
+				return default;
+			
 			return Span<T>(array);
 		}
 		


### PR DESCRIPTION
This pull-request is based on a problem that I had while testing issue https://github.com/beefytech/Beef/issues/1081.
Currently Beef crashes if you try to convert a null array to a span, but I think we should do something like C# and just create a null span in this case. the aim of this pull-request is to so and a little more, as I thought that it would make more sense to also extend the "null array" support to all constructors of span that accepts an array as arguments, like in C#.