### PR TITLE
Remove ToVAListPtr workaround

### DIFF
--- a/BeefLibs/corlib/src/Internal.bf
+++ b/BeefLibs/corlib/src/Internal.bf
@@ -65,11 +65,6 @@ namespace System
 			return &mVAList;
 #endif
 		}
-
-		public void* ToVAListPtr() mut
-		{
-			return &mVAList;
-		}
 	}
 
 	[AlwaysInclude]


### PR DESCRIPTION
Remove `ToVAListPtr` function, as it is not actually needed to achieve cross-platform va_list interop (per #1520 discussion)