### PR TITLE
Add Ninja as a optional CMake Generator

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,12 +4,28 @@ echo Starting build.sh
 PATH=/usr/local/bin:$PATH:$HOME/bin
 SCRIPTPATH=$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 ROOTPATH="$(dirname "$SCRIPTPATH")"
-echo Building from from $SCRIPTPATH
+echo Building from $SCRIPTPATH
 cd $SCRIPTPATH
 
-USE_NINJA=""
+if [[ $1 == "clean" ]]; then
+	rm -rf ../jbuild
+	rm -rf ../jbuild_d
+fi
+
 if command -v ninja >/dev/null 2>&1 ; then
-    USE_NINJA="-GNinja"
+	CAN_USE_NINJA=1
+	if [ -d ../jbuild_d ] && [ ! -f ../jbuild_d/build.ninja ]; then
+		CAN_USE_NINJA=0
+	fi
+
+	if [ $CAN_USE_NINJA == 1 ]; then
+		echo "Ninja is enabled for this build."
+		USE_NINJA="-GNinja"
+	else
+		echo "Ninja couldn't be enabled for this build, consider doing a clean build to start using Ninja for faster build speeds."
+	fi
+else
+	echo "Ninja isn't installed, consider installing it for faster build speeds."
 fi
 
 # exit when any command fails

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -7,6 +7,11 @@ ROOTPATH="$(dirname "$SCRIPTPATH")"
 echo Building from from $SCRIPTPATH
 cd $SCRIPTPATH
 
+USE_NINJA=""
+if command -v ninja >/dev/null 2>&1 ; then
+    USE_NINJA="-GNinja"
+fi
+
 # exit when any command fails
 set -e
 
@@ -35,10 +40,10 @@ if [ ! -d jbuild_d ]; then
 	mkdir jbuild
 fi
 cd jbuild_d
-cmake -DCMAKE_BUILD_TYPE=Debug ../
+cmake $USE_NINJA -DCMAKE_BUILD_TYPE=Debug ../
 cmake --build .
 cd ../jbuild
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ../
+cmake $USE_NINJA -DCMAKE_BUILD_TYPE=RelWithDebInfo ../
 cmake --build .
 
 cd ../IDE/dist

--- a/extern/llvm_build.sh
+++ b/extern/llvm_build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+USE_NINJA=""
+if command -v ninja >/dev/null 2>&1 ; then
+    USE_NINJA="-GNinja"
+fi
+
 if [ ! -d llvm-project_13_0_1 ]; then
 	if [ -f llvm-13.0.1.src.tar.xz ]; then # if user downloaded llvm-13.0.1.src.tar.xz then use it instead
 		tar -xf llvm-13.0.1.src.tar.xz
@@ -17,7 +22,7 @@ fi
 
 if [ ! -d llvm_linux_13_0_1/bin ]; then
 	cd llvm_linux_13_0_1
-	cmake ../llvm-project_13_0_1/llvm -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86;WebAssembly" -DCMAKE_BUILD_TYPE:String="Debug"
+	cmake $USE_NINJA ../llvm-project_13_0_1/llvm -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86;WebAssembly" -DCMAKE_BUILD_TYPE:String="Debug"
 	cmake --build . -t $(cat ../llvm_targets.txt)
 	cd ..
 fi
@@ -28,7 +33,7 @@ fi
 
 if [ ! -d llvm_linux_rel_13_0_1/bin ]; then
 	cd llvm_linux_rel_13_0_1
-	cmake ../llvm-project_13_0_1/llvm -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86;WebAssembly" -DCMAKE_BUILD_TYPE:String="Release"
+	cmake $USE_NINJA ../llvm-project_13_0_1/llvm -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86;WebAssembly" -DCMAKE_BUILD_TYPE:String="Release"
 	cmake --build . -t $(cat ../llvm_targets.txt)
 	cd ..
 fi


### PR DESCRIPTION
This PR allows the Beef's build script to use Ninja for building if Ninja is installed and the CMakeFiles doesn't exist or were generated by Ninja, I did it this way so not to break anything and not impose Ninja as a requirement, but maybe making Ninja a requirement wouldn't be a bad idea too :)

Here is a benchmark that I did using `time` compiling a clean build:
```
Ninja:
real	2m25.508s
user	9m52.981s
sys	0m32.548s

Without ninja:
real	8m38.425s
user	8m5.723s
sys	0m30.840s
```