### PR TITLE
handle uint64 constExpr printing

### DIFF
--- a/BeefLibs/corlib/src/Type.bf
+++ b/BeefLibs/corlib/src/Type.bf
@@ -1126,6 +1126,12 @@ namespace System.Reflection
 				(*(float*)&mValue).ToString(strBuffer);
 			case typeof(double):
 				(*(double*)&mValue).ToString(strBuffer);
+			case typeof (bool):
+				strBuffer.Append((*(bool*)&mValue) ? "true" : "false");
+			case typeof(char8), typeof(char16), typeof(char32):
+				strBuffer.Append('\'');
+				(*(char32*)&mValue).ToString(strBuffer);
+				strBuffer.Append('\'');
 			case typeof(uint64), typeof(uint):
 				(*(uint64*)&mValue).ToString(strBuffer);
 			default:

--- a/BeefLibs/corlib/src/Type.bf
+++ b/BeefLibs/corlib/src/Type.bf
@@ -1126,6 +1126,8 @@ namespace System.Reflection
 				(*(float*)&mValue).ToString(strBuffer);
 			case typeof(double):
 				(*(double*)&mValue).ToString(strBuffer);
+			case typeof(uint64), typeof(uint):
+				(*(uint64*)&mValue).ToString(strBuffer);
 			default:
 				mValue.ToString(strBuffer);
 			}

--- a/BeefLibs/corlib/src/Type.bf
+++ b/BeefLibs/corlib/src/Type.bf
@@ -1130,7 +1130,10 @@ namespace System.Reflection
 				strBuffer.Append((*(bool*)&mValue) ? "true" : "false");
 			case typeof(char8), typeof(char16), typeof(char32):
 				strBuffer.Append('\'');
-				(*(char32*)&mValue).ToString(strBuffer);
+				var str = (*(char32*)&mValue).ToString(.. scope .());
+				let len = str.Length;
+				String.QuoteString(&str[0], len, str);
+				strBuffer.Append(str[(len + 1)...^2]);
 				strBuffer.Append('\'');
 			case typeof(uint64), typeof(uint):
 				(*(uint64*)&mValue).ToString(strBuffer);

--- a/IDE/mintest/minlib/src/System/Type.bf
+++ b/IDE/mintest/minlib/src/System/Type.bf
@@ -1126,6 +1126,12 @@ namespace System.Reflection
 				(*(float*)&mValue).ToString(strBuffer);
 			case typeof(double):
 				(*(double*)&mValue).ToString(strBuffer);
+			case typeof (bool):
+				strBuffer.Append((*(bool*)&mValue) ? "true" : "false");
+			case typeof(char8), typeof(char16), typeof(char32):
+				strBuffer.Append('\'');
+				(*(char32*)&mValue).ToString(strBuffer);
+				strBuffer.Append('\'');
 			case typeof(uint64), typeof(uint):
 				(*(uint64*)&mValue).ToString(strBuffer);
 			default:

--- a/IDE/mintest/minlib/src/System/Type.bf
+++ b/IDE/mintest/minlib/src/System/Type.bf
@@ -1126,6 +1126,8 @@ namespace System.Reflection
 				(*(float*)&mValue).ToString(strBuffer);
 			case typeof(double):
 				(*(double*)&mValue).ToString(strBuffer);
+			case typeof(uint64), typeof(uint):
+				(*(uint64*)&mValue).ToString(strBuffer);
 			default:
 				mValue.ToString(strBuffer);
 			}

--- a/IDE/mintest/minlib/src/System/Type.bf
+++ b/IDE/mintest/minlib/src/System/Type.bf
@@ -1130,7 +1130,10 @@ namespace System.Reflection
 				strBuffer.Append((*(bool*)&mValue) ? "true" : "false");
 			case typeof(char8), typeof(char16), typeof(char32):
 				strBuffer.Append('\'');
-				(*(char32*)&mValue).ToString(strBuffer);
+				var str = (*(char32*)&mValue).ToString(.. scope .());
+				let len = str.Length;
+				String.QuoteString(&str[0], len, str);
+				strBuffer.Append(str[(len + 1)...^2]);
 				strBuffer.Append('\'');
 			case typeof(uint64), typeof(uint):
 				(*(uint64*)&mValue).ToString(strBuffer);


### PR DESCRIPTION
not the most necessary of changes, but you know...
prints uint64.MaxValue not as -1. uint technically only absolutely needs to be printed as a uint64 on 64-bit, but it's not like it matters

Edit: now does printing for bool and char, for when that's a valid thing to do ( #1328 ), not totally sure about the char printing though. It does work, but for unicode chars we could maybe use a \u notation? Don't know if thats strictly necessary