### PR TITLE
Add assert to Span<T>.RemoveFromEnd

### DIFF
--- a/BeefLibs/corlib/src/Span.bf
+++ b/BeefLibs/corlib/src/Span.bf
@@ -276,6 +276,7 @@ namespace System
 
 		public void RemoveFromEnd(int length) mut
 		{
+			Debug.Assert((uint)length <= (uint)mLength);
 			mLength -= length;
 		}
 


### PR DESCRIPTION
This assert exists in `RemoveFromStart` so there is no reason not to add it to `RemoveFromEnd`.