### PR TITLE
Partial support for scientific notation in float.Parse()

### DIFF
--- a/BeefLibs/corlib/src/Float.bf
+++ b/BeefLibs/corlib/src/Float.bf
@@ -169,11 +169,31 @@ namespace System
 			bool isNeg = false;
 		    double result = 0;
 			double decimalMultiplier = 0;
+			double exponent = 0;
 			
 			//TODO: Use Number.ParseNumber
 			for (int32 i = 0; i < val.Length; i++)
 			{
 				char8 c = val.Ptr[i];
+
+				//Exponent prefix used in scientific notation. E.g. 1.2E5
+				if((c == 'e') || (c == 'E'))
+				{
+					//Error if there are no numbers after the prefix
+					if(i == val.Length - 1)
+						return .Err;
+
+					//Parse exponent
+					var exponentParseResult = int32.Parse(val.Substring(i + 1));
+					if(exponentParseResult == .Err)
+						return .Err;
+					else
+					{
+						//If exponent is valid discard anything after it
+						exponent = (double)exponentParseResult.Value;
+						break;
+					}
+				}
 
 				if (c == '.')
 				{
@@ -210,7 +230,12 @@ namespace System
 				else
 					return .Err;
 			}
-			return isNeg ? (float)(-result) : (float)result;
+
+			//Calculate final result
+			if(isNeg)
+				result *= -1;
+			result *= Math.Pow(10, exponent);
+			return (float)result;
 		}
     }
 }

--- a/IDE/Tests/Test1/src/Parse.bf
+++ b/IDE/Tests/Test1/src/Parse.bf
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+using System;
+
+namespace IDETest
+{
+	class ParseTester
+	{
+        public static mixin FloatParseTest(StringView string, float expectedResult)
+        {
+            {
+                float result = float.Parse(string);
+                Debug.Assert(expectedResult - result < float.Epsilon);
+            }
+        }
+
+		public static void Test()
+		{
+            FloatParseTest!("1.2", 1.2f);
+            FloatParseTest!("-0.2", -0.2f);
+            FloatParseTest!("2.5E2", 2.5E2f);
+            FloatParseTest!("2.7E-10", 2.7E-10f);
+            FloatParseTest!("-0.17E-7", -0.17E-7f);
+            FloatParseTest!("8.7e6", 8.7e6f);
+            FloatParseTest!("3.3e-11", 3.3e-11f);
+            FloatParseTest!("0.002e5", 0.002e5f);
+		}
+	}
+}

--- a/IDE/Tests/Test1/src/Program.bf
+++ b/IDE/Tests/Test1/src/Program.bf
@@ -32,6 +32,7 @@ namespace IDETest
 			TypedPrimitives.Test();
 			Unions.Test();
 			Virtuals.Test();
+			ParseTester.Test();
 
 			Bug001.Test();
 			Bug002.Test();


### PR DESCRIPTION
Adds scientific notation to `float.Parse()`. Only supports syntax where you prefix the exponent with `e` or `E`. Doesn't support `base * 10 ^ exp` syntax. There's some examples of supported syntax in `/IDE/Tests/Test1/src/Parse.bf`.