### PR TITLE
Add option to highlight current line in editor

### DIFF
--- a/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
@@ -486,8 +486,8 @@ namespace Beefy.theme.dark
 							{
 								float thickness = 2 * (lineSpacing / 18);
 								// This isn't quite the right value, but I'm not sure how to get this
-								// to properly lighlight the whole line without getting cut off - this works well for now.
-								float totalLineWidth = mEditWidget.mScrollContentContainer.mWidth - thickness / 2;
+								// to properly highlight the whole line without getting cut off - this works well for now.
+								float totalLineWidth = mEditWidget.mScrollContentContainer.mWidth - thickness;
 
 								float x = (int)mEditWidget.mHorzPos.v; // If we don't round to int we get jitter while scrolling.
 								using (g.PushColor(DarkTheme.COLOR_CURRENT_LINE_HILITE))

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
@@ -484,13 +484,14 @@ namespace Beefy.theme.dark
                         {
 							if (mHiliteCurrentLine && selStartIdx == selEndIdx)
 							{
-								float totalLineWidth = mEditWidget.mWidth - mTextInsets.mLeft - mTextInsets.mRight - 1;
-								if (mEditWidget.mVertScrollbar != null)
-									totalLineWidth -= mEditWidget.mVertScrollbar.Width;
-
 								float thickness = 2 * (lineSpacing / 18);
+								// This isn't quite the right value, but I'm not sure how to get this
+								// to properly lighlight the whole line without getting cut off - this works well for now.
+								float totalLineWidth = mEditWidget.mScrollContentContainer.mWidth - thickness / 2;
+
+								float x = (int)mEditWidget.mHorzPos.v; // If we don't round to int we get jitter while scrolling.
 								using (g.PushColor(DarkTheme.COLOR_CURRENT_LINE_HILITE))
-									g.OutlineRect(0, curY, totalLineWidth, lineSpacing + thickness, thickness);
+									g.OutlineRect(x, curY, totalLineWidth, lineSpacing + thickness, thickness);
 							}
 
                             float brightness = (float)Math.Cos(Math.Max(0.0f, mCursorBlinkTicks - 20) / 9.0f);                            

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
@@ -22,6 +22,7 @@ namespace Beefy.theme.dark
 		public bool mWantsCheckScrollPosition;
 		public uint32 mViewWhiteSpaceColor;
 		public bool mScrollToStartOnLostFocus;
+		public bool mHiliteCurrentLine;
 
 		protected static uint32[] sDefaultColors = new uint32[] ( Color.White ) ~ delete _;
 
@@ -480,9 +481,20 @@ namespace Beefy.theme.dark
                         }                        
 
                         if (aX != -1)
-                        {                            
+                        {
+							if (mHiliteCurrentLine && selStartIdx == selEndIdx)
+							{
+								float totalLineWidth = mEditWidget.mWidth - mTextInsets.mLeft - mTextInsets.mRight - 1;
+								if (mEditWidget.mVertScrollbar != null)
+									totalLineWidth -= mEditWidget.mVertScrollbar.Width;
+
+								float thickness = 2 * (lineSpacing / 18);
+								using (g.PushColor(DarkTheme.COLOR_CURRENT_LINE_HILITE))
+									g.OutlineRect(0, curY, totalLineWidth, lineSpacing + thickness, thickness);
+							}
+
                             float brightness = (float)Math.Cos(Math.Max(0.0f, mCursorBlinkTicks - 20) / 9.0f);                            
-                            brightness = Math.Max(0, Math.Min(1.0f, brightness * 2.0f + 1.6f));
+                            brightness = Math.Clamp(brightness * 2.0f + 1.6f, 0, 1);
                             if (mEditWidget.mVertPos.IsMoving)
                                 brightness = 0; // When we animate a pgup or pgdn, it's weird seeing the cursor scrolling around
 
@@ -503,7 +515,7 @@ namespace Beefy.theme.dark
                             }
                             else
                             {
-                                using (g.PushColor(Color.Mult(cursorColor, Color.Get(brightness))))
+								using (g.PushColor(Color.Mult(cursorColor, Color.Get(brightness))))
                                     g.FillRect(aX, curY, Math.Max(1.0f, GS!(1)), lineSpacing);
                             }
                             drewCursor = true;

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
@@ -191,6 +191,7 @@ namespace Beefy.theme.dark
         public static uint32 COLOR_SELECTED_OUTLINE    = 0xFFCFAE11;
         public static uint32 COLOR_MENU_FOCUSED        = 0xFFE5A910;
         public static uint32 COLOR_MENU_SELECTED       = 0xFFCB9B80;
+		public static uint32 COLOR_CURRENT_LINE_HILITE = 0xFF4C4C54;
 
 		public static float sScale = 1.0f;
 		public static int32 sSrcImgScale = 1;

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -6097,6 +6097,7 @@ namespace IDE
 			//mEditWidget.mVertScrollbar.mScrollIncrement = editWidgetContent.mFont.GetLineSpacing();
             editWidgetContent.mHiliteColor = 0xFF384858;
             editWidgetContent.mUnfocusedHiliteColor = 0x80384858;
+			editWidgetContent.mHiliteCurrentLine = mSettings.mEditorSettings.mHiliteCurrentLine;
 
             return editWidget;
         }

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -324,6 +324,7 @@ namespace IDE
 			public Color mBuildError = 0xFFFF8080;
 			public Color mBuildWarning = 0xFFFFFF80;
 			public Color mVisibleWhiteSpace = 0xFF9090C0;
+			public Color mCurrentLineHilite = 0xFF4C4C54;
 
 			public void Deserialize(StructuredData sd)
 			{
@@ -348,6 +349,7 @@ namespace IDE
 				GetColor("WorkspaceFailedText", ref mWorkspaceFailedText);
 				GetColor("WorkspaceManualIncludeText", ref mWorkspaceManualIncludeText);
 				GetColor("WorkspaceIgnoredText", ref mWorkspaceIgnoredText);
+				GetColor("CurrentLineHilite", ref mCurrentLineHilite);
 
 				GetColor("Code", ref mCode);
 				GetColor("Keyword", ref mKeyword);
@@ -411,6 +413,7 @@ namespace IDE
 				DarkTheme.COLOR_SELECTED_OUTLINE = mSelectedOutline;
 				DarkTheme.COLOR_MENU_FOCUSED = mMenuFocused;
 				DarkTheme.COLOR_MENU_SELECTED = mMenuSelected;
+				DarkTheme.COLOR_CURRENT_LINE_HILITE = mCurrentLineHilite;
 			}
 		}
 
