### PR TITLE
Add "Delete All Right" command to IDE

### DIFF
--- a/IDE/src/Commands.bf
+++ b/IDE/src/Commands.bf
@@ -198,6 +198,7 @@ namespace IDE
 			Add("Compile File", new => gApp.Cmd_CompileFile);
 			Add("Debug All Tests", new () => { gApp.[Friend]RunTests(true, true); });
 			Add("Debug Normal Tests", new () => { gApp.[Friend]RunTests(false, true); });
+			Add("Delete All Right", new => gApp.[Friend]DeleteAllRight);
 			Add("Duplicate Line", new () => { gApp.[Friend]DuplicateLine(); });
 			Add("Exit", new => gApp.[Friend]Cmd_Exit);
 			Add("Find All References", new => gApp.Cmd_FindAllReferences);

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -2409,6 +2409,12 @@ namespace IDE
 			//CloseWorkspace();
 			//FinishShowingNewWorkspace();
 		}
+		
+		[IDECommand]
+		void DeleteAllRight()
+		{
+			GetActiveSourceEditWidgetContent()?.DeleteAllRight();
+		}
 
 		[IDECommand]
 		void DuplicateLine()

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -2237,6 +2237,41 @@ namespace IDE.ui
 
 			return false;
 		}
+		
+		public void DeleteAllRight()
+		{
+			int startPos;
+			int endPos;
+			if (HasSelection())
+			{
+				mSelection.ValueRef.GetAsForwardSelect(out startPos, out endPos);
+			}
+			else
+			{
+				startPos = endPos = CursorTextPos;
+			}
+
+			int line;
+			int lineChar;
+			GetLineCharAtIdx(endPos, out line, out lineChar);
+
+			let lineText = scope String();
+			GetLineText(line, lineText);
+
+			endPos += lineText.Length - lineChar;
+
+			if (startPos == endPos)
+			{
+				return;
+			}
+
+			mSelection = EditSelection();
+			mSelection.ValueRef.mStartPos = (int32)startPos;
+			mSelection.ValueRef.mEndPos = (int32)endPos;
+			DeleteSelection();
+
+			CursorTextPos = startPos;
+		}
 
 		public void DuplicateLine()
 		{


### PR DESCRIPTION
Deletes all characters from cursor position to the end of current line.

This command is called "Delete All Right" in VS Code and "Edit.DeleteToEOL" in Visual Studio.

![CTKlVePa9g](https://user-images.githubusercontent.com/3995549/140413996-b9995cf2-ed8b-4122-beec-4f9a12f78392.gif)

