### PR TITLE
make console write take stringview consistently

### DIFF
--- a/BeefLibs/corlib/src/Console.bf
+++ b/BeefLibs/corlib/src/Console.bf
@@ -212,12 +212,12 @@ namespace System
 
 		public static Result<void> ReadToEnd(String outText) => In.ReadToEnd(outText);
 
-		public static void Write(String line)
+		public static void Write(StringView line)
 		{
 			Out.Write(line).IgnoreError();
 		}
 
-		public static void Write(String fmt, params Object[] args)
+		public static void Write(StringView fmt, params Object[] args)
 		{
 			String str = scope String(256);
 			str.AppendF(fmt, params args);
@@ -239,7 +239,7 @@ namespace System
 			Out.Write("\n").IgnoreError();
 		}
 
-		public static void WriteLine(String line)
+		public static void WriteLine(StringView line)
 		{
 			Out.WriteLine(line).IgnoreError();
 		}


### PR DESCRIPTION
Console.WriteX now takes stringView, for one since it's possible. But also because the formatted WriteLine call already does that, and so when outputting a stringView, it ends up choosing the (StringView fmt, Object[] args) overload rather sneakily, doing an AppendF call which may even error if the view contains ``{``)