### PR TITLE
Highlight matching parens under cursor

### DIFF
--- a/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
@@ -185,13 +185,14 @@ namespace Beefy.theme.dark
             COUNT
         };
 
-		public static uint32 COLOR_TEXT                = 0xFFFFFFFF;
-        public static uint32 COLOR_WINDOW              = 0xFF595962;
-        public static uint32 COLOR_BKG                 = 0xFF26262A;
-        public static uint32 COLOR_SELECTED_OUTLINE    = 0xFFCFAE11;
-        public static uint32 COLOR_MENU_FOCUSED        = 0xFFE5A910;
-        public static uint32 COLOR_MENU_SELECTED       = 0xFFCB9B80;
-		public static uint32 COLOR_CURRENT_LINE_HILITE = 0xFF4C4C54;
+		public static uint32 COLOR_TEXT                   = 0xFFFFFFFF;
+        public static uint32 COLOR_WINDOW                 = 0xFF595962;
+        public static uint32 COLOR_BKG                    = 0xFF26262A;
+        public static uint32 COLOR_SELECTED_OUTLINE       = 0xFFCFAE11;
+        public static uint32 COLOR_MENU_FOCUSED           = 0xFFE5A910;
+        public static uint32 COLOR_MENU_SELECTED          = 0xFFCB9B80;
+		public static uint32 COLOR_CURRENT_LINE_HILITE    = 0xFF4C4C54;
+		public static uint32 COLOR_MATCHING_PARENS_HILITE = 0x28FFFFFF;
 
 		public static float sScale = 1.0f;
 		public static int32 sSrcImgScale = 1;

--- a/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
+++ b/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
@@ -2661,6 +2661,12 @@ namespace Beefy.widgets
 			GetLineAndColumnAtCoord(x, y, out line2, out column);
 		}
 
+		public void GetLineColumnAtIdx(int idx, out int line, out int column)
+		{
+			GetLineCharAtIdx(idx, out line, var lineChar);
+			GetColumnAtLineChar(line, lineChar, out column);
+		}
+
 		public virtual void GetLineCharAtIdx(int idx, out int line, out int theChar)
 		{
 			int lineA;

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -326,6 +326,7 @@ namespace IDE
 			public Color mVisibleWhiteSpace = 0xFF9090C0;
 			public Color mCurrentLineHilite = 0xFF4C4C54;
 			public Color mCurrentLineNumberHilite = 0x18FFFFFF;
+			public Color mMatchingParensHilite = 0x28FFFFFF;
 
 			public void Deserialize(StructuredData sd)
 			{
@@ -386,6 +387,7 @@ namespace IDE
 				GetColor("VisibleWhiteSpace", ref mVisibleWhiteSpace);
 				GetColor("CurrentLineHilite", ref mCurrentLineHilite);
 				GetColor("CurrentLineNumberHilite", ref mCurrentLineNumberHilite);
+				GetColor("MatchingParensHilite", ref mMatchingParensHilite);
 			}
 
 			public void Apply()
@@ -417,6 +419,7 @@ namespace IDE
 				DarkTheme.COLOR_MENU_FOCUSED = mMenuFocused;
 				DarkTheme.COLOR_MENU_SELECTED = mMenuSelected;
 				DarkTheme.COLOR_CURRENT_LINE_HILITE = mCurrentLineHilite;
+				DarkTheme.COLOR_MATCHING_PARENS_HILITE = mMatchingParensHilite;
 			}
 		}
 

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -185,7 +185,6 @@ namespace IDE.ui
 
 		enum HiliteMatchingParensPositionCache
 		{
-			//TODO: Better naming?
 			case NeedToRecalculate;
 			case UnmatchedParens;
 			case Valid(float x1, float y1, float x2, float y2);


### PR DESCRIPTION
I often rely on this in other editors, especially in complex math expressions.

I have it enabled by default in all SourceEditWidgets, including the Immediate panel for example. It's also enabled by default and there is no option to turn it off. IMO I don't see why you would turn this off, but I can add it if you think I should. I did add a theming option for it so themes can change the color.

![Untitled](https://user-images.githubusercontent.com/55242398/149029622-5100e055-3ecb-425d-956d-32f1fab555df.png)

