### PR TITLE
fix save unnamed new file crash

### DIFF
--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -1481,7 +1481,7 @@ namespace IDE
 		{
 #if !CLI
 			String fullDir = scope .();
-			Path.GetDirectoryPath(sourceViewPanel.mFilePath, fullDir);
+			Path.GetDirectoryPath(sourceViewPanel.mFilePath ?? mWorkspace.mStartupProject.mProjectPath, fullDir);
 
 			SaveFileDialog dialog = scope .();
 			dialog.SetFilter("All files (*.*)|*.*");


### PR DESCRIPTION
when using File->New->New File, fix crash on save. Provide a reasonable default path for this rather rare case (everything else seems to already check for fielPath to be null). Maybe now viable option to create files in safe mode or just for non .bf files.