### PR TITLE
Added editor option for // -style comments in certain cases

### DIFF
--- a/IDE/src/Commands.bf
+++ b/IDE/src/Commands.bf
@@ -194,6 +194,8 @@ namespace IDE
 			Add("Close Document", new () => { gApp.[Friend]TryCloseCurrentDocument(); });
 			Add("Close Panel", new () => { gApp.[Friend]TryCloseCurrentPanel(); });
 			Add("Close Workspace", new => gApp.[Friend]Cmd_CloseWorkspaceAndSetupNew);
+			Add("Comment Block", new => gApp.[Friend]CommentBlock);
+			Add("Comment Lines", new => gApp.[Friend]CommentLines);
 			Add("Comment Selection", new => gApp.[Friend]CommentSelection);
 			Add("Compile File", new => gApp.Cmd_CompileFile);
 			Add("Debug All Tests", new () => { gApp.[Friend]RunTests(true, true); });

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -2425,6 +2425,22 @@ namespace IDE
 		}
 
 		[IDECommand]
+		void CommentBlock()
+		{
+			var sewc = GetActiveSourceEditWidgetContent();
+			if (sewc != null)
+				sewc.CommentBlock();
+		}
+
+		[IDECommand]
+		void CommentLines()
+		{
+			var sewc = GetActiveSourceEditWidgetContent();
+			if (sewc != null)
+				sewc.CommentLines();
+		}
+
+		[IDECommand]
 		void CommentSelection()
 		{
 			var sewc = GetActiveSourceEditWidgetContent();
@@ -5386,6 +5402,8 @@ namespace IDE
 			advancedEditMenu.AddMenuItem(null);
 			AddMenuItem(advancedEditMenu, "Make Uppercase", "Make Uppercase");
 			AddMenuItem(advancedEditMenu, "Make Lowercase", "Make Lowercase");
+			AddMenuItem(advancedEditMenu, "Comment Block", "Comment Block");
+			AddMenuItem(advancedEditMenu, "Comment Lines", "Comment Lines");
 			AddMenuItem(advancedEditMenu, "Comment Selection", "Comment Selection");
 			AddMenuItem(advancedEditMenu, "Uncomment Selection", "Uncomment Selection");
 			AddMenuItem(advancedEditMenu, "Reformat Document", "Reformat Document");

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -625,6 +625,7 @@ namespace IDE
 			public FileRecoveryKind mEnableFileRecovery = .Yes;
 			public bool mFormatOnSave = false;
 			public bool mSyncWithWorkspacePanel = false;
+			public bool mToggleCommentAlt = false;
 
 			public void Serialize(StructuredData sd)
 			{

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -625,7 +625,6 @@ namespace IDE
 			public FileRecoveryKind mEnableFileRecovery = .Yes;
 			public bool mFormatOnSave = false;
 			public bool mSyncWithWorkspacePanel = false;
-			public bool mToggleCommentAlt = false;
 
 			public void Serialize(StructuredData sd)
 			{
@@ -651,7 +650,6 @@ namespace IDE
 				sd.Add("EnableFileRecovery", mEnableFileRecovery);
 				sd.Add("FormatOnSave", mFormatOnSave);
 				sd.Add("SyncWithWorkspacePanel", mSyncWithWorkspacePanel);
-				sd.Add("ToggleCommentAlt", mToggleCommentAlt);
 			}
 
 			public void Deserialize(StructuredData sd)
@@ -681,7 +679,6 @@ namespace IDE
 				sd.GetEnum<FileRecoveryKind>("EnableFileRecovery", ref mEnableFileRecovery);
 				sd.Get("FormatOnSave", ref mFormatOnSave);
 				sd.Get("SyncWithWorkspacePanel", ref mSyncWithWorkspacePanel);
-				sd.Get("ToggleCommentAlt", ref mToggleCommentAlt);
 			}
 
 			public void SetDefaults()

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -756,6 +756,8 @@ namespace IDE
 				Add("Cancel Build", "Ctrl+Break");
 				Add("Close Document", "Ctrl+W");
 				Add("Compile File", "Ctrl+F7");
+				Add("Comment Block", "Ctrl+K, Ctrl+B");
+				Add("Comment Lines", "Ctrl+K, Ctrl+L");
 				Add("Comment Selection", "Ctrl+K, Ctrl+C");
 				Add("Duplicate Line", "Ctrl+D");
 				Add("Find Class", "Alt+Shift+L");

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -650,6 +650,7 @@ namespace IDE
 				sd.Add("EnableFileRecovery", mEnableFileRecovery);
 				sd.Add("FormatOnSave", mFormatOnSave);
 				sd.Add("SyncWithWorkspacePanel", mSyncWithWorkspacePanel);
+				sd.Add("ToggleCommentAlt", mToggleCommentAlt);
 			}
 
 			public void Deserialize(StructuredData sd)
