### PR TITLE
IDEHelper changes

### DIFF
--- a/IDE/src/Compiler/BfCompiler.bf
+++ b/IDE/src/Compiler/BfCompiler.bf
@@ -124,10 +124,10 @@ namespace IDE.Compiler
 		static extern char8* BfCompiler_GetGeneratorGenData(void* bfCompiler, char8* typeDefName, char8* args);
 
 		[CallingConvention(.Stdcall), CLink]
-		static extern char8* BfCompiler_GetTypeDefList(void* bfCompiler);
+		static extern char8* BfCompiler_GetTypeDefList(void* bfCompiler, bool includeLocation);
 
 		[CallingConvention(.Stdcall), CLink]
-		static extern char8* BfCompiler_GetTypeDefMatches(void* bfCompiler, char8* searchStr);
+		static extern char8* BfCompiler_GetTypeDefMatches(void* bfCompiler, char8* searchStr, bool includeLocation);
 
 		[CallingConvention(.Stdcall), CLink]
 		static extern char8* BfCompiler_GetTypeDefInfo(void* bfCompiler, char8* typeDefName);
@@ -846,14 +846,14 @@ namespace IDE.Compiler
 			outStr.Append(BfCompiler_GetGeneratorGenData(mNativeBfCompiler, typeDefName, args));
 		}
 
-		public void GetTypeDefList(String outStr)
+		public void GetTypeDefList(String outStr, bool includeLocation = false)
 		{
-			outStr.Append(BfCompiler_GetTypeDefList(mNativeBfCompiler));
+			outStr.Append(BfCompiler_GetTypeDefList(mNativeBfCompiler, includeLocation));
 		}
 
-		public void GetTypeDefMatches(String searchStr, String outStr)
+		public void GetTypeDefMatches(String searchStr, String outStr, bool includeLocation = false)
 		{
-			outStr.Append(BfCompiler_GetTypeDefMatches(mNativeBfCompiler, searchStr));
+			outStr.Append(BfCompiler_GetTypeDefMatches(mNativeBfCompiler, searchStr, includeLocation));
 		}
 
 		public void GetTypeDefInfo(String typeDefName, String outStr)

--- a/IDE/src/Compiler/BfParser.bf
+++ b/IDE/src/Compiler/BfParser.bf
@@ -181,6 +181,9 @@ namespace IDE.Compiler
 		[CallingConvention(.Stdcall), CLink]
 		static extern void BfParser_GetLineCharAtIdx(void* bfParser, int32 idx, int32* line, int32* lineChar);
 
+        [CallingConvention(.Stdcall), CLink]
+        static extern int32 BfParser_GetIndexAtLine(void* bfParser, int32 line);
+
 		public BfSystem mSystem;
         public void* mNativeBfParser;
         public bool mIsUsed;
@@ -442,5 +445,10 @@ namespace IDE.Compiler
 
 			return (line, char);
 		}
+
+        public int GetIndexAtLine(int line)
+        {
+            return BfParser_GetIndexAtLine(mNativeBfParser, (.) line);
+        }
     }
 }

--- a/IDE/src/Compiler/BfParser.bf
+++ b/IDE/src/Compiler/BfParser.bf
@@ -175,6 +175,9 @@ namespace IDE.Compiler
 		[CallingConvention(.Stdcall), CLink]
 		static extern void BfParser_SetCompleteParse(void* bfParser);
 
+		[CallingConvention(.Stdcall), CLink]
+		static extern void BfParser_GetLineCharAtIdx(void* bfParser, int32 idx, int32* line, int32* lineChar);
+
 		public BfSystem mSystem;
         public void* mNativeBfParser;
         public bool mIsUsed;
@@ -418,6 +421,15 @@ namespace IDE.Compiler
 		{
 			var md5Hash;
 			BfParser_SetHashMD5(mNativeBfParser, ref md5Hash);
+		}
+
+		public (int, int) GetLineCharAtIdx(int idx) {
+			int32 line = 0;
+			int32 char = 0;
+
+			BfParser_GetLineCharAtIdx(mNativeBfParser, (.) idx, &line, &char);
+
+			return (line, char);
 		}
     }
 }

--- a/IDEHelper/Compiler/BfCompiler.h
+++ b/IDEHelper/Compiler/BfCompiler.h
@@ -541,13 +541,13 @@ public:
 	void GetSymbolReferences();
 	void Cancel();
 	void RequestFastFinish();
-	String GetTypeDefList();
+	String GetTypeDefList(bool includeLocation);
 	String GetGeneratorString(BfTypeDef* typeDef, BfTypeInstance* typeInst, const StringImpl& generatorMethodName, const StringImpl* args);
 	void HandleGeneratorErrors(StringImpl& result);
 	String GetGeneratorTypeDefList();
 	String GetGeneratorInitData(const StringImpl& typeName, const StringImpl& args);
 	String GetGeneratorGenData(const StringImpl& typeName, const StringImpl& args);
-	String GetTypeDefMatches(const StringImpl& searchSrc);
+	String GetTypeDefMatches(const StringImpl& searchSrc, bool includeLocation);
 	void GetTypeDefs(const StringImpl& typeName, Array<BfTypeDef*>& typeDefs);
 	String GetTypeDefInfo(const StringImpl& typeName);
 	int GetTypeId(const StringImpl& typeName);

--- a/IDEHelper/Compiler/BfParser.cpp
+++ b/IDEHelper/Compiler/BfParser.cpp
@@ -4171,3 +4171,13 @@ BF_EXPORT void BF_CALLTYPE BfParser_SetCompleteParse(BfParser* bfParser)
 {
 	bfParser->mCompleteParse = true;
 }
+
+BF_EXPORT void BF_CALLTYPE BfParser_GetLineCharAtIdx(BfParser* bfParser, int idx, int* line, int* lineChar)
+{
+	int _line, _lineChar;
+
+	bfParser->GetLineCharAtIdx(idx, _line, _lineChar);
+
+	*line = _line;
+	*lineChar = _lineChar;
+}

--- a/IDEHelper/Compiler/BfParser.cpp
+++ b/IDEHelper/Compiler/BfParser.cpp
@@ -4201,3 +4201,8 @@ BF_EXPORT void BF_CALLTYPE BfParser_GetLineCharAtIdx(BfParser* bfParser, int idx
 	*line = _line;
 	*lineChar = _lineChar;
 }
+
+BF_EXPORT int BF_CALLTYPE BfParser_GetIndexAtLine(BfParser* bfParser, int line)
+{
+	return bfParser->GetIndexAtLine(line);
+}


### PR DESCRIPTION
Add BfParser_GetLineCharAtIdx, BfParser_GetIndexAtLine, include fields in document symbols and optionally include location in type defs.

I needed to move TypeDefMatchHelper a bit up because now it is needed in BfCompiler::GetTypeDefList.