### PR TITLE
Add `GetCustomAttributes` and `GetCustomAttributes<T>`

### DIFF
--- a/BeefLibs/corlib/src/Reflection/AttributeInfo.bf
+++ b/BeefLibs/corlib/src/Reflection/AttributeInfo.bf
@@ -1,3 +1,4 @@
+using System.Collections;
 namespace System.Reflection
 {
 	class AttributeInfo
@@ -111,6 +112,238 @@ namespace System.Reflection
 			}
 
 			return .Err;
+		}
+
+		public struct CustomAttributeEnumerator : IEnumerator<Object>, IDisposable
+		{
+			void* data;
+			int32 attrIdx;
+			uint8 count;
+			Object targetAttr;
+
+			public this(void* inAttrData)
+			{
+				data = inAttrData;
+				data++;
+				attrIdx = 0;
+				count = data != null ? AttributeInfo.Decode!<uint8>(data) : 0;
+				targetAttr = null;
+			}
+
+			public Object Current
+			{
+				get
+				{
+					return targetAttr;
+				}
+			}
+
+			public bool MoveNext() mut
+			{
+				if (attrIdx >= count || data == null)
+					return false;
+
+				void* startPtr = data;
+				var len = AttributeInfo.Decode!<uint16>(data);
+				void* endPtr = (uint8*)startPtr + len;
+
+				var typeId = AttributeInfo.Decode!<TypeId>(data);
+
+				var methodIdx = AttributeInfo.Decode!<uint16>(data);
+
+				Type attrType = Type.[Friend]GetType(typeId);
+				TypeInstance attrTypeInst = attrType as TypeInstance;
+				MethodInfo methodInfo = .(attrTypeInst, attrTypeInst.[Friend]mMethodDataPtr + methodIdx);
+
+				Object[] args = scope Object[methodInfo.[Friend]mData.mMethodData.mParamCount];
+
+				int argIdx = 0;
+				while (data < endPtr)
+				{
+				    var attrDataType = AttributeInfo.Decode!<TypeCode>(data);
+					switch (attrDataType)
+					{
+					case .Int8,
+						 .UInt8,
+						 .Char8,
+						 .Boolean:
+						let attrData = AttributeInfo.Decode!<int8>(data);
+						args[argIdx] = scope:: box attrData;
+					case .Int16,
+						.UInt16,
+						.Char16:
+						let attrData = AttributeInfo.Decode!<int16>(data);
+						args[argIdx] = scope:: box attrData;
+					case .Int32,
+						 .UInt32,
+						 .Char32:
+						let attrData = AttributeInfo.Decode!<int32>(data);
+						args[argIdx] = scope:: box attrData;
+					case .Float:
+						let attrData = AttributeInfo.Decode!<float>(data);
+						args[argIdx] = scope:: box attrData;
+					case .Int64,
+						.UInt64,
+						.Double:
+						let attrData = AttributeInfo.Decode!<int64>(data);
+						args[argIdx] = scope:: box attrData;
+					case (TypeCode)typeof(TypeCode).MaxValue + 8: //BfConstType_TypeOf
+						let argTypeId = AttributeInfo.Decode!<int32>(data);
+						args[argIdx] = Type.[Friend]GetType((.)argTypeId);
+					case (TypeCode)255:
+						let stringId = AttributeInfo.Decode!<int32>(data);
+						String str = String.[Friend]sIdStringLiterals[stringId];
+						args[argIdx] = str;
+					default:
+						Runtime.FatalError("Not handled");
+					}
+					argIdx++;
+				}
+
+				Type boxedAttrType = attrType.BoxedType;
+
+				delete targetAttr;
+				targetAttr = boxedAttrType.CreateObject().Get();
+
+				if (methodInfo.Invoke((uint8*)Internal.UnsafeCastToPtr(targetAttr) + boxedAttrType.[Friend]mMemberDataOffset, params args) case .Ok(var val))
+					val.Dispose();
+
+				attrIdx++;
+				return true;
+			}
+
+			public void Dispose()
+			{
+				delete targetAttr;
+			}
+
+			public Result<Object> GetNext() mut
+			{
+				if (!MoveNext())
+					return .Err;
+				return Current;
+			}
+		}
+
+		public struct CustomAttributeEnumerator<T> : IEnumerator<T>
+		{
+			void* data;
+			int32 attrIdx;
+			uint8 count;
+			T targetAttr;
+
+			public this(void* inAttrData)
+			{
+				data = inAttrData;
+				data++;
+				attrIdx = 0;
+				count = data != null ? AttributeInfo.Decode!<uint8>(data) : 0;
+				targetAttr = ?;
+			}
+
+			public T Current
+			{
+				get
+				{
+					return targetAttr;
+				}
+			}
+
+			public bool MoveNext() mut
+			{
+				if (attrIdx >= count || data == null)
+					return false;
+
+				void* endPtr = null;
+				TypeId typeId = 0;
+
+				while (true)
+				{
+					void* startPtr = data;
+					var len = AttributeInfo.Decode!<uint16>(data);
+					endPtr = (uint8*)startPtr + len;
+
+					typeId = AttributeInfo.Decode!<TypeId>(data);
+					if (typeId != typeof(T).TypeId)
+					{
+						attrIdx++;
+						if (attrIdx >= count)
+							return false;
+					    data = endPtr;
+					    continue;
+					}
+
+					break;
+				}
+
+				var methodIdx = AttributeInfo.Decode!<uint16>(data);
+
+				Type attrType = Type.[Friend]GetType(typeId);
+				TypeInstance attrTypeInst = attrType as TypeInstance;
+				MethodInfo methodInfo = .(attrTypeInst, attrTypeInst.[Friend]mMethodDataPtr + methodIdx);
+
+				Object[] args = scope Object[methodInfo.[Friend]mData.mMethodData.mParamCount];
+
+				int argIdx = 0;
+				while (data < endPtr)
+				{
+				    var attrDataType = AttributeInfo.Decode!<TypeCode>(data);
+					switch (attrDataType)
+					{
+					case .Int8,
+						 .UInt8,
+						 .Char8,
+						 .Boolean:
+						let attrData = AttributeInfo.Decode!<int8>(data);
+						args[argIdx] = scope:: box attrData;
+					case .Int16,
+						.UInt16,
+						.Char16:
+						let attrData = AttributeInfo.Decode!<int16>(data);
+						args[argIdx] = scope:: box attrData;
+					case .Int32,
+						 .UInt32,
+						 .Char32:
+						let attrData = AttributeInfo.Decode!<int32>(data);
+						args[argIdx] = scope:: box attrData;
+					case .Float:
+						let attrData = AttributeInfo.Decode!<float>(data);
+						args[argIdx] = scope:: box attrData;
+					case .Int64,
+						.UInt64,
+						.Double:
+						let attrData = AttributeInfo.Decode!<int64>(data);
+						args[argIdx] = scope:: box attrData;
+					case (TypeCode)typeof(TypeCode).MaxValue + 8: //BfConstType_TypeOf
+						let argTypeId = AttributeInfo.Decode!<int32>(data);
+						args[argIdx] = Type.[Friend]GetType((.)argTypeId);
+					case (TypeCode)255:
+						let stringId = AttributeInfo.Decode!<int32>(data);
+						String str = String.[Friend]sIdStringLiterals[stringId];
+						args[argIdx] = str;
+					default:
+						Runtime.FatalError("Not handled");
+					}
+					argIdx++;
+				}
+
+				if (methodInfo.Invoke(&targetAttr, params args) case .Ok(var val))
+					val.Dispose();
+
+				attrIdx++;
+				return true;
+			}
+
+			public void Dispose()
+			{
+			}
+
+			public Result<T> GetNext() mut
+			{
+				if (!MoveNext())
+					return .Err;
+				return Current;
+			}
 		}
 	}
 }

