### PR TITLE
Sdl white flash fix

### DIFF
--- a/BeefLibs/SDL2/src/SDLApp.bf
+++ b/BeefLibs/SDL2/src/SDLApp.bf
@@ -117,8 +117,12 @@ namespace SDL2
 			SDL.EventState(.JoyDeviceAdded, .Disable);
 			SDL.EventState(.JoyDeviceRemoved, .Disable);
 
-			mWindow = SDL.CreateWindow(mTitle, .Undefined, .Undefined, mWidth, mHeight, .Shown);
+			mWindow = SDL.CreateWindow(mTitle, .Undefined, .Undefined, mWidth, mHeight, .Hidden);
 			mRenderer = SDL.CreateRenderer(mWindow, -1, .Accelerated);
+			SDL.ShowWindow(mWindow);
+			SDL.SetRenderDrawColor(mRenderer, 0, 0, 0, 255);
+			SDL.RenderClear(mRenderer);
+			SDL.RenderPresent(mRenderer);
 			mScreen = SDL.GetWindowSurface(mWindow);
 			SDLImage.Init(.PNG | .JPG);
 			mHasAudio = SDLMixer.OpenAudio(44100, SDLMixer.MIX_DEFAULT_FORMAT, 2, 4096) >= 0;

--- a/BeefLibs/SDL2/src/SDLApp.bf
+++ b/BeefLibs/SDL2/src/SDLApp.bf
@@ -191,9 +191,9 @@ namespace SDL2
 			if (sound == null)
 				return;
 
+			SDLMixer.VolumeChunk(sound.mChunk, (int32)(volume * 128));
 			int32 channel = SDLMixer.PlayChannel(-1, sound.mChunk, 0);
 			//SDLMixer.SetPanning()
-			SDLMixer.Volume(channel, (int32)(volume * 128));
 		}
 
 		public void Render()


### PR DESCRIPTION
When starting up SpaceGame in SDL Accelerated mode, profiling says 600 ms is spent in WinVerifyTrust. And this is when the SDL has initialized the window to default white background. To the user this appears as a white flash before the games black background appears.

I changed the code to hide the window until it's background color is set to black.