### PR TITLE
Fail build when `execute_process` fails

### DIFF
--- a/BeefBoot/CMakeLists.txt
+++ b/BeefBoot/CMakeLists.txt
@@ -137,7 +137,16 @@ execute_process(
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/bin/llvm-config --system-libs --link-static
   OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
   OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE EXEC_RESULT
 )
+
+if (EXEC_RESULT AND NOT EXEC_RESULT EQUAL 0)
+  if (EXEC_RESULT MATCHES "^[0-9]+$")
+    message(FATAL_ERROR "llvm-config exited with code ${EXEC_RESULT}.")
+  else()
+    message(FATAL_ERROR "llvm-config couldn't be executed: ${EXEC_RESULT}")
+  endif()
+endif()
 
 if (${APPLE})
     set(TARGET_LIBS_OS "")

--- a/IDEHelper/CMakeLists.txt
+++ b/IDEHelper/CMakeLists.txt
@@ -195,8 +195,17 @@ add_library(${PROJECT_NAME} SHARED
 execute_process(
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/bin/llvm-config --system-libs --link-static
   OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
-  OUTPUT_STRIP_TRAILING_WHITESPACE  
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE EXEC_RESULT
 )
+
+if (EXEC_RESULT AND NOT EXEC_RESULT EQUAL 0)
+  if (EXEC_RESULT MATCHES "^[0-9]+$")
+    message(FATAL_ERROR "llvm-config exited with code ${EXEC_RESULT}.")
+  else()
+    message(FATAL_ERROR "llvm-config couldn't be executed: ${EXEC_RESULT}")
+  endif()
+endif()
 
 set(TARGET_LIBS_OS "${LLVM_SYSTEM_LIBS}")
 


### PR DESCRIPTION
This is something that always annoyed me since the error caused by the failure of `execute_process` is really cryptic (https://github.com/beefytech/Beef/issues/418#issue-656171643).
Thi PR makes the failure of `execute_process` to also immediately cause the build to fail, and it makes clear the cause of the build failure.