### PR TITLE
[IDE] Added setting to open new tabs on right instead of left

### DIFF
--- a/BeefLibs/Beefy2D/src/theme/dark/DarkTabbedView.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkTabbedView.bf
@@ -398,12 +398,12 @@ namespace Beefy.theme.dark
                 func(mRightTab);
         }
 
-        public override TabButton AddTab(String label, float width, Widget content, bool ownsContent)
+        public override TabButton AddTab(String label, float width, Widget content, bool ownsContent, int insertIdx)
         {
 			float useWidth = width;
             if (useWidth == 0)
                 useWidth = DarkTheme.sDarkTheme.mSmallFont.GetWidth(label) + GS!(30);
-            return base.AddTab(label, useWidth, content, ownsContent);
+            return base.AddTab(label, useWidth, content, ownsContent, insertIdx);
         }
 
         public override void RemoveTab(TabButton tabButton, bool deleteTab = true)

--- a/BeefLibs/Beefy2D/src/widgets/TabbedView.bf
+++ b/BeefLibs/Beefy2D/src/widgets/TabbedView.bf
@@ -472,7 +472,7 @@ namespace Beefy.widgets
             return activeTab;
         }
 
-        public virtual TabButton AddTab(String label, float width, Widget content, bool ownsContent)
+        public virtual TabButton AddTab(String label, float width, Widget content, bool ownsContent, int insertIdx)
         {
             TabButton aTabButton = CreateTabButton();
             aTabButton.mTabbedView = this;
@@ -481,7 +481,7 @@ namespace Beefy.widgets
             aTabButton.mWantWidth = width;
             aTabButton.mHeight = mTabHeight;
             aTabButton.mContent = content;
-            AddTab(aTabButton, 0);            
+            AddTab(aTabButton, insertIdx);
             return aTabButton;
         }
 

--- a/BeefLibs/Beefy2D/src/widgets/TabbedView.bf
+++ b/BeefLibs/Beefy2D/src/widgets/TabbedView.bf
@@ -320,7 +320,7 @@ namespace Beefy.widgets
                     //tabbedView.mSharedData.mOpenNewWindowDelegate = mTabbedView.mSharedData.mOpenNewWindowDelegate;
                     tabbedView.SetRequestedSize(mTabbedView.mWidth, mTabbedView.mHeight);
                     mTabbedView.RemoveTab(this, false);
-                    tabbedView.AddTab(this);
+                    tabbedView.AddTab(this, 0);
 
                     float rootX;
                     float rootY;
@@ -481,7 +481,7 @@ namespace Beefy.widgets
             aTabButton.mWantWidth = width;
             aTabButton.mHeight = mTabHeight;
             aTabButton.mContent = content;
-            AddTab(aTabButton);            
+            AddTab(aTabButton, 0);            
             return aTabButton;
         }
 
@@ -501,7 +501,7 @@ namespace Beefy.widgets
             return bestIdx;    
         }
 
