### PR TITLE
Fix for Debug.WriteLine() - Avoid potential String reallocation

### DIFF
--- a/BeefLibs/corlib/src/Diagnostics/Debug.bf
+++ b/BeefLibs/corlib/src/Diagnostics/Debug.bf
@@ -70,7 +70,7 @@ namespace System.Diagnostics
 
 		public static void WriteLine(StringView line)
 		{
-			String lineStr = scope String(Math.Min(line.Length, 4096));
+			String lineStr = scope String(Math.Min(line.Length + 1, 4096));
 			lineStr.Append(line);
 			lineStr.Append('\n');
 			Write(lineStr.Ptr, lineStr.Length);


### PR DESCRIPTION
Debug.WriteLine() no longer reallocate its scoped String when appending a newline.
This only happened when the StringView length matches the buffersize in the String.