### PR TITLE
Make Variant `IDisposable`

### DIFF
--- a/BeefLibs/corlib/src/Variant.bf
+++ b/BeefLibs/corlib/src/Variant.bf
@@ -2,7 +2,7 @@ using System.Diagnostics;
 
 namespace System
 {
-    struct Variant
+    struct Variant : IDisposable
 	{
 		enum ObjectType
 		{


### PR DESCRIPTION
A variant should always be disposed so it makes sense to make it `IDisposable`.