--- a/BeefLibs/corlib/src/Reflection/FieldInfo.bf
+++ b/BeefLibs/corlib/src/Reflection/FieldInfo.bf
@@ -231,9 +231,19 @@ namespace System.Reflection
 		{
 			if (Compiler.IsComptime)
 			{
-				T val = ?;
-				if (Type.[Friend]Comptime_Field_GetCustomAttribute((int32)mTypeInstance.TypeId, mFieldData.mCustomAttributesIdx, (.)typeof(T).TypeId, &val))
-					return val;
+				int32 attrIdx = -1;
+				Type attrType = null;
+				repeat
+				{
+					attrType = Type.[Friend]Comptime_Field_GetCustomAttributeType((int32)mTypeInstance.TypeId, mFieldData.mCustomAttributesIdx, ++attrIdx);
+					if (attrType == typeof(T))
+					{
+						T val = ?;
+						if (Type.[Friend]Comptime_Field_GetCustomAttribute((int32)mTypeInstance.TypeId, mFieldData.mCustomAttributesIdx, attrIdx, &val))
+							return val;
+					}
+				}
+				while (attrType != null);
 				return .Err;
 			}
 			return mTypeInstance.[Friend]GetCustomAttribute<T>(mFieldData.mCustomAttributesIdx);
@@ -241,16 +251,24 @@ namespace System.Reflection
 
 		public AttributeInfo.CustomAttributeEnumerator GetCustomAttributes()
 		{
-			if (Compiler.IsComptime)
-				Runtime.NotImplemented();
 			return mTypeInstance.[Friend]GetCustomAttributes(mFieldData.mCustomAttributesIdx);
+		}
+
+		[Comptime]
+		public AttributeInfo.ComptimeFieldCustomAttributeEnumerator GetCustomAttributes()
+		{
+			return .((int32)mTypeInstance.TypeId, mFieldData.mCustomAttributesIdx);
 		}
 
 		public AttributeInfo.CustomAttributeEnumerator<T> GetCustomAttributes<T>() where T : Attribute
 		{
-			if (Compiler.IsComptime)
-				Runtime.NotImplemented();
 			return mTypeInstance.[Friend]GetCustomAttributes<T>(mFieldData.mCustomAttributesIdx);
+		}
+
+		[Comptime]
+		public AttributeInfo.ComptimeFieldCustomAttributeEnumerator<T> GetCustomAttributes<T>() where T : Attribute
+		{
+			return .((int32)mTypeInstance.TypeId, mFieldData.mCustomAttributesIdx);
 		}
 
 	    void* GetDataPtrAndType(Object value, out Type type)

--- a/BeefLibs/corlib/src/Reflection/FieldInfo.bf
+++ b/BeefLibs/corlib/src/Reflection/FieldInfo.bf
@@ -239,6 +239,20 @@ namespace System.Reflection
 			return mTypeInstance.[Friend]GetCustomAttribute<T>(mFieldData.mCustomAttributesIdx);
 		}
 
