### PR TITLE
Add MatchIndex to StringSplitEnumerator

### DIFF
--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -2817,6 +2817,14 @@ namespace System
 				return mMatchPos;
 			}
 		}
+		
+		public int32 MatchIndex
+		{
+			get
+			{
+				return mCurCount - 1;
+			}
+		}
 
 		public bool HasMore
 		{


### PR DESCRIPTION
This pull request simply exposes the index of the current match of the StringSplitEnumerator