### PR TITLE
Fix error handling in `Version.Parse`

### DIFF
--- a/BeefLibs/corlib/src/Version.bf
+++ b/BeefLibs/corlib/src/Version.bf
@@ -93,7 +93,7 @@ namespace System
 			}
 
 			let major = ParseComponent!(components.GetNext());
-			let minor = ParseComponent!(components.GetNext());
+			let minor = ParseComponent!(Try!(components.GetNext()));
 
 			if (!components.HasMore)
 				return Version(major, minor);


### PR DESCRIPTION
The first version component will always exist even when the source string is empty, but in this case the second wouldn't exist and we weren't checking for that.