### PR TITLE
Add in UnEscape Function for Strings

### DIFF
--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -502,6 +502,19 @@ namespace System
 				return .Err;
 			}
 
+			return UnEscapeString(ptr, length, outString);
+		}
+
+		public Result<void> UnQuoteString(String outString)
+		{
+			return UnQuoteString(Ptr, Length, outString);
+		}
+
+		public static Result<void> UnEscapeString(char8* ptr, int length, String outString)
+		{
+			if (length < 2)
+				return .Err;
+
 			var ptr;
 			ptr++;
 			char8* endPtr = ptr + length - 2;
@@ -540,15 +553,10 @@ namespace System
 			return .Ok;
 		}
 
-		public Result<void> UnQuoteString(String outString)
-		{
-			return UnQuoteString(Ptr, Length, outString);
-		}
-
-		public Result<void> UnEscapeString(String outString)
-		{
-			return UnEscapeString(Ptr, Length, outString);
-		}
+	public Result<void> UnEscapeString(String outString)
+	{
+		return UnEscapeString(Ptr, Length, outString);
+	}
 
 		static String sHexUpperChars = "0123456789ABCDEF";
 		public void ToString(String outString, String format, IFormatProvider formatProvider)

--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -545,6 +545,11 @@ namespace System
 			return UnQuoteString(Ptr, Length, outString);
 		}
 
+		public Result<void> UnEscapeString(String outString)
+		{
+			return UnEscapeString(Ptr, Length, outString);
+		}
+
 		static String sHexUpperChars = "0123456789ABCDEF";
 		public void ToString(String outString, String format, IFormatProvider formatProvider)
 		{


### PR DESCRIPTION
This turns the character combinations like \n into their literal representation.
Different from UnQuote this doesnt require Quotes and since this is the same code as UnQuote some code from there has been removed and replaced with a call to UnEscape.