### PR TITLE
Make IDE remove itself from attach to process list

### DIFF
--- a/IDE/src/ui/AttachDialog.bf
+++ b/IDE/src/ui/AttachDialog.bf
@@ -130,9 +130,16 @@ namespace IDE.ui
 			mFullProcessList.Clear();
 			Process.GetProcesses(mFullProcessList);
 
-			int index = mFullProcessList.FindIndex(scope (p) => p.Id == Process.CurrentId);
-			delete mFullProcessList[index];
-			mFullProcessList.RemoveAt(index);
+			// Remove ourselves from the list
+			for (var process in mFullProcessList)
+			{
+				if (process.Id == Process.CurrentId)
+				{
+					delete process;
+					@process.Remove();
+					break;
+				}
+			}
 		}
 
 		void FilterProcesses(bool fullRefresh)

--- a/IDE/src/ui/AttachDialog.bf
+++ b/IDE/src/ui/AttachDialog.bf
@@ -129,6 +129,10 @@ namespace IDE.ui
 			ClearAndDeleteItems(mFullProcessList);			
 			mFullProcessList.Clear();
 			Process.GetProcesses(mFullProcessList);
+
+			int index = mFullProcessList.FindIndex(scope (p) => p.Id == Process.CurrentId);
+			delete mFullProcessList[index];
+			mFullProcessList.RemoveAt(index);
 		}
 
 		void FilterProcesses(bool fullRefresh)


### PR DESCRIPTION
There's no point in having the IDE itself in the attach to process list, it only causes confusion when you want to attach to another IDE, so this PR removes it from the list.