+		public AttributeInfo.CustomAttributeEnumerator GetCustomAttributes()
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+			return mTypeInstance.[Friend]GetCustomAttributes(mFieldData.mCustomAttributesIdx);
+		}
+
+		public AttributeInfo.CustomAttributeEnumerator<T> GetCustomAttributes<T>() where T : Attribute
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+			return mTypeInstance.[Friend]GetCustomAttributes<T>(mFieldData.mCustomAttributesIdx);
+		}
+
 	    void* GetDataPtrAndType(Object value, out Type type)
 	    {
 	        type = value.[Friend]RawGetType();

--- a/BeefLibs/corlib/src/Reflection/MethodInfo.bf
+++ b/BeefLibs/corlib/src/Reflection/MethodInfo.bf
@@ -112,9 +112,19 @@ namespace System.Reflection
 		{
 			if (Compiler.IsComptime)
 			{
-				T val = ?;
-				if (Type.[Friend]Comptime_Method_GetCustomAttribute(mData.mComptimeMethodInstance, (.)typeof(T).TypeId, &val))
-					return val;
+				int32 attrIdx = -1;
+				Type attrType = null;
+				repeat
+				{
+					attrType = Type.[Friend]Comptime_Method_GetCustomAttributeType(mData.mComptimeMethodInstance, ++attrIdx);
+					if (attrType == typeof(T))
+					{
+						T val = ?;
+						if (Type.[Friend]Comptime_Method_GetCustomAttribute(mData.mComptimeMethodInstance, attrIdx, &val))
+							return val;
+					}
+				}
+				while (attrType != null);
 				return .Err;
 			}
 			return mTypeInstance.[Friend]GetCustomAttribute<T>(mData.mMethodData.mCustomAttributesIdx);
@@ -122,16 +132,24 @@ namespace System.Reflection
 
 		public AttributeInfo.CustomAttributeEnumerator GetCustomAttributes()
 		{
-			if (Compiler.IsComptime)
-				Runtime.NotImplemented();
 			return mTypeInstance.[Friend]GetCustomAttributes(mData.mMethodData.mCustomAttributesIdx);
+		}
+
+		[Comptime]
+		public AttributeInfo.ComptimeMethodCustomAttributeEnumerator GetCustomAttributes()
+		{
+			return .(mData.mComptimeMethodInstance);
 		}
 
 		public AttributeInfo.CustomAttributeEnumerator<T> GetCustomAttributes<T>() where T : Attribute
 		{
-			if (Compiler.IsComptime)
-				Runtime.NotImplemented();
 			return mTypeInstance.[Friend]GetCustomAttributes<T>(mData.mMethodData.mCustomAttributesIdx);
+		}
+
+		[Comptime]
+		public AttributeInfo.ComptimeMethodCustomAttributeEnumerator<T> GetCustomAttributes<T>() where T : Attribute
+		{
+			return .(mData.mComptimeMethodInstance);
 		}
 
 		public Result<T> GetReturnCustomAttribute<T>() where T : Attribute

--- a/BeefLibs/corlib/src/Reflection/MethodInfo.bf
+++ b/BeefLibs/corlib/src/Reflection/MethodInfo.bf
@@ -92,6 +92,22 @@ namespace System.Reflection
 			return mTypeInstance.[Friend]GetCustomAttribute<T>(mData.mMethodData.mParamData[paramIdx].mCustomAttributesIdx);
 		}
 
+		public AttributeInfo.CustomAttributeEnumerator GetParamCustomAttributes(int paramIdx)
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+			Debug.Assert((uint)paramIdx < (uint)mData.mMethodData.mParamCount);
+			return mTypeInstance.[Friend]GetCustomAttributes(mData.mMethodData.mParamData[paramIdx].mCustomAttributesIdx);
+		}
+
+		public AttributeInfo.CustomAttributeEnumerator<T> GetParamCustomAttributes<T>(int paramIdx) where T : Attribute
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+			Debug.Assert((uint)paramIdx < (uint)mData.mMethodData.mParamCount);
+			return mTypeInstance.[Friend]GetCustomAttributes<T>(mData.mMethodData.mParamData[paramIdx].mCustomAttributesIdx);
+		}
+
 		public Result<T> GetCustomAttribute<T>() where T : Attribute
 		{
 			if (Compiler.IsComptime)
@@ -104,11 +120,39 @@ namespace System.Reflection
 			return mTypeInstance.[Friend]GetCustomAttribute<T>(mData.mMethodData.mCustomAttributesIdx);
 		}
 
