### PR TITLE
Fix `Dictionary<T>.ValueEnumerator.Key`

### DIFF
--- a/BeefLibs/corlib/src/Collections/Dictionary.bf
+++ b/BeefLibs/corlib/src/Collections/Dictionary.bf
@@ -1077,7 +1077,7 @@ namespace System.Collections
 			{
 				get
 				{
-					return ref mDictionary.mEntries[mIndex].mKey;
+					return ref mDictionary.mEntries[mIndex - 1].mKey;
 				}
 			}
 


### PR DESCRIPTION
I also noticed that `ValueEnumerator` makes a copy of the value and `CurrentRef` is a ref to this copied value... This doesn't make much sense to me, so maybe we should change this too.