### PR TITLE
Toggle breakpoint at begin scopes

### DIFF
--- a/IDE/src/Commands.bf
+++ b/IDE/src/Commands.bf
@@ -205,6 +205,7 @@ namespace IDE
 			Add("Breakpoint Symbol", new () => { gApp.mBreakpointPanel.AddSymbolBreakpoint(gApp.[Friend]GetCurrentWindow()); });
 			Add("Breakpoint Toggle Thread", new => gApp.[Friend]ToggleThreadBreakpoint, .Editor);
 			Add("Breakpoint Toggle", new => gApp.[Friend]ToggleBreakpoint, .Editor);
+			Add("Breakpoint Toggle at begin scopes", new => gApp.[Friend]ToggleBeginScopeBreakpoints, .Editor);
 			Add("Build Workspace", new => gApp.[Friend]Compile);
 			Add("Cancel Build", new => gApp.[Friend]CancelBuild);
 			Add("Clean Beef", new => gApp.Cmd_CleanBeef);

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -4505,6 +4505,16 @@ namespace IDE
 			}
 		}
 
+		void ToggleBeginScopeBreakpoints(WidgetWindow window, Breakpoint.SetKind setKind, Breakpoint.SetFlags setFlags, bool bindToThread = false)
+		{
+			var documentPanel = GetActiveDocumentPanel();
+
+			if (var sourceViewPanel = documentPanel as SourceViewPanel)
+			{
+			    sourceViewPanel.ToggleBreakpointAtBeginScopes(setKind, setFlags, bindToThread ? gApp.mDebugger.GetActiveThread() : -1);
+			}
+		}
+
 		[IDECommand]
 		void ToggleComment()
 		{

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -3867,12 +3867,25 @@ namespace IDE.ui
 				var sp=scope String();
 				mEditWidget.Content.ExtractLine(l-1,sp);
 				sp.TrimEnd();
-
 				if (s.Length > 0 && s.StartsWith('{') && sp.EndsWith(')'))
 				{ 
+					String sna=scope String();
+					//Because debugger does not want breakpoints on {'s, skip comment and empty lines before placing BP
+					while(l<lc)
+					{
+						var sn = scope String();
+						l++;
+						mEditWidget.Content.ExtractLine(l,sn);
+						sn.Trim();
+						if (!(sn.Length==0 || sn.StartsWith('/')))
+						{
+							sna.Append(sn);
+							break;
+						}
+					}
+					if (sna.StartsWith('}')) continue;
 					ToggleBreakpointAt(l, 0, setKind, flags, threadId);
 				}
-
 			}
 			return;
 		}

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -3851,10 +3851,10 @@ namespace IDE.ui
 			if (activePanel != this)
 				activePanel.ToggleBreakpointAtBeginScopes(setKind, flags, threadId);
 
-		    if (mOldVersionPanel != null)
-		    {                
-		        return;
-		    }
+			if (mOldVersionPanel != null)
+			{
+				return;
+			}
 
 			var l=0;
 			var lc=mEditWidget.Content.GetLineCount();

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -3856,28 +3856,28 @@ namespace IDE.ui
 				return;
 			}
 
-			var l=0;
-			var lc=mEditWidget.Content.GetLineCount();
-			while(l<lc)
+			var l = 0;
+			var lc = mEditWidget.Content.GetLineCount();
+			while(l < lc)
 			{
 				l++;
-				var s=scope String();
-				mEditWidget.Content.ExtractLine(l,s);
+				var s = scope String();
+				mEditWidget.Content.ExtractLine(l, s);
 				s.TrimStart();
-				var sp=scope String();
-				mEditWidget.Content.ExtractLine(l-1,sp);
+				var sp = scope String();
+				mEditWidget.Content.ExtractLine(l - 1, sp);
 				sp.TrimEnd();
 				if (s.Length > 0 && s.StartsWith('{') && sp.EndsWith(')'))
 				{ 
-					String sna=scope String();
+					String sna = scope String();
 					//Because debugger does not want breakpoints on {'s, skip comment and empty lines before placing BP
-					while(l<lc)
+					while(l < lc)
 					{
 						var sn = scope String();
 						l++;
-						mEditWidget.Content.ExtractLine(l,sn);
+						mEditWidget.Content.ExtractLine(l, sn);
 						sn.Trim();
-						if (!(sn.Length==0 || sn.StartsWith('/')))
+						if (!(sn.Length == 0 || sn.StartsWith('/')))
 						{
 							sna.Append(sn);
 							break;

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -3845,6 +3845,38 @@ namespace IDE.ui
 			return ToggleBreakpointAt(lineIdx, lineCharIdx, setKind, flags, threadId);
 		}
 
+		public void ToggleBreakpointAtBeginScopes(Breakpoint.SetKind setKind = .Toggle, Breakpoint.SetFlags flags = .None, int threadId = -1)
+		{
+			var activePanel = GetActivePanel();
+			if (activePanel != this)
+				activePanel.ToggleBreakpointAtBeginScopes(setKind, flags, threadId);
+
+		    if (mOldVersionPanel != null)
+		    {                
+		        return;
+		    }
+
+			var l=0;
+			var lc=mEditWidget.Content.GetLineCount();
+			while(l<lc)
+			{
+				l++;
+				var s=scope String();
+				mEditWidget.Content.ExtractLine(l,s);
+				s.TrimStart();
+				var sp=scope String();
+				mEditWidget.Content.ExtractLine(l-1,sp);
+				sp.TrimEnd();
+
+				if (s.Length > 0 && s.StartsWith('{') && sp.EndsWith(')'))
+				{ 
+					ToggleBreakpointAt(l, 0, setKind, flags, threadId);
+				}
+
+			}
+			return;
+		}
+
 		public Breakpoint ToggleBreakpointAt(int lineIdx, int lineCharIdx, Breakpoint.SetKind setKind = .Toggle, Breakpoint.SetFlags flags = .None, int threadId = -1)
 		{
 			var lineIdx;


### PR DESCRIPTION
Added new command that toggles breakpoint(s) at begin of scopes. Not bound by default.
