### PR TITLE
Fix `Variant.Get<T>()` Crash

### DIFF
--- a/BeefLibs/corlib/src/Variant.bf
+++ b/BeefLibs/corlib/src/Variant.bf
@@ -293,7 +293,7 @@ namespace System
 				obj = (T)Internal.UnsafeCastToObject(*(void**)(void*)mData);
 			else
 				obj = (T)Internal.UnsafeCastToObject((void*)mData);
-			Debug.Assert(obj.GetType().IsSubtypeOf(type));
+			Debug.Assert(obj == null || obj.GetType().IsSubtypeOf(type));
 			return obj;
 		}
 


### PR DESCRIPTION
This PR fixes a crash that happens if you try to call `Get<T>()` on a variant that contains a null object.