+		public AttributeInfo.CustomAttributeEnumerator GetCustomAttributes()
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+			return mTypeInstance.[Friend]GetCustomAttributes(mData.mMethodData.mCustomAttributesIdx);
+		}
+
+		public AttributeInfo.CustomAttributeEnumerator<T> GetCustomAttributes<T>() where T : Attribute
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+			return mTypeInstance.[Friend]GetCustomAttributes<T>(mData.mMethodData.mCustomAttributesIdx);
+		}
+
 		public Result<T> GetReturnCustomAttribute<T>() where T : Attribute
 		{
 			if (Compiler.IsComptime)
 				return .Err;
 			return mTypeInstance.[Friend]GetCustomAttribute<T>(mData.mMethodData.mReturnCustomAttributesIdx);
+		}
+
+		public AttributeInfo.CustomAttributeEnumerator GetReturnCustomAttributes()
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+			return mTypeInstance.[Friend]GetCustomAttributes(mData.mMethodData.mReturnCustomAttributesIdx);
+		}
+
+		public AttributeInfo.CustomAttributeEnumerator<T> GetReturnCustomAttributes<T>() where T : Attribute
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+			return mTypeInstance.[Friend]GetCustomAttributes<T>(mData.mMethodData.mReturnCustomAttributesIdx);
 		}
 
 		public enum CallError

--- a/BeefLibs/corlib/src/Type.bf
+++ b/BeefLibs/corlib/src/Type.bf
@@ -670,6 +670,26 @@ namespace System
 			return .Err;
 		}
 
+		public AttributeInfo.CustomAttributeEnumerator GetCustomAttributes()
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+
+			if (var typeInstance = this as TypeInstance)
+				return typeInstance.[Friend]GetCustomAttributes(typeInstance.[Friend]mCustomAttributesIdx);
+			Runtime.NotImplemented();
+		}
+
+		public AttributeInfo.CustomAttributeEnumerator<T> GetCustomAttributes<T>() where T : Attribute
+		{
+			if (Compiler.IsComptime)
+				Runtime.NotImplemented();
+
+			if (var typeInstance = this as TypeInstance)
+				return typeInstance.[Friend]GetCustomAttributes<T>(typeInstance.[Friend]mCustomAttributesIdx);
+			Runtime.NotImplemented();
+		}
+
 		public override void ToString(String strBuffer)
 		{
 			GetFullName(strBuffer);
@@ -1073,6 +1093,24 @@ namespace System.Reflection
 			default:
 				return .Err;
 			}
