### PR TITLE
Fixed negating floats during comptime

### DIFF
--- a/IDEHelper/Compiler/CeMachine.cpp
+++ b/IDEHelper/Compiler/CeMachine.cpp
@@ -7637,6 +7637,7 @@ bool CeContext::Execute(CeFunction* startFunction, uint8* startStackPtr, uint8* 
 			break;
 		case CeOp_Neg_F32:
 			CEOP_UNARY(-, float);
+			break;
 		case CeOp_Neg_F64:
 			CEOP_UNARY(-, double);
 			break;


### PR DESCRIPTION
Fixed negating floats during comptime resulting in the error "Unhandled op in comptime".

Example that didn't work and is fixed now:
```beef
static float CalcF()
{
	float g = 1.0f;
	return -g;
}

const float f = CalcF();
```