@@ -679,6 +680,7 @@ namespace IDE
 				sd.GetEnum<FileRecoveryKind>("EnableFileRecovery", ref mEnableFileRecovery);
 				sd.Get("FormatOnSave", ref mFormatOnSave);
 				sd.Get("SyncWithWorkspacePanel", ref mSyncWithWorkspacePanel);
+				sd.Get("ToggleCommentAlt", ref mToggleCommentAlt);
 			}
 
 			public void SetDefaults()

--- a/IDE/src/ui/SettingsDialog.bf
+++ b/IDE/src/ui/SettingsDialog.bf
@@ -126,7 +126,7 @@ namespace IDE.ui
 			AddPropertiesItem(category, "Enable File Recovery", "mEnableFileRecovery");
 			AddPropertiesItem(category, "Format on Save", "mFormatOnSave");
 			AddPropertiesItem(category, "Sync with Workspace Panel", "mSyncWithWorkspacePanel");
-
+			AddPropertiesItem(category, "Toggle comment alternate style", "mToggleCommentAlt");
 			category.Open(true, true);
 		}
 

--- a/IDE/src/ui/SettingsDialog.bf
+++ b/IDE/src/ui/SettingsDialog.bf
@@ -127,6 +127,7 @@ namespace IDE.ui
 			AddPropertiesItem(category, "Format on Save", "mFormatOnSave");
 			AddPropertiesItem(category, "Sync with Workspace Panel", "mSyncWithWorkspacePanel");
 			AddPropertiesItem(category, "Toggle comment alternate style", "mToggleCommentAlt");
+			
 			category.Open(true, true);
 		}
 

--- a/IDE/src/ui/SettingsDialog.bf
+++ b/IDE/src/ui/SettingsDialog.bf
@@ -126,7 +126,6 @@ namespace IDE.ui
 			AddPropertiesItem(category, "Enable File Recovery", "mEnableFileRecovery");
 			AddPropertiesItem(category, "Format on Save", "mFormatOnSave");
 			AddPropertiesItem(category, "Sync with Workspace Panel", "mSyncWithWorkspacePanel");
-			AddPropertiesItem(category, "Toggle comment alternate style", "mToggleCommentAlt");
 			
 			category.Open(true, true);
 		}

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -2280,7 +2280,23 @@ namespace IDE.ui
 
 				int firstCharPos = minPos + (startLen - afterTrimStart);
 				int lastCharPos = maxPos - (afterTrimStart - afterTrimEnd);
-				if ((doComment != true) && (trimmedStr.Contains("//"))) 
+
+				int q = 0;
+				var nc = trimmedStr.Count('\n');
+
+				if(afterTrimEnd == 0)
+				{
+					if (undoBatchStart != null)
+						mData.mUndoManager.Add(undoBatchStart.mBatchEnd);
+
+					CursorLineAndColumn = startLineAndCol;
+
+					if (doComment == null)
+						mSelection = null;
+
+					return false; // not sure if this should be false in blank/only whitespace selection case
+				}
+				else if ((doComment != true) && (trimmedStr.Contains("//"))) 
 				{
 					for (int i = firstCharPos; i < lastCharPos - 1; i++)
 					{
@@ -2298,9 +2314,7 @@ namespace IDE.ui
 					}
 					mSelection = EditSelection(minPos, lastCharPos);
 				}