-        public virtual void AddTab(TabButton tabButton, int insertIdx = 0)
+        public virtual void AddTab(TabButton tabButton, int insertIdx)
         {
             AddWidget(tabButton);
             mTabs.Insert(insertIdx, tabButton);

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -5807,7 +5807,7 @@ namespace IDE
 
 		TabbedView.TabButton SetupTab(TabbedView tabView, String name, float width, Widget content, bool ownsContent) // 2
 		{
-			TabbedView.TabButton tabButton = tabView.AddTab(name, width, content, ownsContent);
+			TabbedView.TabButton tabButton = tabView.AddTab(name, width, content, ownsContent, GetTabInsertIndex(tabView));
 			if ((var panel = content as Panel) && (var darkTabButton = tabButton as DarkTabbedView.DarkTabButton))
 			{
 				darkTabButton.mTabWidthOffset = panel.TabWidthOffset;

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -5840,7 +5840,7 @@ namespace IDE
             newTabButton.mWantWidth = newTabButton.GetWantWidth();
             newTabButton.mHeight = tabbedView.mTabHeight; 
             newTabButton.mContent = disassemblyPanel;
-            tabbedView.AddTab(newTabButton);
+            tabbedView.AddTab(newTabButton, GetTabInsertIndex(tabbedView));
             
             newTabButton.mCloseClickedEvent.Add(new () => CloseDocument(disassemblyPanel));
             newTabButton.Activate();
@@ -5849,6 +5849,14 @@ namespace IDE
 			mLastActivePanel = disassemblyPanel;
             return disassemblyPanel;
         }
+
+		int GetTabInsertIndex(TabbedView tabs)
+		{
+			if (mSettings.mUISettings.mInsertNewTabs == .RightOfExistingTabs)
+				return tabs.mTabs.Count;
+			else
+				return 0;
+		}
 
         public class SourceViewTab : DarkTabbedView.DarkTabButton
         {
@@ -6021,7 +6029,7 @@ namespace IDE
             tabButton.mIsRightTab = false;            
             var darkTabbedView = (DarkTabbedView)tabButton.mTabbedView;
             darkTabbedView.SetRightTab(null, false);
-            darkTabbedView.AddTab(tabButton);
+            darkTabbedView.AddTab(tabButton, GetTabInsertIndex(darkTabbedView));
             tabButton.Activate();
         }
 
@@ -6397,7 +6405,7 @@ namespace IDE
                 tabbedView.SetRightTab(newTabButton);
             }
             else
-                tabbedView.AddTab(newTabButton);
+                tabbedView.AddTab(newTabButton, GetTabInsertIndex(tabbedView));
             newTabButton.mCloseClickedEvent.Add(new () => DocumentCloseClicked(sourceViewPanel));
             newTabButton.Activate(setFocus);
             if ((setFocus) && (sourceViewPanel.mWidgetWindow != null))

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -416,8 +416,15 @@ namespace IDE
 
 		public class UISettings
 		{
+			public enum InsertNewTabsKind
+			{
+				LeftOfExistingTabs,
+				RightOfExistingTabs,
+			}
+
 			public Colors mColors = new .() ~ delete _;
 			public float mScale = 100;
+			public InsertNewTabsKind mInsertNewTabs = .LeftOfExistingTabs;
 			public List<String> mTheme = new .() ~ DeleteContainerAndItems!(_);
 
 			public void SetDefaults()
@@ -557,6 +564,7 @@ namespace IDE
 					for (let str in mTheme)
 						sd.Add(str);
 				}
+				sd.Add("InsertNewTabs", mInsertNewTabs);
 			}
 
 			public void Deserialize(StructuredData sd)
@@ -569,6 +577,7 @@ namespace IDE
 					sd.GetCurString(str);
 					mTheme.Add(str);
 				}
+				sd.Get("InsertNewTabs", ref mInsertNewTabs);
 			}
 		}
 

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -432,6 +432,7 @@ namespace IDE
 				DeleteAndNullify!(mColors);
 				mColors = new .();
 				mScale = 100;
+				mInsertNewTabs = .LeftOfExistingTabs;
 				ClearAndDeleteItems(mTheme);
 			}
 

--- a/IDE/src/ui/SettingsDialog.bf
+++ b/IDE/src/ui/SettingsDialog.bf
@@ -78,6 +78,7 @@ namespace IDE.ui
 
 			AddPropertiesItem(category, "Scale", "mScale");
 			AddPropertiesItem(category, "Theme", "mTheme");
+			AddPropertiesItem(category, "Insert New Tabs", "mInsertNewTabs");
 
 			category.Open(true, true);
 		}


### PR DESCRIPTION
Title should be pretty self explanatory. 

There's now a new setting to change whether new tabs appear on the left, or on the right.

Tabs opening on the left bugged me a little bit since I'm used to Visual Studio, which opens tabs on the right (by default at least). Also it seemed like an easy thing to add for my first contribution :)

For now I've left the old behavior as the default.

Let me know if something's not up to snuff.

![screenshot](https://user-images.githubusercontent.com/55242398/144185937-6ec08a86-f619-451c-b207-a7763a54805d.png)

I see now that someone else requested something like this in #981 