### PR TITLE
Fix ASSERTIONS in emcc command-line

### DIFF
--- a/IDE/src/BuildContext.bf
+++ b/IDE/src/BuildContext.bf
@@ -655,8 +655,8 @@ namespace IDE
 					if (workspaceOptions.mEmitDebugInfo != .No)
 						linkLine.Append(" -g");
 
-					if (workspaceOptions.mRuntimeChecks)
-						linkLine.Append(" -s ASSERTIONS=1");
+					if (!workspaceOptions.mRuntimeChecks)
+						linkLine.Append(" -s ASSERTIONS=0");
 
 					linkLine.Replace('\\', '/');
 


### PR DESCRIPTION
ASSERTIONS is actually enabled by default, so I guess we should disable it instead of trying to enable it.

Source: https://emscripten.org/docs/porting/Debugging.html#compiler-settings