### PR TITLE
Fix incorrect search & replace for "char => char8" in comments

### DIFF
--- a/BeefLibs/Beefy2D/src/gfx/Font.bf
+++ b/BeefLibs/Beefy2D/src/gfx/Font.bf
@@ -112,13 +112,13 @@ namespace Beefy.gfx
 		enum MarkPosition
 		{
 			AboveC, // Center
-			AboveR, // Left edge of mark aligned on center of char8
-			AboveE, // Center of mark aligned on right edge of char8
+			AboveR, // Left edge of mark aligned on center of char
+			AboveE, // Center of mark aligned on right edge of char
 			BelowC,
 			BelowR,
 			OverC,
 			OverE,
-			TopR, // Center of edge aligned to top of char8
+			TopR, // Center of edge aligned to top of char
 		}
 
         const int32 LOW_CHAR_COUNT = 128;
@@ -798,7 +798,7 @@ namespace Beefy.gfx
 					else if (newMatrix.tx > clipRect.mX + clipRect.mWidth)
 					{
 						isFullyClipped = true;
-						if ((newMatrix.a > 0) && (fontMetrics == null)) // Forward? If so, all future char8s will clip
+						if ((newMatrix.a > 0) && (fontMetrics == null)) // Forward? If so, all future chars will clip
 							break;
 					}
 				}

--- a/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
+++ b/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
@@ -459,7 +459,7 @@ namespace Beefy.widgets
 			public UndoManager mUndoManager = new UndoManager() ~ delete _;
 			public int32 mNextCharId = 1; //
 			public int32 mCurTextVersionId = 1; // Changes when text is modified
-			//public int mCurComplexChangeId = 1; // Changes when text is modified by more than a single-char8acter insertion or deletion
+			//public int mCurComplexChangeId = 1; // Changes when text is modified by more than a single-character insertion or deletion
 
 			public List<EditWidgetContent> mUsers = new List<EditWidgetContent>() ~ delete _;
 

--- a/BeefLibs/corlib/src/Diagnostics/AsyncStreamReader.bf
+++ b/BeefLibs/corlib/src/Diagnostics/AsyncStreamReader.bf
@@ -19,7 +19,7 @@ namespace System.Diagnostics
 		private char8[] char8Buffer;
 		// Record the number of valid bytes in the byteBuffer, for a few checks.
 
-		// This is the maximum number of char8s we can get from one call to 
+		// This is the maximum number of chars we can get from one call to 
 		// ReadBuffer.  Used so ReadBuffer can tell when to copy data into
 		// a user's char8[] directly, instead of our internal char8[].
 		private int32 mMaxCharsPerBuffer;
@@ -194,7 +194,7 @@ namespace System.Diagnostics
 			int lineStart = 0;
 			int len = sb.Length;
 