-				int q = 0;
-				var nc = trimmedStr.Count('\n');
-				if ((doComment != true) && (trimmedStr.StartsWith("/*")))
+				else if ((doComment != true) && (trimmedStr.StartsWith("/*")))
 				{
 					if (trimmedStr.EndsWith("*/\n"))
 					{

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -2160,9 +2160,9 @@ namespace IDE.ui
 			return true;
 		}
 
-		public bool ToggleComment(bool? doComment = null)
+		public bool CommentBlock()
 		{
-			if (gApp.mSettings.mEditorSettings.mToggleCommentAlt) return ToggleCommentAlt(doComment);
+			bool? doComment = true;
 
 			if (CheckReadOnly())
 				return false;
@@ -2175,11 +2175,11 @@ namespace IDE.ui
 				mSelection = .(CursorTextPos, cursorEndPos);
 			}
 
-		    if ((HasSelection()) && (mSelection.Value.Length > 1))
-		    {
+			if ((HasSelection()) && (mSelection.Value.Length > 1))
+			{
 				var startLineAndCol = CursorLineAndColumn;
 
-				UndoBatchStart undoBatchStart = new UndoBatchStart("embeddedToggleComment");
+				UndoBatchStart undoBatchStart = new UndoBatchStart("embeddedCommentBlock");
 				mData.mUndoManager.Add(undoBatchStart);
 
 				mData.mUndoManager.Add(new SetCursorAction(this));
@@ -2202,20 +2202,7 @@ namespace IDE.ui
 				int firstCharPos = minPos + (startLen - afterTrimStart);
 				int lastCharPos = maxPos - (afterTrimStart - afterTrimEnd);
 
-				if ((doComment != true) && (trimmedStr.StartsWith("/*")))
-				{
-					if (trimmedStr.EndsWith("*/"))
-					{
-						mSelection = EditSelection(firstCharPos, firstCharPos + 2);
-						DeleteChar();
-						mSelection = EditSelection(lastCharPos - 4, lastCharPos - 2);
-						DeleteChar();
-
-						if (doComment != null)
-							mSelection = EditSelection(firstCharPos, lastCharPos - 4);
-					}
-				}
-				else if (doComment != false)
+				if (doComment != false)
 				{
 					CursorTextPos = firstCharPos;
 					InsertAtCursor("/*");
@@ -2234,17 +2221,109 @@ namespace IDE.ui
 				if (doComment == null)
 					mSelection = null;
 
-		        return true;
-		    }
+			    return true;
+			}
 
 			return false;
 		}
-		
-		public bool ToggleCommentAlt(bool? doComment = null)
+
+		public bool CommentLines()
+		{
+			bool? doComment = true;
+			if (CheckReadOnly())
+				return false;
+			bool noStar = false;
+
+			var startLineAndCol = CursorLineAndColumn;
+			if ((!HasSelection()) && (doComment != null))
+			{
+				CursorToLineEnd();
+				int cursorEndPos = CursorTextPos;
+
+				mSelection = .(CursorTextPos, cursorEndPos);
+				noStar = true;
+			}
+
+
+			if (true || (HasSelection()) && (mSelection.Value.Length > 0))
+			{
+				//int cursorEndPos = CursorTextPos;
+
+				// set selection to begin from line start
+				int lineIdx;
+				int lineChar;
+				GetLineCharAtIdx(mSelection.GetValueOrDefault().MinPos,out lineIdx, out lineChar);
+				MoveCursorTo(lineIdx, 0);
+				mSelection = .(CursorTextPos, mSelection.GetValueOrDefault().MaxPos);
+
+				UndoBatchStart undoBatchStart = new UndoBatchStart("embeddedCommentLines");
+				mData.mUndoManager.Add(undoBatchStart);
+
+				mData.mUndoManager.Add(new SetCursorAction(this));
+
+				int minPos = mSelection.GetValueOrDefault().MinPos;
+				int maxPos = mSelection.GetValueOrDefault().MaxPos;
+				mSelection = null;
+
+				var str = scope String();
+				ExtractString(minPos, maxPos - minPos, str);
+				var trimmedStr = scope String();
+				trimmedStr.Append(str);
+				int32 startLen = (int32)trimmedStr.Length;
+				trimmedStr.TrimStart();
+				int32 afterTrimStart = (int32)trimmedStr.Length;
+				trimmedStr.TrimEnd();
+				//int32 afterTrimEnd = (int32)trimmedStr.Length;
+				trimmedStr.Append('\n');
+
+				int firstCharPos = minPos + (startLen - afterTrimStart);
+				//int lastCharPos = maxPos - (afterTrimStart - afterTrimEnd);
+
+				int q = 0;
+				//var nc = trimmedStr.Count('\n');
+
+				if (doComment != false)
+				{
+					while (firstCharPos >= 0 && SafeGetChar(firstCharPos) != '\n')
+					{
+						firstCharPos--;
+					}
+					bool blank=true;
+					for (int i = firstCharPos + 1; i < maxPos + q; i++)
+					{
+						blank=false;
+						CursorTextPos = i; // needed to add i < maxPos + q; for this to work with InsertAtCursor
+						InsertAtCursor("//"); q++; q++;
+
+						while (SafeGetChar(i) != '\n' && i < maxPos + q)
+						{
+							i++;
+						}
+					}
+					mSelection = EditSelection(minPos, maxPos + q);
+				}
+
+				
+				if (undoBatchStart != null)
+					mData.mUndoManager.Add(undoBatchStart.mBatchEnd);
+
+				CursorLineAndColumn = startLineAndCol;
+
+				if (doComment == null)
+					mSelection = null;
+
+				return true;
+			}
+
+			//return false;
+		}
+
+		public bool ToggleComment(bool? doComment = null)
 		{
 			if (CheckReadOnly())
 				return false;
 			bool noStar = false;
+			var startLineAndCol = CursorLineAndColumn;
 			if ((!HasSelection()) && (doComment != null))
 			{
 				CursorToLineEnd();
@@ -2256,7 +2335,13 @@ namespace IDE.ui
 
 			if ((HasSelection()) && (mSelection.Value.Length > 0))
 			{
-				var startLineAndCol = CursorLineAndColumn;
+
+				int lineIdx;
+				int lineChar;
+				GetLineCharAtIdx(mSelection.GetValueOrDefault().MinPos,out lineIdx, out lineChar);
+				MoveCursorTo(lineIdx, 0);
+				mSelection = .(CursorTextPos, mSelection.GetValueOrDefault().MaxPos);
+
 
 				UndoBatchStart undoBatchStart = new UndoBatchStart("embeddedToggleComment");
 				mData.mUndoManager.Add(undoBatchStart);
@@ -2296,11 +2381,11 @@ namespace IDE.ui
 
 					return false; // not sure if this should be false in blank/only whitespace selection case
 				}
-				else if ((doComment != true) && (trimmedStr.Contains("//"))) 
+				else if ((doComment != true) && (trimmedStr.StartsWith("//"))) 
 				{
-					for (int i = firstCharPos; i < lastCharPos - 1; i++)
+					for (int i = firstCharPos; i <= lastCharPos; i++)
 					{
-						if (minPos == 0 || (minPos>0 && SafeGetChar(i - 1) == '\n' || SafeGetChar(i - 1) == '\t'))
+						if ((minPos == 0 && i==0) || (minPos>=0 && SafeGetChar(i - 1) == '\n' || SafeGetChar(i - 1) == '\t'))
 						if (SafeGetChar(i - 0) == '/' && SafeGetChar(i + 1) == '/')
 						{
 							mSelection = EditSelection(i - 0, i + 2);
@@ -2312,7 +2397,11 @@ namespace IDE.ui
 							}
 						}
 					}
-					mSelection = EditSelection(minPos, lastCharPos);
+
+					CursorToLineEnd();
+					int cursorEndPos = CursorTextPos;
+					mSelection = .(minPos, cursorEndPos);
+
 				}
 				else if ((doComment != true) && (trimmedStr.StartsWith("/*")))
 				{
@@ -2327,25 +2416,9 @@ namespace IDE.ui
 							mSelection = EditSelection(firstCharPos, lastCharPos - 4);
 					}
 				}
-				else if (doComment != false && nc<=1 && minPos >=0 && (SafeGetChar(minPos-1) != ' ' && SafeGetChar(minPos-1) != '\t') && SafeGetChar(minPos-1) != '\n')
+				else if (doComment != false && minPos >=0 && ((nc<=1 && (SafeGetChar(minPos-1) != ' ' && SafeGetChar(minPos-1) != '\t') && SafeGetChar(minPos-1) != '\n')
+															|| nc>=1 && (SafeGetChar(maxPos-1) != ' ' && SafeGetChar(maxPos-1) != '\t') && SafeGetChar(maxPos-1) != '\n'))
 				{ //if selection is from beginning of the line then we want to use // comment, that's why the check for line count and ' ' and tab
-					CursorTextPos = firstCharPos;
-					if (noStar) {
-						CursorTextPos = minPos;
-
-						InsertAtCursor("//"); //goes here if no selection
-					}
-					else
-					{
-						InsertAtCursor("/*");
-						CursorTextPos = lastCharPos + 2;
-						InsertAtCursor("*/");
-					}
-					if (!noStar && doComment != null)
-						mSelection = EditSelection(firstCharPos, lastCharPos + 4);
-				}
-				else if (doComment != false && nc>=1 && minPos >0 && (SafeGetChar(maxPos-1) != ' ' && SafeGetChar(maxPos-1) != '\t') && SafeGetChar(maxPos-1) != '\n')
-				{ 
 					CursorTextPos = firstCharPos;
 					if (noStar) {
 						CursorTextPos = minPos;
@@ -2394,7 +2467,7 @@ namespace IDE.ui
 
 			return false;
 		}
-
+		
 		public void DeleteAllRight()
 		{
 			int startPos;

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -2238,6 +2238,147 @@ namespace IDE.ui
 			return false;
 		}
 		
+		public bool ToggleCommentAlt(bool? doComment = null)
+		{
+			if (CheckReadOnly())
+				return false;
+			bool noStar = false;
+			if ((!HasSelection()) && (doComment != null))
+			{
+				CursorToLineEnd();
+				int cursorEndPos = CursorTextPos;
+				CursorToLineStart(false);
+				mSelection = .(CursorTextPos, cursorEndPos);
+				noStar = true;
+			}
+
+			if ((HasSelection()) && (mSelection.Value.Length > 0))
+			{
+				var startLineAndCol = CursorLineAndColumn;
+
+				UndoBatchStart undoBatchStart = new UndoBatchStart("embeddedToggleComment");
+				mData.mUndoManager.Add(undoBatchStart);
+
+				mData.mUndoManager.Add(new SetCursorAction(this));
+
+				int minPos = mSelection.GetValueOrDefault().MinPos;
+				int maxPos = mSelection.GetValueOrDefault().MaxPos;
+				mSelection = null;
+
+				var str = scope String();
+				ExtractString(minPos, maxPos - minPos, str);
+				var trimmedStr = scope String();
+				trimmedStr.Append(str);
+				int32 startLen = (int32)trimmedStr.Length;
+				trimmedStr.TrimStart();
+				int32 afterTrimStart = (int32)trimmedStr.Length;
+				trimmedStr.TrimEnd();
+				int32 afterTrimEnd = (int32)trimmedStr.Length;
+				trimmedStr.Append('\n');
+
+				int firstCharPos = minPos + (startLen - afterTrimStart);
+				int lastCharPos = maxPos - (afterTrimStart - afterTrimEnd);
+				if ((doComment != true) && (trimmedStr.Contains("//"))) 
+				{
+					for (int i = firstCharPos; i < lastCharPos - 1; i++)
+					{
+						if (minPos == 0 || (minPos>0 && SafeGetChar(i - 1) == '\n' || SafeGetChar(i - 1) == '\t'))
+						if (SafeGetChar(i - 0) == '/' && SafeGetChar(i + 1) == '/')
+						{
+							mSelection = EditSelection(i - 0, i + 2);
+							DeleteSelection();
+							lastCharPos -= 2;
+							while (i < maxPos && SafeGetChar(i) != '\n')
+							{
+								i++;
+							}
+						}
+			}
+					mSelection = EditSelection(minPos, lastCharPos);
+				}
+				int q = 0;
+				var nc = trimmedStr.Count('\n');
+				if ((doComment != true) && (trimmedStr.StartsWith("/*")))
+				{
+					if (trimmedStr.EndsWith("*/\n"))
+					{
+						mSelection = EditSelection(firstCharPos, firstCharPos + 2);
+						DeleteChar();
+						mSelection = EditSelection(lastCharPos - 4, lastCharPos - 2);
+						DeleteChar();
+
+						if (doComment != null)
+							mSelection = EditSelection(firstCharPos, lastCharPos - 4);
+					}
+				}
+				else if (doComment != false && nc<=1 && minPos >=0 && (SafeGetChar(minPos-1) != ' ' && SafeGetChar(minPos-1) != '\t') && SafeGetChar(minPos-1) != '\n')
+				{ //if selection is from beginning of the line then we want to use // comment, that's why the check for line count and ' ' and tab
+					CursorTextPos = firstCharPos;
+					if (noStar) {
+						CursorTextPos = minPos;
+
+						InsertAtCursor("//"); //goes here if no selection
+					}
+					else
+					{
+						InsertAtCursor("/*");
+						CursorTextPos = lastCharPos + 2;
+						InsertAtCursor("*/");
+					}
+					if (!noStar && doComment != null)
+						mSelection = EditSelection(firstCharPos, lastCharPos + 4);
+				}
+				else if (doComment != false && nc>=1 && minPos >0 && (SafeGetChar(maxPos-1) != ' ' && SafeGetChar(maxPos-1) != '\t') && SafeGetChar(maxPos-1) != '\n')
+				{ 
+					CursorTextPos = firstCharPos;
+					if (noStar) {
+						CursorTextPos = minPos;
+
+						InsertAtCursor("//"); //goes here if no selection
+					}
+					else
+					{
+						InsertAtCursor("/*");
+						CursorTextPos = lastCharPos + 2;
+						InsertAtCursor("*/");
+					}
+					if (!noStar && doComment != null)
+						mSelection = EditSelection(firstCharPos, lastCharPos + 4);
+				}
+				else if (doComment != false)
+				{
+					while (firstCharPos >= 0 && SafeGetChar(firstCharPos) != '\n')
+					{
+						firstCharPos--;
+					}
+
+					for (int i = firstCharPos + 1; i < maxPos + q; i++)
+			{
+						CursorTextPos = i; // needed to add i < maxPos + q; for this to work with InsertAtCursor
+						InsertAtCursor("//"); q++; q++;
+
+						while (SafeGetChar(i) != '\n' && i < maxPos + q)
+						{
+							i++;
+						}
+					}
+					mSelection = EditSelection(minPos, maxPos + q);
+			}
+
+				if (undoBatchStart != null)
+					mData.mUndoManager.Add(undoBatchStart.mBatchEnd);
+
+				CursorLineAndColumn = startLineAndCol;
+
+				if (doComment == null)
+					mSelection = null;
+
+				return true;
+			}
+
+			return false;
+		}
+
 		public void DeleteAllRight()
 		{
 			int startPos;

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -2295,7 +2295,7 @@ namespace IDE.ui
 								i++;
 							}
 						}
-			}
+					}
 					mSelection = EditSelection(minPos, lastCharPos);
 				}
 				int q = 0;
