### PR TITLE
VarArgs multiplatform compatibility tweak

### DIFF
--- a/BeefLibs/corlib/src/Internal.bf
+++ b/BeefLibs/corlib/src/Internal.bf
@@ -66,7 +66,7 @@ namespace System
 #endif
 		}
 
-		public void** ToVAListPtr() mut
+		public void* ToVAListPtr() mut
 		{
 			return &mVAList;
 		}

--- a/BeefLibs/corlib/src/Internal.bf
+++ b/BeefLibs/corlib/src/Internal.bf
@@ -27,7 +27,7 @@ namespace System
 #if BF_PLATFORM_WINDOWS
 		void* mVAList;
 #else
-		int[3] mVAList; // Conservative size for va_list
+		int[5] mVAList; // Conservative size for va_list
 #endif
 
 		[Intrinsic("va_start")]
@@ -64,6 +64,11 @@ namespace System
 #else
 			return &mVAList;
 #endif
+		}
+
+		public void** ToVAListPtr() mut
+		{
+			return &mVAList;
 		}
 	}
 


### PR DESCRIPTION
Fix for #1520 

- Increased size of VarArgs.mVAList on non-Windows platforms
- Added ToVAListPtr() which returns &mVAList on all platforms