### PR TITLE
Allow handling of `ToFileTimeUtc` error

### DIFF
--- a/BeefLibs/corlib/src/DateTime.bf
+++ b/BeefLibs/corlib/src/DateTime.bf
@@ -555,15 +555,13 @@ namespace System
 			return ToUniversalTime().ToFileTimeUtc();
 		}
 
-		public int64 ToFileTimeUtc()
+		public Result<int64> ToFileTimeUtc()
 		{
 			// Treats the input as universal if it is not specified
 			int64 ticks = ((InternalKind & LocalMask) != 0UL) ? ToUniversalTime().InternalTicks : this.InternalTicks;
 			ticks -= FileTimeOffset;
 			if (ticks < 0)
-			{
-				Runtime.FatalError();
-			}
+				return .Err;
 			return ticks;
 		}
 


### PR DESCRIPTION
This is only a change to `ToFileTimeUtc`, I didn't change anything else since looks like I would need to change multiple files to add proper error returns in them (and a DateTime overhaul isn't my objective rn lol).