+		}
+
+		AttributeInfo.CustomAttributeEnumerator GetCustomAttributes(int customAttributeIdx)
+		{
+			if (customAttributeIdx == -1)
+			    return .(null);
+
+			void* data = mCustomAttrDataPtr[customAttributeIdx];
+			return .(data);
+		}
+
+		AttributeInfo.CustomAttributeEnumerator<T> GetCustomAttributes<T>(int customAttributeIdx) where T : Attribute
+		{
+			if (customAttributeIdx == -1)
+			    return .(null);
+
+			void* data = mCustomAttrDataPtr[customAttributeIdx];
+			return .(data);
 		}
     }
 

--- a/BeefLibs/corlib/src/Type.bf
+++ b/BeefLibs/corlib/src/Type.bf
@@ -528,9 +528,12 @@ namespace System
 		static extern Type Comptime_GetTypeByName(StringView name);
 		static extern String Comptime_Type_ToString(int32 typeId);
 		static extern Type Comptime_GetSpecializedType(Type unspecializedType, Span<Type> typeArgs);
-		static extern bool Comptime_Type_GetCustomAttribute(int32 typeId, int32 attributeId, void* dataPtr);
-		static extern bool Comptime_Field_GetCustomAttribute(int32 typeId, int32 fieldIdx, int32 attributeId, void* dataPtr);
-		static extern bool Comptime_Method_GetCustomAttribute(int64 methodHandle, int32 attributeId, void* dataPtr);
+		static extern bool Comptime_Type_GetCustomAttribute(int32 typeId, int32 attributeIdx, void* dataPtr);
+		static extern bool Comptime_Field_GetCustomAttribute(int32 typeId, int32 fieldIdx, int32 attributeIdx, void* dataPtr);
+		static extern bool Comptime_Method_GetCustomAttribute(int64 methodHandle, int32 attributeIdx, void* dataPtr);
+		static extern Type Comptime_Type_GetCustomAttributeType(int32 typeId, int32 attributeIdx);
+		static extern Type Comptime_Field_GetCustomAttributeType(int32 typeId, int32 fieldIdx, int32 attributeIdx);
+		static extern Type Comptime_Method_GetCustomAttributeType(int64 methodHandle, int32 attributeIdx);
 		static extern int32 Comptime_GetMethodCount(int32 typeId);
 		static extern int64 Comptime_GetMethod(int32 typeId, int32 methodIdx);
 		static extern String Comptime_Method_ToString(int64 methodHandle);
