### PR TITLE
Increase StaticInitPriority of FFIType

### DIFF
--- a/BeefLibs/corlib/src/FFI/Function.bf
+++ b/BeefLibs/corlib/src/FFI/Function.bf
@@ -1,6 +1,6 @@
 namespace System.FFI
 {
-	[CRepr]
+	[CRepr, StaticInitPriority(100)]
 	struct FFIType
 	{
 		public enum TypeKind : uint16


### PR DESCRIPTION
I found an issue where `FFIType.Pointer` was being used uninitialized in `MethodInfo.Invoke`, this is fixed by increasing the static init priority  of `FFIType`.