### PR TITLE
Add ICharacter interface

### DIFF
--- a/BeefLibs/corlib/src/Char16.bf
+++ b/BeefLibs/corlib/src/Char16.bf
@@ -1,6 +1,6 @@
 namespace System
 {
-	struct Char16 : char16, IHashable, IIsNaN
+	struct Char16 : char16, ICharacter, IHashable, IIsNaN
 	{
 		const int UNICODE_PLANE00_END = 0x00ffff;
 		// The starting codepoint for Unicode plane 1.  Plane 1 contains 0x010000 ~ 0x01ffff.

--- a/BeefLibs/corlib/src/Char32.bf
+++ b/BeefLibs/corlib/src/Char32.bf
@@ -1,6 +1,6 @@
 namespace System
 {
-	struct Char32 : char32, IHashable, IIsNaN
+	struct Char32 : char32, ICharacter, IHashable, IIsNaN
 	{
 	    public int GetHashCode()
 		{

--- a/BeefLibs/corlib/src/Char8.bf
+++ b/BeefLibs/corlib/src/Char8.bf
@@ -1,7 +1,7 @@
 namespace System
 {
 #unwarn
-	struct Char8 : char8, IHashable, IIsNaN
+	struct Char8 : char8, ICharacter, IHashable, IIsNaN
 	{
 		bool IIsNaN.IsNaN
 		{

--- a/BeefLibs/corlib/src/IComparable.bf
+++ b/BeefLibs/corlib/src/IComparable.bf
@@ -23,6 +23,10 @@ namespace System
 	{
 	}
 
+	interface ICharacter
+	{
+	}
+
 	[Obsolete("Consider operator constraint such as `where bool : operator T == T`", false)]
 	interface IOpEquals
 	{


### PR DESCRIPTION
Closes https://github.com/beefytech/Beef/issues/1246

I tested with the code below and it seems to be working as expected
```cs
		public static void TestChar<T>(T char) where T : var, ICharacter
		{
			Console.WriteLine((int32)char);
		}

		[Test]
		public static void Test()
		{
			//TestChar(0); // Error as expected
			TestChar((char8)0);
			TestChar((char16)0);
			TestChar((char32)0);
			TestChar('\0');
		}
```