@@ -647,7 +650,16 @@ namespace System
 		{
 			if (Compiler.IsComptime)
 			{
-				return Comptime_Type_GetCustomAttribute((int32)TypeId, (.)typeof(T).TypeId, null);
+				int32 attrIdx = -1;
+				Type attrType = null;
+				repeat
+				{
+					attrType = Type.[Friend]Comptime_Type_GetCustomAttributeType((int32)TypeId, ++attrIdx);
+					if (attrType == typeof(T))
+						return true;
+				}
+				while (attrType != null);
+				return false;
 			}
 
 			if (var typeInstance = this as TypeInstance)
@@ -659,9 +671,19 @@ namespace System
 		{
 			if (Compiler.IsComptime)
 			{
-				T val = ?;
-				if (Comptime_Type_GetCustomAttribute((int32)TypeId, (.)typeof(T).TypeId, &val))
-					return val;
+				int32 attrIdx = -1;
+				Type attrType = null;
+				repeat
+				{
+					attrType = Type.[Friend]Comptime_Type_GetCustomAttributeType((int32)TypeId, ++attrIdx);
+					if (attrType == typeof(T))
+					{
+						T val = ?;
+						if (Type.[Friend]Comptime_Type_GetCustomAttribute((int32)TypeId, attrIdx, &val))
+							return val;
+					}
+				}
+				while (attrType != null);
 				return .Err;
 			}
 
@@ -672,22 +694,28 @@ namespace System
 
 		public AttributeInfo.CustomAttributeEnumerator GetCustomAttributes()
 		{
-			if (Compiler.IsComptime)
-				Runtime.NotImplemented();
-
 			if (var typeInstance = this as TypeInstance)
 				return typeInstance.[Friend]GetCustomAttributes(typeInstance.[Friend]mCustomAttributesIdx);
 			Runtime.NotImplemented();
 		}
 
+		[Comptime]
+		public AttributeInfo.ComptimeTypeCustomAttributeEnumerator GetCustomAttributes()
+		{
+			return .((int32)TypeId);
+		}
+
 		public AttributeInfo.CustomAttributeEnumerator<T> GetCustomAttributes<T>() where T : Attribute
 		{
-			if (Compiler.IsComptime)
-				Runtime.NotImplemented();
-
 			if (var typeInstance = this as TypeInstance)
 				return typeInstance.[Friend]GetCustomAttributes<T>(typeInstance.[Friend]mCustomAttributesIdx);
 			Runtime.NotImplemented();
+		}
+
+		[Comptime]
+		public AttributeInfo.ComptimeTypeCustomAttributeEnumerator<T> GetCustomAttributes<T>() where T : Attribute
+		{
+			return .((int32)TypeId);
 		}
 
 		public override void ToString(String strBuffer)

--- a/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
@@ -2904,6 +2904,13 @@ BfCustomAttribute* BfCustomAttributes::Get(BfType* type)
 	return NULL;
 }
 
+BfCustomAttribute* BfCustomAttributes::Get(int idx)
+{
+	if (idx >= mAttributes.size())
+		return NULL;
+	return &mAttributes[idx];
+}
+
 //////////////////////////////////////////////////////////////////////////
 
 BfResolvedTypeSet::~BfResolvedTypeSet()

--- a/IDEHelper/Compiler/BfResolvedTypeUtils.h
+++ b/IDEHelper/Compiler/BfResolvedTypeUtils.h
@@ -2550,6 +2550,7 @@ public:
 	bool Contains(BfTypeDef* typeDef);
 	BfCustomAttribute* Get(BfTypeDef* typeDef);
 	BfCustomAttribute* Get(BfType* type);
+	BfCustomAttribute* Get(int idx);
 
 	void ReportMemory(MemReporter* memReporter);
 };

--- a/IDEHelper/Compiler/CeMachine.h
+++ b/IDEHelper/Compiler/CeMachine.h
@@ -328,6 +328,9 @@ enum CeFunctionKind
 	CeFunctionKind_Type_GetCustomAttribute,
 	CeFunctionKind_Field_GetCustomAttribute,
 	CeFunctionKind_Method_GetCustomAttribute,
+	CeFunctionKind_Type_GetCustomAttributeType,
+	CeFunctionKind_Field_GetCustomAttributeType,
+	CeFunctionKind_Method_GetCustomAttributeType,
 	CeFunctionKind_GetMethodCount,
 	CeFunctionKind_GetMethod,
 	CeFunctionKind_Method_ToString,
@@ -908,7 +911,8 @@ public:
 	bool CheckMemory(addr_ce addr, int32 size);
 	bool GetStringFromAddr(addr_ce strInstAddr, StringImpl& str);
 	bool GetStringFromStringView(addr_ce addr, StringImpl& str);
-	bool GetCustomAttribute(BfModule* module, BfIRConstHolder* constHolder, BfCustomAttributes* customAttributes, int attributeTypeId, addr_ce resultAddr);
+	bool GetCustomAttribute(BfModule* module, BfIRConstHolder* constHolder, BfCustomAttributes* customAttributes, int attributeIdx, addr_ce resultAddr);
+	BfType* GetCustomAttributeType(BfCustomAttributes* customAttributes, int attributeIdx);
 
 	bool WriteConstant(BfModule* module, addr_ce addr, BfConstant* constant, BfType* type, bool isParams = false);	
 	BfIRValue CreateConstant(BfModule* module, uint8* ptr, BfType* type, BfType** outType = NULL);	


### PR DESCRIPTION
This PR adds `GetCustomAttributes` (box-based enumerator) and `GetCustomAttributes<T>`, but be aware that currently there are 2 issues:
- ~~`GetCustomAttributes` can't box a type that doesn't have a generated "boxed type".~~ (Solved by https://github.com/beefytech/Beef/pull/1474/commits/d52ebfa1db1b7564126d42dfda52a831f51bf49e)
- ~~Comptime implementation is not implemented.~~ (Solved by https://github.com/beefytech/Beef/pull/1474/commits/3df708779d9e4431eb937024cd4cc4e26ad417f7)

