### PR TITLE
Fix Encoding static init priority

### DIFF
--- a/BeefLibs/corlib/src/Text/Encoding.bf
+++ b/BeefLibs/corlib/src/Text/Encoding.bf
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 namespace System.Text
 {
+	[StaticInitPriority(100)]
 	abstract class Encoding
 	{
 		public enum DecodeError


### PR DESCRIPTION
This solves a crash while trying to use streams in a static constructor