### PR TITLE
Fix StreamReader Peek method

### DIFF
--- a/BeefLibs/corlib/src/IO/StreamReader.bf
+++ b/BeefLibs/corlib/src/IO/StreamReader.bf
@@ -190,7 +190,7 @@ namespace System.IO
 			{
 				if (Try!(ReadBuffer()) == 0) return .Err;
 			}
-			return mCharBuffer[mCharPos + 1];
+			return mCharBuffer[mCharPos];
 		}
 
 		public Task<String> ReadLineAsync()


### PR DESCRIPTION
Not sure why I put a `+ 1` there... But this pull request fixes it