### PR TITLE
Improve Enum.Parse functionality

### DIFF
--- a/BeefLibs/corlib/src/Enum.bf
+++ b/BeefLibs/corlib/src/Enum.bf
@@ -25,6 +25,8 @@ namespace System
 			{
 				if (str.Equals(name, ignoreCase))
 					return .Ok(data);
+				if (int64.Parse(str) case .Ok(let val) && val == (.)data)
+					return .Ok(data);
 			}
 
 			return .Err;


### PR DESCRIPTION
I just noticed that C#'s Enum.TryParse also handles the case of the enum being in numeric format but that doesn't happen in Beef's Enum.Parse, I guess this wasn't intentional so I made this PR so we could bring Beef's implementation closer to the C# one If that's desired.