### PR TITLE
Also use `c_wchar` in `StringView.ToScopedNativeWChar`

### DIFF
--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -4107,18 +4107,21 @@ namespace System
 		public mixin ToScopedNativeWChar()
 		{
 			int encodedLen = UTF16.GetEncodedLen(this);
-			char16* buf;
+			c_wchar* buf;
 			if (encodedLen < 128)
 			{
-				buf = scope:mixin char16[encodedLen+1]* ( ? );
+				buf = scope:mixin c_wchar[encodedLen+1]* ( ? );
 			}
 			else
 			{
-				buf = new char16[encodedLen+1]* ( ? );
+				buf = new c_wchar[encodedLen+1]* ( ? );
 				defer:mixin delete buf;
 			}
 
-			UTF16.Encode(this, buf, encodedLen);
+			if (sizeof(c_wchar) == 2)
+				UTF16.Encode(this, (.)buf, encodedLen);
+			else
+				UTF32.Encode(this, (.)buf, encodedLen);
 			buf[encodedLen] = 0;
 			buf
 		}


### PR DESCRIPTION
Looks like at some point `String.ToScopedNativeWChar` was changed to use `c_wchar` instead of `char16`, but `StringView.ToScopedNativeWChar` wasn't changed. This PR fixes this.