### PR TITLE
Improve robustness of CrashCatcher registration

### DIFF
--- a/BeefySysLib/platform/win/CrashCatcher.h
+++ b/BeefySysLib/platform/win/CrashCatcher.h
@@ -35,6 +35,7 @@ public:
 	virtual void SetRelaunchCmd(const StringImpl& relaunchCmd);
 
 	static CrashCatcher* Get();
+	static int Shutdown();
 };
 
 NS_BF_END


### PR DESCRIPTION
This is a fix for https://github.com/beefytech/Beef/issues/1455

Implement a counter mechanism to tear down CrashCatcher, and allow it to be reinitialized as needed within the same process.