### PR TITLE
Make BeefPerf maximizable

### DIFF
--- a/BeefTools/BeefPerf/src/BPApp.bf
+++ b/BeefTools/BeefPerf/src/BPApp.bf
@@ -234,9 +234,8 @@ namespace BeefPerf
 			mMainFrame = new MainFrame();
 			mDockingFrame = mMainFrame.mDockingFrame;
 
-			BFWindow.Flags windowFlags = BFWindow.Flags.Border | BFWindow.Flags.SysMenu | //| BFWindow.Flags.CaptureMediaKeys |
-			    BFWindow.Flags.Caption | BFWindow.Flags.Minimize | BFWindow.Flags.QuitOnClose | BFWindowBase.Flags.Resizable |
-                BFWindow.Flags.Menu | BFWindow.Flags.SysMenu;
+			BFWindow.Flags windowFlags = .Border | .SysMenu | .Caption | .Minimize | .Maximize |
+				.QuitOnClose | .Resizable | .Menu | .SysMenu;
 			if (mWantsFullscreen)
 				windowFlags |= BFWindowBase.Flags.Fullscreen;
 

--- a/BeefTools/BeefPerf/src/BPApp.bf
+++ b/BeefTools/BeefPerf/src/BPApp.bf
@@ -235,7 +235,7 @@ namespace BeefPerf
 			mDockingFrame = mMainFrame.mDockingFrame;
 
 			BFWindow.Flags windowFlags = .Border | .SysMenu | .Caption | .Minimize | .Maximize |
-				.QuitOnClose | .Resizable | .Menu | .SysMenu;
+				.QuitOnClose | .Resizable | .Menu;
 			if (mWantsFullscreen)
 				windowFlags |= BFWindowBase.Flags.Fullscreen;
 


### PR DESCRIPTION
Enables the maximize button. Also changed the flags to use the .Enum shorthand since the enum name is already in the variable declaration.