### PR TITLE
Build LLVM on Linux from Official Release Tarball.

### DIFF
--- a/extern/llvm_build.sh
+++ b/extern/llvm_build.sh
@@ -7,13 +7,33 @@ if command -v ninja >/dev/null 2>&1 ; then
 fi
 
 if [ ! -d llvm-project_13_0_1 ]; then
-	if [ -f llvm-13.0.1.src.tar.xz ]; then # if user downloaded llvm-13.0.1.src.tar.xz then use it instead
-		tar -xf llvm-13.0.1.src.tar.xz
-		mkdir llvm-project_13_0_1
-		mv llvm-13.0.1.src llvm-project_13_0_1/llvm
-	else # shallow git clone llvm repo if llvm-13.0.1.src.tar.xz does not exists
-		git clone --depth 1 --branch llvmorg-13.0.1 https://github.com/llvm/llvm-project.git llvm-project_13_0_1
+	# download source tarball, unless it is already present.
+	if [ ! -f llvm-13.0.1.src.tar.xz ]; then
+		# download llvm: https://releases.llvm.org/download.html#13.0.1
+		wget --quiet --show-progress https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/llvm-13.0.1.src.tar.xz
 	fi
+
+	# verify checksum
+	SUM=`sha256sum llvm_targets.txt | cut -d ' ' -f 1`
+	if [[ $SUM != "e2b5637470cb5c227b7811b805cec6bc506e10c74062cd866fd9b56cdd6d7dc9" ]]; then
+		echo Error! Wrong checksum: $SUM
+		echo Probably the download is incomplete.
+		echo Try deleting llvm-13.0.1.src.tar.xz and rerun this script.
+		echo Exiting.
+		exit 1
+	else
+		echo Checksum: OK
+	fi
+
+	# extract source tarball
+	tar -xf llvm-13.0.1.src.tar.xz
+
+	# recreate directory structure of LLVM git repo.
+	# this step is obsolete, since we don't clone the git repo anymore.
+	# but paths need to be adjusted below, if this is skipped.
+	mkdir llvm-project_13_0_1
+	mv llvm-13.0.1.src llvm-project_13_0_1/llvm
+
 fi #end if llvm-project_13_0_1 exists
 
 if [ ! -d llvm_linux_13_0_1 ]; then


### PR DESCRIPTION
For building llvm, this will download the official release tarball and verify the download.

Previously, it was just cloning the git repo at the release tag. And then proceeded without verifying the download.