### PR TITLE
Fix SDLApp in wasm

### DIFF
--- a/BeefLibs/SDL2/src/SDLApp.bf
+++ b/BeefLibs/SDL2/src/SDLApp.bf
@@ -232,7 +232,7 @@ namespace SDL2
 #endif
 		}
 
-		public void RunOneFrame()
+		private void RunOneFrame()
 		{
 			int32 waitTime = 1;
 			SDL.Event event;


### PR DESCRIPTION
Infinite loops breaks wasm, so instead we have to use `emscripten_set_main_loop` which does a `requestAnimationFrame` under the covers.

This PR also fixes a crash because `GetDirectoryPath` fails in wasm.