### PR TITLE
[IDE] Find class dialog and open file in workspace dialog now remembers last searched string

### DIFF
--- a/IDE/src/ui/ClassViewPanel.bf
+++ b/IDE/src/ui/ClassViewPanel.bf
@@ -13,6 +13,8 @@ namespace IDE.ui
 {
 	class ClassViewPanel : Panel
 	{
+		private static String sLastSearchString = new String() ~ delete _;
+
 		public class ClassViewListViewItem : IDEListViewItem
 		{
 		    public float mLabelOffset;
@@ -406,6 +408,15 @@ namespace IDE.ui
 				mSearchEdit.mOnSubmit.Add(new (evt) =>
 					{
 						mWantsSubmit = true;
+					});
+
+				mSearchEdit.SetText(sLastSearchString);
+				mSearchEdit.Content.SelectAll();
+
+				findClassDialog.mOnClosed.Add(new () =>
+					{
+						sLastSearchString.Clear();
+						mSearchEdit.GetText(sLastSearchString);
 					});
 			}
 

--- a/IDE/src/ui/OpenFileInSolutionDialog.bf
+++ b/IDE/src/ui/OpenFileInSolutionDialog.bf
@@ -64,6 +64,8 @@ namespace IDE.ui
         public bool mFilterChanged;
         public volatile bool mExitingThread;
         public Thread mDateThread;
+
+		static String sLastSearchString = new String() ~ delete _;
         
         public this()
         {
@@ -91,9 +93,15 @@ namespace IDE.ui
             AddWidget(mFileList);
             mTabWidgets.Add(mFileList);
 
-            mEditWidget = AddEdit("");
+            mEditWidget = AddEdit(sLastSearchString);
             mEditWidget.mOnKeyDown.Add(new => EditKeyDownHandler);
             mEditWidget.mOnContentChanged.Add(new (evt) => { mFilterChanged = true; });
+
+			mOnClosed.Add(new () =>
+				{
+					sLastSearchString.Clear();
+					mEditWidget.GetText(sLastSearchString);
+				});
         }
 
         void ShutdownThread()


### PR DESCRIPTION
A lot of the times I find myself searching for a class and after I close it I want to open it again, or a different class with similiar name.
It auto selects the entire string so the user can continue typing without having to delete the previous search.

EDIT: Now also works for Open file in workspace dialog.