### PR TITLE
Fix LoadTextFile failure when in autoRetry

### DIFF
--- a/BeefLibs/Beefy2D/src/Utils.bf
+++ b/BeefLibs/Beefy2D/src/Utils.bf
@@ -170,7 +170,7 @@ namespace Beefy
 					if (autoRetry)
 					{
 						if (fileOpenErr == .SharingViolation)
-							retry = true;
+							retry = i != 99;
 					}
 					if (!retry)
                     	return .Err(.OpenError(fileOpenErr));


### PR DESCRIPTION
This PR makes LoadTextFile properly fail when we are at the last attempt on retrying to open the file. Without this change, the IDE crashes when trying to use the FileStream that wasn't successfully opened.