### PR TITLE
Fix errno in Linux

### DIFF
--- a/BeefLibs/corlib/src/Net/Socket.bf
+++ b/BeefLibs/corlib/src/Net/Socket.bf
@@ -176,9 +176,16 @@ namespace System.Net
 
 		[Import("wsock32.lib"), CLink, CallingConvention(.Stdcall)]
 		static extern int32 WSAGetLastError();
+#elif BF_PLATFORM_LINUX
+		[LinkName("__errno_location")]
+		static extern int32* _errno();
+#elif BF_PLATFORM_MACOS
+		[LinkName("__error")]
+		static extern int32* _errno();
 #else
 		[CLink]
 		static int32 errno;
+		static int32* _errno() => &errno;
 #endif
 
 		[CLink, CallingConvention(.Stdcall)]
@@ -258,7 +265,7 @@ namespace System.Net
 #if BF_PLATFORM_WINDOWS
 			return WSAGetLastError();
 #else
-			return errno;
+			return *_errno();
 #endif
 		}
 


### PR DESCRIPTION
Before this change:
```
failed to listen. (0: Success)
```

After this change:
```
failed to listen. (98: Address already in use)
```

Code snippet:
```
			if (_sockin.Listen(Settings.MaxConnections) case .Err(let err))
			{
				Program.ExitWithOSError(1, err, "failed to listen."); // it calls 'strerror' to get the error string.
			}
```

**Note**: I kept the old code as a fallback for others platforms.