### PR TITLE
fix compiler warning about unused variable on linux

### DIFF
--- a/BeefBoot/CMakeLists.txt
+++ b/BeefBoot/CMakeLists.txt
@@ -27,9 +27,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 # Definition of Macros
-add_definitions(   
-   -DIDEHELPER_EXPORTS 
-   -DBFSYSLIB_DYNAMIC 
+add_definitions(
+   -DIDEHELPER_EXPORTS
+   -DBFSYSLIB_DYNAMIC
    -DUNICODE
    -D_UNICODE
    -DBF_NO_FBX
@@ -41,10 +41,10 @@ if (${APPLE})
   include_directories(
     .
     ../
-    ../BeefySysLib/    
+    ../BeefySysLib/
     ../BeefySysLib/third_party
-    ../BeefySysLib/third_party/freetype/include    
-    ../extern/llvm-project_13_0_1/llvm/include  
+    ../BeefySysLib/third_party/freetype/include
+    ../extern/llvm-project_13_0_1/llvm/include
     ../extern/llvm-project_13_0_1/llvm/lib/Target
     ../IDEHelper
 
@@ -54,14 +54,14 @@ else()
   include_directories(
     .
     ../
-    ../BeefySysLib/    
+    ../BeefySysLib/
     ../BeefySysLib/third_party
-    ../BeefySysLib/third_party/freetype/include    
-    ../extern/llvm-project_13_0_1/llvm/include  
+    ../BeefySysLib/third_party/freetype/include
+    ../extern/llvm-project_13_0_1/llvm/include
     ../extern/llvm-project_13_0_1/llvm/lib/Target
     ../IDEHelper
 
-    ../BeefySysLib/platform/linux    
+    ../BeefySysLib/platform/linux
   )
 endif()
 
@@ -69,7 +69,7 @@ endif()
 # Defines outputs , depending Debug or Release. #
 #################################################
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")  
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(
     -D_DEBUG
   )
@@ -85,23 +85,23 @@ else()
     ../extern/llvm_linux_rel_13_0_1/lib/Target/X86
   )
   set(EXECUTABLE_OUTPUT_PATH  "${CMAKE_BINARY_DIR}/${OUTPUT_RELEASE}")
-  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")    
+  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")
 endif()
 
 ################### Dependencies ##################
 # Add Dependencies to project.                    #
 ###################################################
 
-option(BUILD_DEPENDS 
-   "Build other CMake project." 
-   ON 
+option(BUILD_DEPENDS
+   "Build other CMake project."
+   ON
 )
 
 # Dependencies : disable BUILD_DEPENDS to link with lib already build.
 if(BUILD_DEPENDS)
-   
+
 else()
-   
+
 endif()
 
 ################# Flags ################
@@ -113,7 +113,7 @@ if(MSVC)
    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /GL /Od /Oi /Gy /EHsc")
 endif(MSVC)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wno-multichar -Wno-invalid-offsetof")  
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wno-multichar -Wno-invalid-offsetof")
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
   endif()
@@ -161,10 +161,10 @@ endif()
 if(MSVC)
    target_link_libraries(${PROJECT_NAME} BeefySysLib IDEHelper kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib)
 else()
-    target_link_libraries(${PROJECT_NAME} BeefySysLib 
-        IDEHelper 
+    target_link_libraries(${PROJECT_NAME} BeefySysLib
+        IDEHelper
         ${TARGET_LIBS_OS}
-        
-        #${LLVM_LIB}/libLLVMSupport.a 
-        )    
+
+        #${LLVM_LIB}/libLLVMSupport.a
+        )
 endif()

--- a/BeefFuzz/CMakeLists.txt
+++ b/BeefFuzz/CMakeLists.txt
@@ -27,9 +27,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 # Definition of Macros
-add_definitions(   
-   -DIDEHELPER_EXPORTS 
-   -DBFSYSLIB_DYNAMIC 
+add_definitions(
+   -DIDEHELPER_EXPORTS
+   -DBFSYSLIB_DYNAMIC
    -DUNICODE
    -D_UNICODE
    -DBF_NO_FBX
@@ -41,10 +41,10 @@ if (${APPLE})
   include_directories(
     .
     ../
-    ../BeefySysLib/    
+    ../BeefySysLib/
     ../BeefySysLib/third_party
-    ../BeefySysLib/third_party/freetype/include    
-    ../extern/llvm-project_13_0_1/llvm/include  
+    ../BeefySysLib/third_party/freetype/include
+    ../extern/llvm-project_13_0_1/llvm/include
     ../extern/llvm-project_13_0_1/llvm/lib/Target
     ../IDEHelper
 
@@ -54,14 +54,14 @@ else()
   include_directories(
     .
     ../
-    ../BeefySysLib/    
+    ../BeefySysLib/
     ../BeefySysLib/third_party
-    ../BeefySysLib/third_party/freetype/include    
-    ../extern/llvm-project_13_0_1/llvm/include  
+    ../BeefySysLib/third_party/freetype/include
+    ../extern/llvm-project_13_0_1/llvm/include
     ../extern/llvm-project_13_0_1/llvm/lib/Target
     ../IDEHelper
 
-    ../BeefySysLib/platform/linux    
+    ../BeefySysLib/platform/linux
   )
 endif()
 
@@ -69,7 +69,7 @@ endif()
 # Defines outputs , depending Debug or Release. #
 #################################################
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")  
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(
     -D_DEBUG
   )
@@ -85,23 +85,23 @@ else()
     ../extern/llvm_linux_rel_13_0_1/lib/Target/X86
   )
   set(EXECUTABLE_OUTPUT_PATH  "${CMAKE_BINARY_DIR}/${OUTPUT_RELEASE}")
-  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")    
+  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")
 endif()
 
 ################### Dependencies ##################
 # Add Dependencies to project.                    #
 ###################################################
 
-option(BUILD_DEPENDS 
-   "Build other CMake project." 
-   ON 
+option(BUILD_DEPENDS
+   "Build other CMake project."
+   ON
 )
 
 # Dependencies : disable BUILD_DEPENDS to link with lib already build.
 if(BUILD_DEPENDS)
-   
+
 else()
-   
+
 endif()
 
 ################# Flags ################
@@ -160,10 +160,10 @@ endif()
 if(MSVC)
    target_link_libraries(${PROJECT_NAME} BeefySysLib IDEHelper kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib)
 else()
-    target_link_libraries(${PROJECT_NAME} BeefySysLib 
-        IDEHelper 
+    target_link_libraries(${PROJECT_NAME} BeefySysLib
+        IDEHelper
         ${TARGET_LIBS_OS}
-        
-        #${LLVM_LIB}/libLLVMSupport.a 
-        )    
+
+        #${LLVM_LIB}/libLLVMSupport.a
+        )
 endif()

--- a/BeefRT/CMakeLists.txt
+++ b/BeefRT/CMakeLists.txt
@@ -25,9 +25,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 # Definition of Macros
-add_definitions(   
-   -DIDEHELPER_EXPORTS 
-   -DBFSYSLIB_DYNAMIC 
+add_definitions(
+   -DIDEHELPER_EXPORTS
+   -DBFSYSLIB_DYNAMIC
    -DUNICODE
    -D_UNICODE
    -DBF_NO_FBX
@@ -45,16 +45,16 @@ if (HAVE_BACKTRACE_HEADERS)
    add_definitions(-DBFP_HAS_BACKTRACE)
 endif ()
 
-if (${IOS})  
+if (${IOS})
   include_directories(
     .
-    ../BeefySysLib/  
+    ../BeefySysLib/
     ../BeefySysLib/third_party
     ../BeefySysLib/third_party/freetype/include
     ../BeefySysLib/third_party/libffi/build_iphoneos-arm64/include
-    ../  
+    ../
     ../extern
-    ../extern/llvm/include  
+    ../extern/llvm/include
     ../extern/llvm_linux/include
     ../extern/llvm/lib/Target
 
@@ -63,13 +63,13 @@ if (${IOS})
 elseif (${APPLE})
   include_directories(
     .
-    ../BeefySysLib/  
+    ../BeefySysLib/
     ../BeefySysLib/third_party
     ../BeefySysLib/third_party/freetype/include
     ../BeefySysLib/third_party/libffi/x86_64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}/include
-    ../  
+    ../
     ../extern
-    ../extern/llvm/include  
+    ../extern/llvm/include
     ../extern/llvm_linux/include
     ../extern/llvm/lib/Target
 
@@ -79,13 +79,13 @@ elseif (${ANDROID})
   if (ANDROID_ABI STREQUAL "x86")
     include_directories(
       .
-      ../BeefySysLib/  
+      ../BeefySysLib/
       ../BeefySysLib/third_party
       ../BeefySysLib/third_party/freetype/include
       ../BeefySysLib/third_party/libffi/i686-pc-linux-gnu/include
-      ../  
+      ../
       ../extern
-      ../extern/llvm/include  
+      ../extern/llvm/include
       ../extern/llvm_linux/include
       ../extern/llvm/lib/Target
 
@@ -94,13 +94,13 @@ elseif (${ANDROID})
   elseif (ANDROID_ABI STREQUAL "x86_64")
     include_directories(
       .
-      ../BeefySysLib/  
+      ../BeefySysLib/
       ../BeefySysLib/third_party
       ../BeefySysLib/third_party/freetype/include
       ../BeefySysLib/third_party/libffi/x86_64-pc-linux-gnu/include
-      ../  
+      ../
       ../extern
-      ../extern/llvm/include  
+      ../extern/llvm/include
       ../extern/llvm_linux/include
       ../extern/llvm/lib/Target
 
@@ -109,28 +109,28 @@ elseif (${ANDROID})
   elseif (ANDROID_ABI STREQUAL "armeabi-v7a")
     include_directories(
       .
-      ../BeefySysLib/  
+      ../BeefySysLib/
       ../BeefySysLib/third_party
       ../BeefySysLib/third_party/freetype/include
       ../BeefySysLib/third_party/libffi/arm-unknown-linux-gnu/include
-      ../  
+      ../
       ../extern
-      ../extern/llvm/include  
+      ../extern/llvm/include
       ../extern/llvm_linux/include
       ../extern/llvm/lib/Target
 
       ../BeefySysLib/platform/android
     )
-  else()    
+  else()
     include_directories(
       .
-      ../BeefySysLib/  
+      ../BeefySysLib/
       ../BeefySysLib/third_party
       ../BeefySysLib/third_party/freetype/include
       ../BeefySysLib/third_party/libffi/aarch64-unknown-linux-gnu/include
-      ../  
+      ../
       ../extern
-      ../extern/llvm/include  
+      ../extern/llvm/include
       ../extern/llvm_linux/include
       ../extern/llvm/lib/Target
 
@@ -140,13 +140,13 @@ elseif (${ANDROID})
 else()
   include_directories(
     .
-    ../BeefySysLib/  
+    ../BeefySysLib/
     ../BeefySysLib/third_party
     ../BeefySysLib/third_party/freetype/include
     ../BeefySysLib/third_party/libffi/x86_64-unknown-linux-gnu/include
-    ../  
+    ../
     ../extern
-    ../extern/llvm/include  
+    ../extern/llvm/include
     ../extern/llvm_linux/include
     ../extern/llvm/lib/Target
 
@@ -175,16 +175,16 @@ endif()
 # Add Dependencies to project.                    #
 ###################################################
 
-option(BUILD_DEPENDS 
-   "Build other CMake project." 
-   ON 
+option(BUILD_DEPENDS
+   "Build other CMake project."
+   ON
 )
 
 # Dependencies : disable BUILD_DEPENDS to link with lib already build.
 if(BUILD_DEPENDS)
-   
+
 else()
-   
+
 endif()
 
 ################# Flags ################
@@ -196,14 +196,14 @@ if(MSVC)
    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /GL /Od /Oi /Gy /EHsc")
 endif(MSVC)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -Wno-multichar -Wno-invalid-offsetof")    
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -Wno-multichar -Wno-invalid-offsetof")
 endif(NOT MSVC)
 
 ################ Files ################
 #   --   Add files to project.   --   #
 #######################################
 
-file(GLOB SRC_FILES        
+file(GLOB SRC_FILES
     rt/Internal.cpp
     rt/Chars.cpp
     rt/Object.cpp
@@ -283,10 +283,10 @@ endif()
 
 if (${APPLE})
   target_link_libraries(${PROJECT_NAME} pthread ffi)
-elseif (${ANDROID})  
+elseif (${ANDROID})
   #target_link_libraries(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/../BeefySysLib/third_party/libffi/aarch64-unknown-linux-gnu/.libs/libffi.a)
   #target_link_libraries(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/../BeefySysLib/third_party/libffi/i686-pc-linux-gnu/.libs/libffi.a)
-else()  
+else()
   target_link_libraries(${PROJECT_NAME} pthread ffi ${TARGET_LIBS_OS})
 endif()
 

--- a/BeefTools/BeefMem/CMakeLists.txt
+++ b/BeefTools/BeefMem/CMakeLists.txt
@@ -23,9 +23,9 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 # Definition of Macros
 add_definitions(
-   -D_DEBUG   
-   -DIDEHELPER_EXPORTS 
-   -DBFSYSLIB_DYNAMIC 
+   -D_DEBUG
+   -DIDEHELPER_EXPORTS
+   -DBFSYSLIB_DYNAMIC
    -DUNICODE
    -D_UNICODE
    -DBF_NO_FBX
@@ -40,9 +40,9 @@ include_directories(
   ../BeefySysLib/third_party
   ../BeefySysLib/third_party/freetype/include
   ../BeefySysLib/third_party/libffi/x86_64-unknown-linux-gnu/include
-  ../  
+  ../
   ../extern
-  ../extern/llvm/include  
+  ../extern/llvm/include
   ../extern/llvm_linux/include
   ../extern/llvm/lib/Target
   ../extern/llvm_linux/lib/Target/X86
@@ -66,16 +66,16 @@ endif()
 # Add Dependencies to project.                    #
 ###################################################
 
-option(BUILD_DEPENDS 
-   "Build other CMake project." 
-   ON 
+option(BUILD_DEPENDS
+   "Build other CMake project."
+   ON
 )
 
 # Dependencies : disable BUILD_DEPENDS to link with lib already build.
 if(BUILD_DEPENDS)
-   
+
 else()
-   
+
 endif()
 
 ################# Flags ################
@@ -87,7 +87,7 @@ if(MSVC)
    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /GL /Od /Oi /Gy /EHsc")
 endif(MSVC)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -Wno-multichar -Wno-invalid-offsetof")  
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -Wno-multichar -Wno-invalid-offsetof")
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
   endif()
@@ -97,8 +97,8 @@ endif(NOT MSVC)
 #   --   Add files to project.   --   #
 #######################################
 
-file(GLOB SRC_FILES    
-    
+file(GLOB SRC_FILES
+
 )
 
 # Add library to build.

--- a/BeefySysLib/CMakeLists.txt
+++ b/BeefySysLib/CMakeLists.txt
@@ -24,8 +24,8 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 # Definition of Macros
 add_definitions(
-   -DIDEHELPER_EXPORTS 
-   -DBFSYSLIB_DYNAMIC 
+   -DIDEHELPER_EXPORTS
+   -DBFSYSLIB_DYNAMIC
    -DUNICODE
    -D_UNICODE
    -DBF_NO_FBX
@@ -82,16 +82,16 @@ endif()
 # Add Dependencies to project.                    #
 ###################################################
 
-option(BUILD_DEPENDS 
-   "Build other CMake project." 
-   ON 
+option(BUILD_DEPENDS
+   "Build other CMake project."
+   ON
 )
 
 # Dependencies : disable BUILD_DEPENDS to link with lib already build.
 if(BUILD_DEPENDS)
-   
+
 else()
-   
+
 endif()
 
 ################# Flags ################
@@ -103,7 +103,7 @@ if(MSVC)
    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /GL /Od /Oi /Gy /EHsc")
 endif(MSVC)
 if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-multichar")  
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-multichar")
 endif(NOT MSVC)
 
 ################ Files ################
@@ -119,9 +119,9 @@ file(GLOB SRC_FILES
     DataStream.cpp
     FileStream.cpp
     HeadlessApp.cpp
-    MemStream.cpp      
-    ResLib.cpp    
-    Startup.cpp    
+    MemStream.cpp
+    ResLib.cpp
+    Startup.cpp
 
     fbx/FBXReader.cpp
     gfx/DrawLayer.cpp
@@ -132,7 +132,7 @@ file(GLOB SRC_FILES
     gfx/RenderDevice.cpp
     gfx/RenderTarget.cpp
     gfx/Shader.cpp
-    gfx/Texture.cpp    
+    gfx/Texture.cpp
     img/BFIData.cpp
     img/ImageAdjustments.cpp
     img/ImageData.cpp
@@ -142,8 +142,8 @@ file(GLOB SRC_FILES
     img/PNGData.cpp
     img/PSDReader.cpp
     img/PVRData.cpp
-    img/TGAData.cpp    
-    
+    img/TGAData.cpp
+
     third_party/freetype/src/autofit/autofit.c
     third_party/freetype/src/base/ftbase.c
     third_party/freetype/src/base/ftbbox.c
@@ -324,6 +324,6 @@ add_library(${PROJECT_NAME} SHARED
 
 # Link with other dependencies.
 if(MSVC)
-   target_link_libraries(${PROJECT_NAME} imm32.lib version.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib 
+   target_link_libraries(${PROJECT_NAME} imm32.lib version.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib
         )
 endif(MSVC)

--- a/IDE/src/BuildContext.bf
+++ b/IDE/src/BuildContext.bf
@@ -634,7 +634,7 @@ namespace IDE
 					IDEUtils.FixFilePath(llvmDir);
 					llvmDir.Append("llvm/");
 #else
-					String llvmDir = "";					
+					//String llvmDir = "";
 #endif
 					if (gApp.mSettings.mEmscriptenPath.IsEmpty)
 					{

--- a/IDEHelper/CMakeLists.txt
+++ b/IDEHelper/CMakeLists.txt
@@ -24,8 +24,8 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 # Definition of Macros
 add_definitions(
-   -DIDEHELPER_EXPORTS 
-   -DBFSYSLIB_DYNAMIC 
+   -DIDEHELPER_EXPORTS
+   -DBFSYSLIB_DYNAMIC
    -DUNICODE
    -D_UNICODE
    -DBF_NO_FBX
@@ -39,17 +39,17 @@ set (CMAKE_CXX_STANDARD 14)
 INCLUDE(CheckIncludeFiles)
 CHECK_INCLUDE_FILES(backtrace.h HAVE_BACKTRACE_HEADERS)
 if (HAVE_BACKTRACE_HEADERS)
-   add_definitions(-DBFP_HAS_BACKTRACE) 
+   add_definitions(-DBFP_HAS_BACKTRACE)
 endif ()
 
 if (${APPLE})
   include_directories(
     .
     ../
-    ../BeefySysLib/    
+    ../BeefySysLib/
     ../BeefySysLib/third_party
-    ../BeefySysLib/third_party/freetype/include    
-    ../extern/llvm-project_13_0_1/llvm/include  
+    ../BeefySysLib/third_party/freetype/include
+    ../extern/llvm-project_13_0_1/llvm/include
     ../extern/llvm-project_13_0_1/llvm/lib/Target
 
     ../BeefySysLib/platform/osx
@@ -58,13 +58,13 @@ else()
   include_directories(
     .
     ../
-    ../BeefySysLib/    
+    ../BeefySysLib/
     ../BeefySysLib/third_party
-    ../BeefySysLib/third_party/freetype/include    
-    ../extern/llvm-project_13_0_1/llvm/include  
+    ../BeefySysLib/third_party/freetype/include
+    ../extern/llvm-project_13_0_1/llvm/include
     ../extern/llvm-project_13_0_1/llvm/lib/Target
 
-    ../BeefySysLib/platform/linux    
+    ../BeefySysLib/platform/linux
   )
 endif()
 
@@ -101,16 +101,16 @@ endif()
 # Add Dependencies to project.                    #
 ###################################################
 
-option(BUILD_DEPENDS 
-   "Build other CMake project." 
-   ON 
+option(BUILD_DEPENDS
+   "Build other CMake project."
+   ON
 )
 
 # Dependencies : disable BUILD_DEPENDS to link with lib already build.
 if(BUILD_DEPENDS)
-   
+
 else()
-   
+
 endif()
 
 ################# Flags ################
@@ -130,7 +130,7 @@ endif(NOT MSVC)
 #######################################
 
 file(GLOB SRC_FILES
-    BfDiff.cpp    
+    BfDiff.cpp
     Debugger.cpp
     DebugManager.cpp
     DebugVisualizers.cpp
@@ -143,8 +143,8 @@ file(GLOB SRC_FILES
     X86XmmInfo.cpp
 
     LinuxDebugger.cpp
-        
-    Beef/BfCommon.cpp    
+
+    Beef/BfCommon.cpp
     Clang/CDepChecker.cpp
     Clang/ClangHelper.cpp
     Compiler/BfAst.cpp
@@ -181,7 +181,7 @@ file(GLOB SRC_FILES
     Compiler/CeMachine.cpp
     Compiler/CeDebugger.cpp
     Compiler/MemReporter.cpp
-    
+
     Backend/BeContext.cpp
     Backend/BeIRCodeGen.cpp
     Backend/BeModule.cpp
@@ -218,18 +218,18 @@ list(APPEND LLVM_LIBS
   ${LLVM_LIB}/libLLVMCore.a
   ${LLVM_LIB}/libLLVMCodeGen.a
   ${LLVM_LIB}/libLLVMMC.a
-  ${LLVM_LIB}/libLLVMMCParser.a  
-  ${LLVM_LIB}/libLLVMMCDisassembler.a    
+  ${LLVM_LIB}/libLLVMMCParser.a
+  ${LLVM_LIB}/libLLVMMCDisassembler.a
   ${LLVM_LIB}/libLLVMObject.a
   ${LLVM_LIB}/libLLVMBitReader.a
-  ${LLVM_LIB}/libLLVMAsmParser.a    
-  ${LLVM_LIB}/libLLVMTarget.a    
+  ${LLVM_LIB}/libLLVMAsmParser.a
+  ${LLVM_LIB}/libLLVMTarget.a
   ${LLVM_LIB}/libLLVMScalarOpts.a
   ${LLVM_LIB}/libLLVMInstCombine.a
   ${LLVM_LIB}/libLLVMSelectionDAG.a
   ${LLVM_LIB}/libLLVMProfileData.a
-    
-  ${LLVM_LIB}/libLLVMAnalysis.a    
+
+  ${LLVM_LIB}/libLLVMAnalysis.a
   ${LLVM_LIB}/libLLVMAsmPrinter.a
   ${LLVM_LIB}/libLLVMBitWriter.a
   ${LLVM_LIB}/libLLVMVectorize.a
@@ -237,21 +237,21 @@ list(APPEND LLVM_LIBS
   ${LLVM_LIB}/libLLVMInstrumentation.a
   ${LLVM_LIB}/libLLVMDebugInfoDWARF.a
   ${LLVM_LIB}/libLLVMDebugInfoPDB.a
-  ${LLVM_LIB}/libLLVMDebugInfoCodeView.a  
+  ${LLVM_LIB}/libLLVMDebugInfoCodeView.a
   ${LLVM_LIB}/libLLVMGlobalISel.a
   ${LLVM_LIB}/libLLVMTransformUtils.a
-  ${LLVM_LIB}/libLLVMBinaryFormat.a    
+  ${LLVM_LIB}/libLLVMBinaryFormat.a
   ${LLVM_LIB}/libLLVMIRReader.a
-  ${LLVM_LIB}/libLLVMLinker.a    
+  ${LLVM_LIB}/libLLVMLinker.a
   ${LLVM_LIB}/libLLVMAggressiveInstCombine.a
 
-  ${LLVM_LIB}/libLLVMBitstreamReader.a  
+  ${LLVM_LIB}/libLLVMBitstreamReader.a
   ${LLVM_LIB}/libLLVMCFGuard.a
   ${LLVM_LIB}/libLLVMTextAPI.a
   ${LLVM_LIB}/libLLVMRemarks.a
 
-  ${LLVM_LIB}/libLLVMX86Info.a    
-  ${LLVM_LIB}/libLLVMX86Desc.a    
+  ${LLVM_LIB}/libLLVMX86Info.a
+  ${LLVM_LIB}/libLLVMX86Desc.a
   ${LLVM_LIB}/libLLVMX86CodeGen.a
   ${LLVM_LIB}/libLLVMX86AsmParser.a
   ${LLVM_LIB}/libLLVMX86Disassembler.a
@@ -282,7 +282,7 @@ list(APPEND LLVM_LIBS
 
 FOREACH (lib ${LLVM_LIBS})
   string(APPEND TARGET_LIBS_OS " " ${lib})
-ENDFOREACH()  
+ENDFOREACH()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug" )
   FILE(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/../IDE/dist/IDEHelper_libs_d.txt" ${TARGET_LIBS_OS})
@@ -294,7 +294,7 @@ endif()
 if(MSVC)
   target_link_libraries(${PROJECT_NAME} BeefySysLib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib LLVMX86Disassembler.lib LLVMMCDisassembler.lib LLVMSupport.lib LLVMX86Info.lib LLVMX86Desc.lib %(AdditionalDependencies) LLVMMC.lib LLVMObject.lib LLVMCore.lib LLVMBitReader.lib LLVMAsmParser.lib LLVMMCParser.lib LLVMCodeGen.lib LLVMTarget.lib LLVMX86CodeGen.lib LLVMScalarOpts.lib LLVMInstCombine.lib LLVMSelectionDAG.lib LLVMProfileData.lib LLVMTransformUtils.lib LLVMAnalysis.lib LLVMX86AsmParser.lib LLVMAsmPrinter.lib LLVMBitWriter.lib LLVMVectorize.lib LLVMipo.lib LLVMInstrumentation.lib LLVMDebugInfoDWARF.lib LLVMDebugInfoPDB.lib LLVMDebugInfoCodeView.lib LLVMGlobalISel.lib LLVMBinaryFormat.lib LLVMAggressiveInstCombine.lib libcurl_a.lib)
 else()
-  target_link_libraries(${PROJECT_NAME} BeefySysLib hunspell pthread dl ${TARGET_LIBS_OS}    
-        
+  target_link_libraries(${PROJECT_NAME} BeefySysLib hunspell pthread dl ${TARGET_LIBS_OS}
+
   )
 endif()

--- a/extern/hunspell/CMakeLists.txt
+++ b/extern/hunspell/CMakeLists.txt
@@ -24,9 +24,9 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 # Definition of Macros
 add_definitions(
-   -D_DEBUG   
-   -DIDEHELPER_EXPORTS 
-   -DBFSYSLIB_DYNAMIC 
+   -D_DEBUG
+   -DIDEHELPER_EXPORTS
+   -DBFSYSLIB_DYNAMIC
    -DUNICODE
    -D_UNICODE
    -DBF_NO_FBX
@@ -57,16 +57,16 @@ endif()
 # Add Dependencies to project.                    #
 ###################################################
 
-option(BUILD_DEPENDS 
-   "Build other CMake project." 
-   ON 
+option(BUILD_DEPENDS
+   "Build other CMake project."
+   ON
 )
 
 # Dependencies : disable BUILD_DEPENDS to link with lib already build.
 if(BUILD_DEPENDS)
-   
+
 else()
-   
+
 endif()
 
 ################# Flags ################


### PR DESCRIPTION
i get a compiler warning when building on linux.
variable "llvmDir" is unused.

simply commenting that line fixes it.
can build without issues now.