### PR TITLE
[corelib- Stream] Return Ok when reaching the end of file

### DIFF
--- a/BeefLibs/corlib/src/IO/Stream.bf
+++ b/BeefLibs/corlib/src/IO/Stream.bf
@@ -145,7 +145,7 @@ namespace System.IO
 			switch (result)
 			{
 			case .Ok(let size):
-				if (size != sizeof(T))
+				if (size > 0 && size != sizeof(T))
 					return .Err;
 				return .Ok(val);
 			case .Err:


### PR DESCRIPTION
When reaching the end of the file the result of size is 0 and returns error.
Maybe it's necessary to apply this logic in other sections of the code.