### PR TITLE
Fixed Socket.Select() timeout on Linux

### DIFF
--- a/BeefLibs/corlib/src/Net/Socket.bf
+++ b/BeefLibs/corlib/src/Net/Socket.bf
@@ -40,6 +40,13 @@ namespace System.Net
 			}
 		}
 
+        [CRepr]
+        public struct TimeVal
+        {
+        	public int32 mSec;
+        	public int32 mUSec;
+        }
+
 #else
 		public struct HSocket : uint32
 		{
@@ -77,15 +84,14 @@ namespace System.Net
 				return (mSocketBitMasks[fd / BITS_PER_MASK] & (1U << (fd & (BITS_PER_MASK - 1)))) != 0;
 			}
 		}
+
+        [CRepr]
+        public struct TimeVal
+        {
+        	public int64 mSec;
+        	public int32 mUSec;
+        }
 #endif
-
-		[CRepr]
-		public struct TimeVal
-		{
-			public int32 mSec;
-			public int32 mUSec;
-		}
-
 
 
 #if BF_PLATFORM_WINDOWS


### PR DESCRIPTION
TimeVal uses int64 for seconds on Linux.

Tested that both seconds and microseconds works as intended on Windows and Linux now.