### PR TITLE
Catch Int32 case in BfTypeInstance::GetLoweredType on Aarch64

### DIFF
--- a/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
@@ -2033,6 +2033,13 @@ bool BfTypeInstance::GetLoweredType(BfTypeUsage typeUsage, BfTypeCode* outTypeCo
 					return true;
 				}
 
+				if (mInstSize <= 4)
+				{
+					if ((outTypeCode != NULL) && (writeOutCode))
+						*outTypeCode = BfTypeCode_Int32;
+					return true;
+				}
+
 				if (mInstSize <= 8)
 				{
 					if ((outTypeCode != NULL) && (writeOutCode))


### PR DESCRIPTION
Fix for #1537 (and also maybe #1521?)