### PR TITLE
Improve open error for files from network

### DIFF
--- a/BeefLibs/Beefy2D/src/utils/HTTP.bf
+++ b/BeefLibs/Beefy2D/src/utils/HTTP.bf
@@ -20,6 +20,9 @@ namespace Beefy2D.utils
 		static extern int32 HTTP_GetResult(void* netRequest, int32 waitMS);
 
 		[CallingConvention(.Stdcall), CLink]
+		static extern void HTTP_GetLastError(void* netRequest, out char8* error, out int32 errorLength);
+
+		[CallingConvention(.Stdcall), CLink]
 		static extern void HTTP_Delete(void* netRequest);
 
 		public ~this()
@@ -36,6 +39,12 @@ namespace Beefy2D.utils
 		public HTTPResult GetResult()
 		{
 			return (HTTPResult)HTTP_GetResult(mNativeNetRequest, 0);
+		}
+
+		public void GetLastError(String outError)
+		{
+			HTTP_GetLastError(mNativeNetRequest, let error, let errorLength);
+			outError.Append(StringView(error, errorLength));
 		}
 	}
 }

--- a/IDEHelper/DebugManager.cpp
+++ b/IDEHelper/DebugManager.cpp
@@ -1617,6 +1617,12 @@ BF_EXPORT int HTTP_GetResult(NetResult* netResult, int waitMS)
 	}
 }
 
+BF_EXPORT void HTTP_GetLastError(NetResult* netResult, const char** error, int* errorLength)
+{
+	*error = netResult->mError.GetPtr();
+	*errorLength = netResult->mError.GetLength();
+}
+
 BF_EXPORT void HTTP_Delete(NetResult* netResult)
 {
 	if (!netResult->mDoneEvent->WaitFor(0))

--- a/IDEHelper/NetManager.h
+++ b/IDEHelper/NetManager.h
@@ -36,12 +36,12 @@ public:
 #else
 #endif
 	volatile bool mCancelling;
-	bool mFailed;		
+	bool mFailed;
 	String mError;
 	uint32 mLastUpdateTick;
 	bool mShowTracking;
-	NetResult* mResult;	
-	NetResult* mCancelOnSuccess;	
+	NetResult* mResult;
+	NetResult* mCancelOnSuccess;
 
 	NetRequest()
 	{
@@ -74,8 +74,9 @@ public:
 	String mURL;
 	String mOutPath;
 	bool mFailed;
-	NetRequest* mCurRequest;	
-	bool mRemoved;	
+	String mError;
+	NetRequest* mCurRequest;
+	bool mRemoved;
 	SyncEvent* mDoneEvent;
 
 	NetResult()


### PR DESCRIPTION
This pull request does the following two things:

- Adds the curl failure reason to the output window:
![image](https://user-images.githubusercontent.com/86157825/148550215-e53a4ad1-d05a-4bdd-a909-9f9963e95469.png)

- Changes the header to be more descriptive and the "Retry" button to actually retry the HTTP request:
![image](https://user-images.githubusercontent.com/86157825/148550351-1626121f-3a29-4a09-aa8a-1badd7f51657.png)
