### PR TITLE
Add bounds checking to [Pop]Back/[Pop]Front

### DIFF
--- a/BeefLibs/corlib/src/Collections/List.bf
+++ b/BeefLibs/corlib/src/Collections/List.bf
@@ -283,18 +283,32 @@ namespace System.Collections
 
 		public ref T Front
 		{
+			[Checked]
 			get
 			{
-				Debug.Assert(mSize != 0);
+				Runtime.Assert(mSize != 0);
+				return ref mItems[0];
+			}
+
+			[Unchecked, Inline]
+			get
+			{
 				return ref mItems[0];
 			}
 		}
 		
 		public ref T Back
 		{
+			[Checked]
 			get
 			{
-				Debug.Assert(mSize != 0);
+				Runtime.Assert(mSize != 0);
+				return ref mItems[mSize - 1];
+			}
+
+			[Unchecked, Inline]
+			get
+			{
 				return ref mItems[mSize - 1];
 			}
 		}
@@ -723,13 +737,29 @@ namespace System.Collections
 			return result;
 		}
 
+		[Checked]
 		public T PopBack()
 		{
-			T backVal = mItems[mSize - 1];
-			mSize--;
+			Runtime.Assert(mSize != 0);
+			return mItems[--mSize];
+		}
+
+		[Unchecked]
+		public T PopBack()
+		{
+			return mItems[--mSize];
+		}
+
+		[Checked]
+		public T PopFront()
+		{
+			Runtime.Assert(mSize != 0);
+			T backVal = mItems[0];
+			RemoveAt(0);
 			return backVal;
 		}
 
+		[Unchecked]
 		public T PopFront()
 		{
 			T backVal = mItems[0];


### PR DESCRIPTION
Back/Front properties actually already had bounds checking in debug builds, but this pull request makes them do this check on release mode too to follow the implementation of the normal indexer.