### PR TITLE
Fix AltGr triggering keyboard shortcuts.

### DIFF
--- a/BeefLibs/Beefy2D/src/widgets/KeyCode.bf
+++ b/BeefLibs/Beefy2D/src/widgets/KeyCode.bf
@@ -82,6 +82,8 @@ namespace Beefy.widgets
         F12 = 0x7B,
         Numlock = 0x90,
         Scroll = 0x91,
+		RAlt = 0xA5,
+		RMenu = 0xA5,
 		Semicolon = 0xBA,
 		Equals = 0xBB,
 		Comma = 0xBC,

--- a/BeefLibs/Beefy2D/src/widgets/WidgetWindow.bf
+++ b/BeefLibs/Beefy2D/src/widgets/WidgetWindow.bf
@@ -121,7 +121,7 @@ namespace Beefy.widgets
             KeyFlags keyFlags = default;
             if (IsKeyDown(KeyCode.Shift))
                 keyFlags |= KeyFlags.Shift;
-            if (IsKeyDown(KeyCode.Control))
+            if ((IsKeyDown(KeyCode.Control)) && (!IsKeyDown(KeyCode.RAlt)))
                 keyFlags |= KeyFlags.Ctrl;
             if (IsKeyDown(KeyCode.Menu))
                 keyFlags |= KeyFlags.Alt;
@@ -137,7 +137,7 @@ namespace Beefy.widgets
         {   
          	if (mRootWidget == null)
 				 return;
-
+			
             base.Draw(g);			
             mRootWidget.DrawAll(g);            
         }

--- a/BeefySysLib/platform/win/WinBFApp.h
+++ b/BeefySysLib/platform/win/WinBFApp.h
@@ -52,6 +52,7 @@ public:
 	bool					mSoftHasFocus; // Mostly tracks mHasFocus except for when we get an explicit 'LostFocus' callback	
 
 	bool					mNeedsStateReset;		
+	bool					mKeyLayoutHasAltGr;
 
 public:
 	virtual LRESULT WindowProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);

--- a/IDE/src/ui/PropertiesDialog.bf
+++ b/IDE/src/ui/PropertiesDialog.bf
@@ -44,7 +44,8 @@ namespace IDE.ui
 		{
 			if ((evt.mKeyCode == .Control) ||
 				(evt.mKeyCode == .Shift) ||
-				(evt.mKeyCode == .Alt))
+				(evt.mKeyCode == .Alt) ||
+				(evt.mKeyCode == .RAlt))
 				return;
 
 			if ((evt.mKeyFlags == 0) &&


### PR DESCRIPTION
Fixes right ALT (AltGr - which on Slovak keyboard layout is used for symbols such as `| & [ ] { }`) triggering keyboard shortcuts which use CTRL and/or ALT as modifier key. 