### PR TITLE
PlaySound sets SDL volume for the sound played instead of the app

### DIFF
--- a/BeefLibs/SDL2/src/SDLApp.bf
+++ b/BeefLibs/SDL2/src/SDLApp.bf
@@ -191,9 +191,9 @@ namespace SDL2
 			if (sound == null)
 				return;
 
+			SDLMixer.VolumeChunk(sound.mChunk, (int32)(volume * 128));
 			int32 channel = SDLMixer.PlayChannel(-1, sound.mChunk, 0);
 			//SDLMixer.SetPanning()
-			SDLMixer.Volume(channel, (int32)(volume * 128));
 		}
 
 		public void Render()


### PR DESCRIPTION
I didn't include these comments in the change
This pull closes issue https://github.com/beefytech/Beef/issues/976

SDLMixer.VolumeChunk(sound.mChunk, (int32)(volume * 128)); // sets volume for this sound only
int32 channel = SDLMixer.PlayChannel(-1, sound.mChunk, 0);
//SDLMixer.SetPanning()
SDLMixer.Volume(channel, (int32)(volume * 128));
//SDLMixer.Volume(channel, (int32)(volume * 128)); // sets app volume