### PR TITLE
Changed SDL initial bg color from white to black to remove white flas…

### DIFF
--- a/BeefLibs/SDL2/src/SDLApp.bf
+++ b/BeefLibs/SDL2/src/SDLApp.bf
@@ -117,8 +117,12 @@ namespace SDL2
 			SDL.EventState(.JoyDeviceAdded, .Disable);
 			SDL.EventState(.JoyDeviceRemoved, .Disable);
 
-			mWindow = SDL.CreateWindow(mTitle, .Undefined, .Undefined, mWidth, mHeight, .Shown);
+			mWindow = SDL.CreateWindow(mTitle, .Undefined, .Undefined, mWidth, mHeight, .Hidden);
 			mRenderer = SDL.CreateRenderer(mWindow, -1, .Accelerated);
+			SDL.ShowWindow(mWindow);
+			SDL.SetRenderDrawColor(mRenderer, 0, 0, 0, 255);
+			SDL.RenderClear(mRenderer);
+			SDL.RenderPresent(mRenderer);
 			mScreen = SDL.GetWindowSurface(mWindow);
 			SDLImage.Init(.PNG | .JPG);
 			mHasAudio = SDLMixer.OpenAudio(44100, SDLMixer.MIX_DEFAULT_FORMAT, 2, 4096) >= 0;

--- a/BeefLibs/SDL2/src/SDLApp.bf
+++ b/BeefLibs/SDL2/src/SDLApp.bf
@@ -117,12 +117,8 @@ namespace SDL2
 			SDL.EventState(.JoyDeviceAdded, .Disable);
 			SDL.EventState(.JoyDeviceRemoved, .Disable);
 
-			mWindow = SDL.CreateWindow(mTitle, .Undefined, .Undefined, mWidth, mHeight, .Hidden);
+			mWindow = SDL.CreateWindow(mTitle, .Undefined, .Undefined, mWidth, mHeight, .Hidden); // Initially hide window
 			mRenderer = SDL.CreateRenderer(mWindow, -1, .Accelerated);
-			SDL.ShowWindow(mWindow);
-			SDL.SetRenderDrawColor(mRenderer, 0, 0, 0, 255);
-			SDL.RenderClear(mRenderer);
-			SDL.RenderPresent(mRenderer);
 			mScreen = SDL.GetWindowSurface(mWindow);
 			SDLImage.Init(.PNG | .JPG);
 			mHasAudio = SDLMixer.OpenAudio(44100, SDLMixer.MIX_DEFAULT_FORMAT, 2, 4096) >= 0;
@@ -249,7 +245,9 @@ namespace SDL2
 				if (curPhysTickCount == 0)
 				{
 					// Initial render
-					Render();
+					Render();                
+					// Show initially hidden window, mitigates white flash on slow startups
+					SDL.ShowWindow(mWindow); 
 				}
 				else
 				{


### PR DESCRIPTION
…h effect with some GPUs

Changed SDL initial bg color from white to black to remove white flash effect with some GPUs

My NVIDIA user mode driver spends 600-700 ms in WinVerifyTrust when using .Accelerated SDL initialization.
The problem is seen as a brief white flash/strobe effect before the game loads.

If the app was something like white background notepad, then changing that color to white or removing this commit would of course be reasonable but games rarely use 100% white as background so black is a better default.

![beef spacegame startup profile december](https://user-images.githubusercontent.com/81806010/145047617-16e6d7da-52ce-482d-a85f-9b42c95184a3.png)
![beef spacegame startup profile december2](https://user-images.githubusercontent.com/81806010/145047644-f1c6ff8c-6507-4cc0-a36b-d2b59bc99264.png)
