### PR TITLE
Correctly handle null in `Write`/`WriteLine`

### DIFF
--- a/BeefLibs/corlib/src/Console.bf
+++ b/BeefLibs/corlib/src/Console.bf
@@ -221,7 +221,10 @@ namespace System
 		public static void Write(Object obj)
 		{
 			String str = scope String(256);
-			obj.ToString(str);
+			if (obj == null)
+				str.Append("null");
+			else
+				obj.ToString(str);
 			Write(str);
 		}
 
@@ -245,7 +248,10 @@ namespace System
 		public static void WriteLine(Object obj)
 		{
 			String str = scope String(256);
-			obj.ToString(str);
+			if (obj == null)
+				str.Append("null");
+			else
+				obj.ToString(str);
 			WriteLine(str);
 		}
 		


### PR DESCRIPTION
This follows the implementation of format when the object is null, not what happens in C#.
(In C# the new line would be empty)