### PR TITLE
Added button to toggle case sensitivity in quick find and quick replace

### DIFF
--- a/BeefLibs/Beefy2D/src/theme/dark/DarkButton.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkButton.bf
@@ -75,14 +75,16 @@ namespace Beefy.theme.dark
 
             g.SetFont(DarkTheme.sDarkTheme.mSmallFont);
             if (mLabel != null)
-            {
-                using (g.PushColor(mDisabled ? 0x80FFFFFF : Color.White))
-                {
-					using (g.PushColor(DarkTheme.COLOR_TEXT))
+			{
+				using (g.PushColor(mDisabled ? 0x80FFFFFF : Color.White))
+				{
+					using (g.PushColor(TextColor))
 						DarkTheme.DrawUnderlined(g, mLabel, GS!(2), (mHeight - GS!(20)) / 2 + mLabelYOfs, .Centered, mWidth - GS!(4), .Truncate);
-                }
-            }
+				}
+			}
         }
+
+		public virtual Color TextColor => DarkTheme.COLOR_TEXT;
 
 		public override void Update()
 		{

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -7442,6 +7442,7 @@ namespace IDE
 
 			if (window.mFocusWidget is KeysEditWidget)
 			{
+				evt.mKeyCode = .Accept;
 				return;
 			}
 


### PR DESCRIPTION
By default case sensitivity is disabled and persists between actions as long as the IDE didn't restart (it is stored in a static variable).
I wasn't sure how to handle the color so I just hardcoded it. If there are any changes I could make I will be happy to learn.
![image](https://user-images.githubusercontent.com/25082624/139583143-04cb4b80-a315-4e3e-aed0-17dc9682e9c5.png)
![image](https://user-images.githubusercontent.com/25082624/139583147-e2d396d7-534a-43a1-84fa-9464f1028359.png)