### PR TITLE
added proper checking for double.Parse

### DIFF
--- a/BeefLibs/corlib/src/Double.bf
+++ b/BeefLibs/corlib/src/Double.bf
@@ -186,6 +186,20 @@ namespace System
 		public static Result<double> Parse(StringView val)
 		{
 			var tempStr = scope String(val);
+			int count = 0;
+			L:for(char8 c in val)
+			{
+				if(c.IsDigit)
+					continue L;
+				else if(c == '.')
+				{
+					count++;
+					if(count > 0)
+						return .Err;
+				}
+				//This doesnt handle other writing styles yet (hex etc.)
+				return .Err
+			}
 			return .Ok(strtod(tempStr, null));
 		}
 

--- a/BeefLibs/corlib/src/Double.bf
+++ b/BeefLibs/corlib/src/Double.bf
@@ -194,7 +194,7 @@ namespace System
 				else if(c == '.')
 				{
 					count++;
-					if(count > 0)
+					if(count > 1)
 						return .Err;
 				}
 				//This doesnt handle other writing styles yet (hex etc.)


### PR DESCRIPTION
it now loops through the string and errors if it find something that isnt a . or a digit
and counts the amount of .


other parsing functions would have to be redone in a similar matter later