-			// skip a beginning '\n' char8acter of new block if last block ended 
+			// skip a beginning '\n' character of new block if last block ended 
 			// with '\r'
 			if (bLastCarriageReturn && (len > 0) && sb[0] == '\n')
 			{
@@ -206,7 +206,7 @@ namespace System.Diagnostics
 			while (currentIndex < len)
 			{
 				char8 ch = sb[currentIndex];
-				// Note the following common line feed char8s:
+				// Note the following common line feed chars:
 				// \n - UNIX   \r\n - DOS   \r - Mac
 				if (ch == '\r' || ch == '\n')
 				{
@@ -214,7 +214,7 @@ namespace System.Diagnostics
 					s.Append(sb, lineStart, currentIndex - lineStart);
 
 					lineStart = currentIndex + 1;
-					// skip the "\n" char8acter following "\r" char8acter
+					// skip the "\n" character following "\r" character
 					if ((ch == '\r') && (lineStart < len) && (sb[lineStart] == '\n'))
 					{
 						lineStart++;
@@ -232,7 +232,7 @@ namespace System.Diagnostics
 			{
 				bLastCarriageReturn = true;
 			}
-			// Keep the rest char8acaters which can't form a new line in string builder.
+			// Keep the rest characaters which can't form a new line in string builder.
 			if (lineStart < len)
 			{
 				if (lineStart == 0)

--- a/BeefLibs/corlib/src/IO/Path.bf
+++ b/BeefLibs/corlib/src/IO/Path.bf
@@ -15,7 +15,7 @@ namespace System.IO
 		public const char8 DirectorySeparatorChar = '/';
 #endif //BF_PLATFORM_WINDOWS
 		
-		// Platform specific alternate directory separator char8acter.  
+		// Platform specific alternate directory separator character.  
 		// This is backslash ('\') on Unix, and slash ('/') on Windows 
 		// and MacOS.
 		// 
@@ -25,7 +25,7 @@ namespace System.IO
 		public const char8 AltDirectorySeparatorChar = '\\';
 #endif //BF_PLATFORM_WINDOWS
 	
-		// Platform specific volume separator char8acter.  This is colon (':')
+		// Platform specific volume separator character.  This is colon (':')
 		// on Windows and MacOS, and slash ('/') on Unix.  This is mostly
 		// useful for parsing paths like "c:\windows" or "MacVolume:System Folder".  
 		// 
@@ -37,7 +37,7 @@ namespace System.IO
 
 		// Make this public sometime.
 		// The max total path is 260, and the max individual component length is 255. 
-		// For example, D:\<256 char8 file name> isn't legal, even though it's under 260 char8s.
+		// For example, D:\<256 char file name> isn't legal, even though it's under 260 chars.
 		protected const int32 MaxPath = 260;
 		private const int32 MaxDirectoryLength = 255;
 

--- a/BeefLibs/corlib/src/IO/StreamReader.bf
+++ b/BeefLibs/corlib/src/IO/StreamReader.bf
@@ -256,7 +256,7 @@ namespace System.IO
 		        {
 		            char8 ch = tmpCharBuffer[i];
 
-		            // Note the following common line feed char8s:
+		            // Note the following common line feed chars:
 		            // \n - UNIX   \r\n - DOS   \r - Mac
 		            if (ch == '\r' || ch == '\n')
 		            {
@@ -481,7 +481,7 @@ namespace System.IO
 			}
 			while (mCharLen == 0);
 
-            //Console.WriteLine("ReadBuffer called.  char8s: "+char8Len);
+            //Console.WriteLine("ReadBuffer called.  chars: "+char8Len);
 			return mCharLen;
 		}
 
@@ -522,7 +522,7 @@ namespace System.IO
 				repeat
 				{
 					char8 ch = mCharBuffer[i];
-                    // Note the following common line feed char8s:
+                    // Note the following common line feed chars:
                     // \n - UNIX   \r\n - DOS   \r - Mac
 					if (ch == '\r' || ch == '\n')
 					{

--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -1778,7 +1778,7 @@ namespace System
 
                 //Contract.Assert((char8A | char8B) <= 0x7F, "strings have to be ASCII");
 
-                // uppercase both char8s - notice that we need just one compare per char8
+                // uppercase both chars - notice that we need just one compare per char
 				if ((uint32)(charA - 'a') <= (uint32)('z' - 'a')) charA -= 0x20;
 				if ((uint32)(charB - 'a') <= (uint32)('z' - 'a')) charB -= 0x20;
 
@@ -1786,7 +1786,7 @@ namespace System
 				if (charA != charB)
 					return false;
 
-                // Next char8
+                // Next char
 				curA++;curB++;
 				curLength--;
 			}
@@ -1811,7 +1811,7 @@ namespace System
 
                 //Contract.Assert((char8A | char8B) <= 0x7F, "strings have to be ASCII");
 
-                // uppercase both char8s - notice that we need just one compare per char8
+                // uppercase both chars - notice that we need just one compare per char
 				if ((uint32)(charA - 'a') <= (uint32)('z' - 'a')) charA -= 0x20;
 				if ((uint32)(charB - 'a') <= (uint32)('z' - 'a')) charB -= 0x20;
 
@@ -1819,7 +1819,7 @@ namespace System
 				if (charA != charB)
 					return charA - charB;
 
-                // Next char8
+                // Next char
 				a++;b++;
 				length--;
 			}
@@ -1839,7 +1839,7 @@ namespace System
 				int_strsize charB = (int_strsize)*b;
 
 			    //Contract.Assert((char8A | char8B) <= 0x7F, "strings have to be ASCII");
-			    // uppercase both char8s - notice that we need just one compare per char8
+			    // uppercase both chars - notice that we need just one compare per char
 				if ((uint32)(charA - 'a') <= (uint32)('z' - 'a')) charA -= 0x20;
 				if ((uint32)(charB - 'a') <= (uint32)('z' - 'a')) charB -= 0x20;
 
@@ -1847,7 +1847,7 @@ namespace System
 				if (charA != charB)
 					return charA - charB;
 
-			    // Next char8
+			    // Next char
 				a++;b++;
 				length--;
 			}

--- a/BeefLibs/corlib/src/Text/UTF16.bf
+++ b/BeefLibs/corlib/src/Text/UTF16.bf
@@ -140,10 +140,10 @@ namespace System.Text
 
 		public static int GetMaxEncodedLen(int utf8Len)
 		{
-			//  Consider all incoming char8s are < \u80, each incoming char88 equals one outgoing char816 (utfLen * 1)
-			//  For char8s from \u80 to \u7FF, then two incoming char88 equals one outgoing char816 (utfLen * 0.5)
-			//  For char8s from \u800 to \u7FFF, then three incoming char88 equals one or two char816s (utfLen * 0.33) to (utfLen * 0.67)
-			//  For char8s from \u1000 to \u10FFFF, then four incoming char88 equals two outgoing char816s (utfLen * 0.5)
+			//  Consider all incoming chars are < \u80, each incoming char8 equals one outgoing char16 (utfLen * 1)
+			//  For chars from \u80 to \u7FF, then two incoming char8 equals one outgoing char16 (utfLen * 0.5)
+			//  For chars from \u800 to \u7FFF, then three incoming char8 equals one or two char16s (utfLen * 0.33) to (utfLen * 0.67)
+			//  For chars from \u1000 to \u10FFFF, then four incoming char8 equals two outgoing char16s (utfLen * 0.5)
 			return utf8Len;
 		}
 
@@ -211,7 +211,7 @@ namespace System.Text
 				if (c <= '\u{FFFF}')
 				{
 #if BF_UTF_PEDANTIC
-					// Illegal UTF16 char8?
+					// Illegal UTF16 char?
 					Debug.Assert((c <= '\u{D7FF}') || (c >= '\u{E000}'));
 #endif
 					EncodeChar((char16)c);

--- a/IDE/mintest/minlib/src/System/String.bf
+++ b/IDE/mintest/minlib/src/System/String.bf
@@ -716,7 +716,7 @@ namespace System
 					++inIdx;
 					++outIdx;
 				}
-				else // We need to physically move char8acters once we've found an equal span
+				else // We need to physically move characters once we've found an equal span
 				{
 					ptr[outIdx++] = ptr[inIdx++];
 				}

--- a/IDE/src/Workspace.bf
+++ b/IDE/src/Workspace.bf
@@ -1401,7 +1401,7 @@ namespace IDE
                         {
                             if (curColumn == column)
                                 return charId;
-                            // For column == -1, use first non-whitespace char8
+                            // For column == -1, use first non-whitespace char
                             if ((column == -1) && (!c.IsWhiteSpace))
                                 return charId;
                         }

--- a/IDE/src/ui/AutoComplete.bf
+++ b/IDE/src/ui/AutoComplete.bf
@@ -1722,7 +1722,7 @@ namespace IDE.ui
 
                 if ((!SelectEntry(curString)) && (curString.Length > 0))
                 {
-                    // If we can't find any matches, at least select a string that starts with the right char8acter
+                    // If we can't find any matches, at least select a string that starts with the right character
                     curString.RemoveToEnd(1);
                     SelectEntry(curString);
                 }

--- a/IDE/src/ui/BinaryDataWidget.bf
+++ b/IDE/src/ui/BinaryDataWidget.bf
@@ -1553,7 +1553,7 @@ namespace IDE.ui
             bool inStrView = false;
             bool checkSubChar = true;
             float testX = curX;
-            curX += 4; // offset by half a char8acter
+            curX += 4; // offset by half a character
             testX -= GS!(mColumnDisplayStart);
             testX /= (float)GS!(mColumnDisplayStride);
             if (testX < 0.0f)

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -4277,7 +4277,7 @@ namespace IDE.ui
 
                 if (mProcessingCharData[srcIdx].mCharId != destText[destIdx].mCharId)
                 {
-                    // Id doesn't match, char8acter must have been deleted
+                    // Id doesn't match, character must have been deleted
                     srcIdx++;
                     continue;
                 }


### PR DESCRIPTION
Fixed only in comments to avoid accidently breaking code.