### PR TITLE
Add Remove method to Dictionary Enumerators

### DIFF
--- a/BeefLibs/corlib/src/Collections/Dictionary.bf
+++ b/BeefLibs/corlib/src/Collections/Dictionary.bf
@@ -868,6 +868,9 @@ namespace System.Collections
 			{
 				int_cosize curIdx = mIndex - 1;
 				mDictionary.Remove(mDictionary.mEntries[curIdx].mKey);
+#if VERSION_DICTIONARY
+				mVersion = mDictionary.mVersion;
+#endif
 				mIndex = curIdx;
 			}
 
@@ -1016,6 +1019,9 @@ namespace System.Collections
 			{
 				int_cosize curIdx = mIndex - 1;
 				mDictionary.Remove(mDictionary.mEntries[curIdx].mKey);
+#if VERSION_DICTIONARY
+				mVersion = mDictionary.mVersion;
+#endif
 				mIndex = curIdx;
 			}
 
@@ -1119,6 +1125,9 @@ namespace System.Collections
 			{
 				int_cosize curIdx = mIndex - 1;
 				mDictionary.Remove(mDictionary.mEntries[curIdx].mKey);
+#if VERSION_DICTIONARY
+				mVersion = mDictionary.mVersion;
+#endif
 				mIndex = curIdx;
 			}
 

--- a/BeefLibs/corlib/src/Collections/Dictionary.bf
+++ b/BeefLibs/corlib/src/Collections/Dictionary.bf
@@ -864,6 +864,13 @@ namespace System.Collections
 				mDictionary.mEntries[mCurrentIndex].mValue = value;
 			}
 
+			public void Remove() mut
+			{
+				int_cosize curIdx = mIndex - 1;
+				mDictionary.Remove(mDictionary.mEntries[curIdx].mKey);
+				mIndex = curIdx;
+			}
+
 			public void Reset() mut
 			{
 #if VERSION_DICTIONARY
@@ -1005,6 +1012,13 @@ namespace System.Collections
 			{
 			}
 
+			public void Remove() mut
+			{
+				int_cosize curIdx = mIndex - 1;
+				mDictionary.Remove(mDictionary.mEntries[curIdx].mKey);
+				mIndex = curIdx;
+			}
+
 			public void Reset() mut
 			{
 #if VERSION_DICTIONARY
@@ -1099,6 +1113,13 @@ namespace System.Collections
 
 			public void Dispose()
 			{
+			}
+
+			public void Remove() mut
+			{
+				int_cosize curIdx = mIndex - 1;
+				mDictionary.Remove(mDictionary.mEntries[curIdx].mKey);
+				mIndex = curIdx;
 			}
 
 			public void Reset() mut


### PR DESCRIPTION
Sorry if I missed something, but looking at the implementation of both `Dictionary.Remove` and the Dictionary Enumerators, I didn't see any reason to justify a `Remove` method (like the List one) not existing, so I suggest to add it with this pull-request as this is really useful.