### PR TITLE
Allow underline in generated file name

### DIFF
--- a/IDE/src/ui/GenerateDialog.bf
+++ b/IDE/src/ui/GenerateDialog.bf
@@ -653,7 +653,7 @@ namespace IDE.ui
 						{
 							for (char8 c in fileName.RawChars)
 							{
-								if (!c.IsLetterOrDigit)
+								if (!c.IsLetterOrDigit && c != '_')
 								{
 									gApp.Fail(scope $"Invalid generated file name: {fileName}");
 									hadError = true;


### PR DESCRIPTION
I don't think there's a reason to not allow it