### PR TITLE
Return uint32 from COM_IUnknown.AddRef and Release methods

### DIFF
--- a/BeefLibs/corlib/src/Windows.bf
+++ b/BeefLibs/corlib/src/Windows.bf
@@ -48,8 +48,8 @@ namespace System
 			public struct VTable
 			{
 				public function HResult(COM_IUnknown* self, ref Guid riid, void** result) QueryInterface;
-				public function HResult(COM_IUnknown* self) AddRef;
-				public function HResult(COM_IUnknown* self) Release;
+				public function uint32(COM_IUnknown* self) AddRef;
+				public function uint32(COM_IUnknown* self) Release;
 			}
 
 			public enum HResult : int32


### PR DESCRIPTION
IUnknown AddRef & Release methods should return uint32, not HRESULT.

https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-addref
https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-release