### PR TITLE
Allow appending Object to String

### DIFF
--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -1037,6 +1037,13 @@ namespace System
 				}
 			}
 		}
+		
+		public void Append(Object object)
+		{
+			if (object == null)
+				return;
+			Append(object.ToString(.. scope .()));
+		}
 
 		public void operator+=(String str)
 		{
@@ -1056,6 +1063,11 @@ namespace System
 		public void operator+=(char32 c)
 		{
 			Append(c);
+		}
+
+		public void operator+=(Object obj)
+		{
+			Append(obj);
 		}
 
 		[Error("String addition is not supported. Consider allocating a new string and using Append, Concat, or +=")]


### PR DESCRIPTION
This PR adds the Append overload for `Object` and the `operator+=` for `Object` in the String class.