### PR TITLE
Add `TryGetValueAlt` and `ContainsAlt` to Dictionary

### DIFF
--- a/BeefLibs/corlib/src/Collections/Dictionary.bf
+++ b/BeefLibs/corlib/src/Collections/Dictionary.bf
@@ -277,6 +277,19 @@ namespace System.Collections
 				return false;
 			}
 		}
+
+		public bool ContainsAlt<TAltKey>((TAltKey key, TValue value) kvPair) where TAltKey : IHashable where bool : operator TKey == TAltKey
+		{
+			TValue value;
+			if (TryGetValueAlt(kvPair.key, out value))
+			{
+				return value == kvPair.value;
+			}
+			else
+			{
+				return false;
+			}
+		}
 		
 		public void CopyTo(Span<KeyValuePair> kvPair)
 		{

--- a/BeefLibs/corlib/src/Collections/Dictionary.bf
+++ b/BeefLibs/corlib/src/Collections/Dictionary.bf
@@ -739,6 +739,18 @@ namespace System.Collections
 			return false;
 		}
 
+		public bool TryGetValueAlt<TAltKey>(TAltKey key, out TValue value) where TAltKey : IHashable where bool : operator TKey == TAltKey
+		{
+			int_cosize i = (int_cosize)FindEntryAlt<TAltKey>(key);
+			if (i >= 0)
+			{
+				value = mEntries[i].mValue;
+				return true;
+			}
+			value = default(TValue);
+			return false;
+		}
+
 		public bool TryGet(TKey key, out TKey matchKey, out TValue value)
 		{
 			int_cosize i = (int_cosize)FindEntry(key);


### PR DESCRIPTION
Currently there is a `TryGetAlt` in Dictionary, but no `TryGetValueAlt`, this pull request adds it.
This pull request also adds `ContainsAlt` which uses the new `TryGetValueAlt`. _(Although I'm not sure if this is really useful, but I added it anyway for completeness)_