### PR TITLE
Fix ASSERTIONS and add SAFE_HEAP in emcc command-line

### DIFF
--- a/IDE/src/BuildContext.bf
+++ b/IDE/src/BuildContext.bf
@@ -656,7 +656,9 @@ namespace IDE
 						linkLine.Append(" -g");
 
 					if (workspaceOptions.mRuntimeChecks)
-						linkLine.Append(" -s ASSERTIONS=1");
+						linkLine.Append(" -s SAFE_HEAP=1");
+					else
+						linkLine.Append(" -s ASSERTIONS=0");
 
 					linkLine.Replace('\\', '/');
 


### PR DESCRIPTION
- ASSERTIONS are actually enabled by default, so I guess we should disable them instead of trying to enable.
https://emscripten.org/docs/porting/Debugging.html#compiler-settings
- SAFE_HEAP "adds additional memory access checks, and will give clear errors for problems like dereferencing 0 and memory alignment issues." so it clearly makes sense to add it in Debug.