### PR TITLE
Add `Type` overloads to Enum methods

### DIFF
--- a/BeefLibs/corlib/src/Enum.bf
+++ b/BeefLibs/corlib/src/Enum.bf
@@ -6,11 +6,10 @@ namespace System
 	struct Enum
 	{
 		[NoShow(true)]
-		[Comptime(ConstEval=true)]
-		public static int GetCount<T>() where T : Enum
+		public static int GetCount(Type type)
 		{
 			int count = 0;
-			for (var field in typeof(T).GetFields())
+			for (var field in type.GetFields())
 			{
 				if (field.IsEnumCase)
 					count++;
@@ -20,22 +19,45 @@ namespace System
 
 		[NoShow(true)]
 		[Comptime(ConstEval=true)]
+		public static int GetCount<T>() where T : Enum
+		{
+			return GetCount(typeof(T));
+		}
+
+		[NoShow(true)]
+		public static int64 GetMinValue(Type type)
+		{
+			int64? minValue = null;
+			for (var data in GetValues(type))
+			{
+				if (minValue == null)
+					minValue = data;
+				else
+					minValue = Math.Min(minValue.Value, data);
+			}
+			return minValue.ValueOrDefault;
+		}
+
+		[NoShow(true)]
+		[Comptime(ConstEval=true)]
 		public static var GetMinValue<T>() where T : Enum
 		{
 			Compiler.SetReturnType(typeof(T));
+			return GetMinValue(typeof(T));
+		}
 
-			int? minValue = null;
-			for (var field in typeof(T).GetFields())
+		[NoShow(true)]
+		public static int64 GetMaxValue(Type type)
+		{
+			int64? maxValue = null;
+			for (var data in GetValues(type))
 			{
-				if (field.IsEnumCase)
-				{
-					if (minValue == null)
-						minValue = field.[Friend]mFieldData.mData;
-					else
-						minValue = Math.Min(minValue.Value, field.[Friend]mFieldData.mData);
-				}
+				if (maxValue == null)
+					maxValue = data;
+				else
+					maxValue = Math.Max(maxValue.Value, data);
 			}
-			return minValue.ValueOrDefault;
+			return maxValue ?? -1;
 		}
 
 		[NoShow(true)]
@@ -43,36 +65,35 @@ namespace System
 		public static var GetMaxValue<T>() where T : Enum
 		{
 			Compiler.SetReturnType(typeof(T));
-
-			int? maxValue = null;
-			for (var field in typeof(T).GetFields())
-			{
-				if (field.IsEnumCase)
-				{
-					if (maxValue == null)
-						maxValue = field.[Friend]mFieldData.mData;
-					else
-						maxValue = Math.Max(maxValue.Value, field.[Friend]mFieldData.mData);
-				}
-			}
-			if (maxValue == null)
-				return -1;
-			return maxValue.ValueOrDefault;
+			return GetMaxValue(typeof(T));
 		}
 
 		[NoShow(true)]
 		public static void EnumToString(Type type, String strBuffer, int64 iVal)
 		{
-			for (var field in type.GetFields())
+			for (var (name, data) in GetEnumerator(type))
 			{
-				if (field.[Friend]mFieldData.mFlags.HasFlag(.EnumCase) &&
-					*(int64*)&field.[Friend]mFieldData.[Friend]mData == iVal)
+				if (data == iVal)
 				{
-					strBuffer.Append(field.Name);
+					strBuffer.Append(name);
 					return;
 				}
 			}
 			iVal.ToString(strBuffer);
+		}
+
+		[NoShow(true)]
+		public static Result<int64> Parse(Type type, StringView str, bool ignoreCase = false)
+		{
+			for (var (name, data) in GetEnumerator(type))
+			{
+				if (str.Equals(name, ignoreCase))
+					return .Ok(data);
+				if (int64.Parse(str) case .Ok(let val) && val == data)
+					return .Ok(data);
+			}
+
+			return .Err;
 		}
 
 		[NoShow(true)]
@@ -90,6 +111,18 @@ namespace System
 		}
 
 		[NoShow(true)]
+		public static bool IsDefined(Type type, int64 value)
+		{
+			for (var data in GetValues(type))
+			{
+				if (data == value)
+					return true;
+			}
+
+			return false;
+		}
+
+		[NoShow(true)]
 		public static bool IsDefined<T>(T value) where T : Enum
 			where T : enum
 		{
@@ -103,10 +136,22 @@ namespace System
 		}
 
 		[NoShow(true)]
+		public static EnumEnumerator GetEnumerator(Type type)
+		{
+		    return .(type);
+		}
+
+		[NoShow(true)]
 		public static EnumEnumerator<TEnum> GetEnumerator<TEnum>()
 			where TEnum : enum
 		{
 		    return .();
+		}
+
+		[NoShow(true)]
+		public static EnumValuesEnumerator GetValues(Type type)
+		{
+		    return .(type);
 		}
 
 		[NoShow(true)]
@@ -117,6 +162,12 @@ namespace System
 		}
 
 		[NoShow(true)]
+		public static EnumNamesEnumerator GetNames(Type type)
+		{
+		    return .(type);
+		}
+
+		[NoShow(true)]
 		public static EnumNamesEnumerator<TEnum> GetNames<TEnum>()
 			where TEnum : enum
 		{
@@ -124,15 +175,14 @@ namespace System
 		}
 
 		[NoShow(true)]
-		private struct EnumFieldsEnumerator<TEnum>
-			where TEnum : enum
+		private struct EnumFieldsEnumerator
 		{
 			TypeInstance mTypeInstance;
 			int32 mIdx;
 
-			public this()
+			public this(Type type)
 			{
-			    mTypeInstance = typeof(TEnum) as TypeInstance;
+			    mTypeInstance = type as TypeInstance;
 			    mIdx = -1;
 			}
 
@@ -190,9 +240,36 @@ namespace System
 		}
 
 		[NoShow(true)]
-		public struct EnumEnumerator<TEnum> : EnumFieldsEnumerator<TEnum>, IEnumerator<(StringView name, TEnum value)>
+		public struct EnumEnumerator : EnumFieldsEnumerator, IEnumerator<(StringView name, int64 value)>
+		{
+			public this(Type type) : base(type)
+			{
+			}
+
+			public new (StringView name, int64 value) Current
+			{
+				get
+				{
+					return ((.)base.Current.[Friend]mFieldData.[Friend]mName, *(int64*)&base.Current.[Friend]mFieldData.[Friend]mData);
+				}
+			}
+
+			public new Result<(StringView name, int64 value)> GetNext() mut
+			{
+				if (!MoveNext())
+					return .Err;
+				return Current;
+			}
+		}
+
+		[NoShow(true)]
+		public struct EnumEnumerator<TEnum> : EnumFieldsEnumerator, IEnumerator<(StringView name, TEnum value)>
 			where TEnum : enum
 		{
+			public this() : base(typeof(TEnum))
+			{
+			}
+
 			public new (StringView name, TEnum value) Current
 			{
 				get
@@ -210,9 +287,36 @@ namespace System
 		}
 
 		[NoShow(true)]
-		public struct EnumValuesEnumerator<TEnum> : EnumFieldsEnumerator<TEnum>, IEnumerator<TEnum>
+		public struct EnumValuesEnumerator : EnumFieldsEnumerator, IEnumerator<int64>
+		{
+			public this(Type type) : base(type)
+			{
+			}
+
+			public new int64 Current
+			{
+				get
+				{
+					return *(int64*)&base.Current.[Friend]mFieldData.[Friend]mData;
+				}
+			}
+
+			public new Result<int64> GetNext() mut
+			{
+				if (!MoveNext())
+					return .Err;
+				return Current;
+			}
+		}
+
+		[NoShow(true)]
+		public struct EnumValuesEnumerator<TEnum> : EnumFieldsEnumerator, IEnumerator<TEnum>
 			where TEnum : enum
 		{
+			public this() : base(typeof(TEnum))
+			{
+			}
+
 			public new TEnum Current
 			{
 				get
@@ -230,9 +334,36 @@ namespace System
 		}
 
 		[NoShow(true)]
-		public struct EnumNamesEnumerator<TEnum> : EnumFieldsEnumerator<TEnum>, IEnumerator<StringView>
+		public struct EnumNamesEnumerator : EnumFieldsEnumerator, IEnumerator<StringView>
+		{
+			public this(Type type) : base(type)
+			{
+			}
+
+			public new StringView Current
+			{
+				get
+				{
+					return (.)base.Current.[Friend]mFieldData.[Friend]mName;
+				}
+			}
+
+			public new Result<StringView> GetNext() mut
+			{
+				if (!MoveNext())
+					return .Err;
+				return Current;
+			}
+		}
+
+		[NoShow(true)]
+		public struct EnumNamesEnumerator<TEnum> : EnumFieldsEnumerator, IEnumerator<StringView>
 			where TEnum : enum
 		{
+			public this() : base(typeof(TEnum))
+			{
+			}
+
 			public new StringView Current
 			{
 				get


### PR DESCRIPTION
This PR adds `Type` overloads to the Enum methods.
The only difference from their generic counterpart is that, since we don't know the type of the enum at compile-time, we need to use `int64`.