@@ -616,6 +619,7 @@ namespace IDE
 			public bool mFuzzyAutoComplete = false;
 			public bool mShowLocatorAnim = true;
 			public bool mHiliteCursorReferences = true;
+			public bool mHiliteCurrentLine = true;
 			public bool mLockEditing;
 			public LockWhileDebuggingKind mLockEditingWhenDebugging = .WhenNotHotSwappable;// Only applicable for
 			// non-Beef sources
@@ -644,6 +648,7 @@ namespace IDE
 				sd.Add("FuzzyAutoComplete", mFuzzyAutoComplete);
 				sd.Add("ShowLocatorAnim", mShowLocatorAnim);
 				sd.Add("HiliteCursorReferences", mHiliteCursorReferences);
+				sd.Add("HiliteCurrentLine", mHiliteCurrentLine);
 				sd.Add("LockEditing", mLockEditing);
 				sd.Add("LockEditingWhenDebugging", mLockEditingWhenDebugging);
 				sd.Add("PerforceAutoCheckout", mPerforceAutoCheckout);
@@ -675,6 +680,7 @@ namespace IDE
 				sd.Get("FuzzyAutoComplete", ref mFuzzyAutoComplete);
 				sd.Get("ShowLocatorAnim", ref mShowLocatorAnim);
 				sd.Get("HiliteCursorReferences", ref mHiliteCursorReferences);
+				sd.Get("HiliteCurrentLine", ref mHiliteCurrentLine);
 				sd.Get("LockEditing", ref mLockEditing);
 				sd.Get("LockEditingWhenDebugging", ref mLockEditingWhenDebugging);
 				sd.Get("PerforceAutoCheckout", ref mPerforceAutoCheckout);
@@ -1188,6 +1194,10 @@ namespace IDE
 					widgetWindow.mRootWidget.RehupSize();
 				}
 			}
+
+			for (let value in gApp.mFileEditData.Values)
+				if (value.mEditWidget != null)
+					((SourceEditWidgetContent)value.mEditWidget.Content).mHiliteCurrentLine = gApp.mSettings.mEditorSettings.mHiliteCurrentLine;
 
 			if (!mWakaTimeKey.IsEmpty)
 			{

--- a/IDE/src/ui/SettingsDialog.bf
+++ b/IDE/src/ui/SettingsDialog.bf
@@ -101,6 +101,7 @@ namespace IDE.ui
 			AddPropertiesItem(category, "Fuzzy Autocomplete", "mFuzzyAutoComplete");
 			AddPropertiesItem(category, "Show Locator Animation", "mShowLocatorAnim");
 			AddPropertiesItem(category, "Hilite Symbol at Cursor", "mHiliteCursorReferences");
+			AddPropertiesItem(category, "Hilite Current Line", "mHiliteCurrentLine");
 
 			(?, propEntry) = AddPropertiesItem(category, "Spell Check", "mSpellCheckEnabled");
 			var resetButton = new DarkButton();
@@ -128,7 +129,7 @@ namespace IDE.ui
 			AddPropertiesItem(category, "Format on Save", "mFormatOnSave");
 			AddPropertiesItem(category, "Sync with Workspace Panel", "mSyncWithWorkspacePanel");
 			AddPropertiesItem(category, "Wrap Comments at Column", "mWrapCommentsAt");
-			
+
 			category.Open(true, true);
 		}
 

--- a/IDE/src/util/DefinesSet.bf
+++ b/IDE/src/util/DefinesSet.bf
@@ -18,7 +18,7 @@ namespace IDE.util
 				return;
 			}
 
-			if (!mDefinesSet.ContainsAlt(str))
+			if (!mDefinesSet.Contains(scope .(str)))
 			{
 				var strCopy = new String(str);
 				mDefines.Add(strCopy);


### PR DESCRIPTION
Makes it easier to keep track of where you're currently editing.

![screenshot](https://user-images.githubusercontent.com/55242398/148511395-6c041144-0c34-4f0e-903c-ea4cfd9550ab.png)

I tried to make it look like it does in Visual Studio.

![reference](https://user-images.githubusercontent.com/55242398/148511548-eb069776-13b6-48d9-bbab-dfddd9c56a05.png)

I only have it enabled for source code edit panels - so it won't show up in the immediate window for example. There are also options to disable it (it's enabled by default).

![3](https://user-images.githubusercontent.com/55242398/148511940-8e8fec5e-fd30-48e0-8c49-0f974c2dc80d.png)