@@ -2355,7 +2355,7 @@ namespace IDE.ui
 					}
 
 					for (int i = firstCharPos + 1; i < maxPos + q; i++)
-			{
+					{
 						CursorTextPos = i; // needed to add i < maxPos + q; for this to work with InsertAtCursor
 						InsertAtCursor("//"); q++; q++;
 
@@ -2365,7 +2365,7 @@ namespace IDE.ui
 						}
 					}
 					mSelection = EditSelection(minPos, maxPos + q);
-			}
+				}
 
 				if (undoBatchStart != null)
 					mData.mUndoManager.Add(undoBatchStart.mBatchEnd);

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -2244,11 +2244,8 @@ namespace IDE.ui
 				noStar = true;
 			}
 
-
 			if (true || (HasSelection()) && (mSelection.Value.Length > 0))
 			{
-				//int cursorEndPos = CursorTextPos;
-
 				// set selection to begin from line start
 				int lineIdx;
 				int lineChar;
@@ -2280,7 +2277,6 @@ namespace IDE.ui
 				//int lastCharPos = maxPos - (afterTrimStart - afterTrimEnd);
 
 				int q = 0;
-				//var nc = trimmedStr.Count('\n');
 
 				if (doComment != false)
 				{
@@ -2303,7 +2299,6 @@ namespace IDE.ui
 					mSelection = EditSelection(minPos, maxPos + q);
 				}
 
-				
 				if (undoBatchStart != null)
 					mData.mUndoManager.Add(undoBatchStart.mBatchEnd);
 
@@ -2323,6 +2318,7 @@ namespace IDE.ui
 			if (CheckReadOnly())
 				return false;
 			bool noStar = false;
+
 			var startLineAndCol = CursorLineAndColumn;
 			if ((!HasSelection()) && (doComment != null))
 			{
@@ -2335,10 +2331,9 @@ namespace IDE.ui
 
 			if ((HasSelection()) && (mSelection.Value.Length > 0))
 			{
-
 				int lineIdx;
 				int lineChar;
-				GetLineCharAtIdx(mSelection.GetValueOrDefault().MinPos,out lineIdx, out lineChar);
+				GetLineCharAtIdx(mSelection.GetValueOrDefault().MinPos, out lineIdx, out lineChar);
 				MoveCursorTo(lineIdx, 0);
 				mSelection = .(CursorTextPos, mSelection.GetValueOrDefault().MaxPos);
 
@@ -2385,7 +2380,7 @@ namespace IDE.ui
 				{
 					for (int i = firstCharPos; i <= lastCharPos; i++)
 					{
-						if ((minPos == 0 && i==0) || (minPos>=0 && SafeGetChar(i - 1) == '\n' || SafeGetChar(i - 1) == '\t'))
+						if ((minPos == 0 && i == 0) || (minPos>=0 && SafeGetChar(i - 1) == '\n' || SafeGetChar(i - 1) == '\t'))
 						if (SafeGetChar(i - 0) == '/' && SafeGetChar(i + 1) == '/')
 						{
 							mSelection = EditSelection(i - 0, i + 2);
@@ -2416,8 +2411,8 @@ namespace IDE.ui
 							mSelection = EditSelection(firstCharPos, lastCharPos - 4);
 					}
 				}
-				else if (doComment != false && minPos >=0 && ((nc<=1 && (SafeGetChar(minPos-1) != ' ' && SafeGetChar(minPos-1) != '\t') && SafeGetChar(minPos-1) != '\n')
-															|| nc>=1 && (SafeGetChar(maxPos-1) != ' ' && SafeGetChar(maxPos-1) != '\t') && SafeGetChar(maxPos-1) != '\n'))
+				else if (doComment != false && minPos >=0 && ((nc <= 1 && (SafeGetChar(minPos-1) != ' ' && SafeGetChar(minPos-1) != '\t') && SafeGetChar(minPos-1) != '\n')
+															|| nc >= 1 && (SafeGetChar(maxPos-1) != ' ' && SafeGetChar(maxPos-1) != '\t') && SafeGetChar(maxPos-1) != '\n'))
 				{ //if selection is from beginning of the line then we want to use // comment, that's why the check for line count and ' ' and tab
 					CursorTextPos = firstCharPos;
 					if (noStar) {

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -2162,6 +2162,8 @@ namespace IDE.ui
 
 		public bool ToggleComment(bool? doComment = null)
 		{
+			if (gApp.mSettings.mEditorSettings.mToggleCommentAlt) return ToggleCommentAlt(doComment);
+
 			if (CheckReadOnly())
 				return false;
 


### PR DESCRIPTION
If VS is installed and C# was selected as configuration template then CTRL+K+C works differently than in VS C++. 
A new option under Editor ("Toggle comment alternate style") was added that more closely mimics the VS C# style commenting behavior.

