### PR TITLE
Slightly improve StringEnumerator `HasMore`

### DIFF
--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -3053,7 +3053,7 @@ namespace System
 		{
 			get
 			{
-				return mMatchPos < mStrLen;
+				return mMatchPos < mStrLen && (!mSplitOptions.HasFlag(StringSplitOptions.RemoveEmptyEntries) || mStrLen != 0);
 			}
 		}
 
@@ -3216,7 +3216,7 @@ namespace System
 		{
 			get
 			{
-				return mMatchPos < mStrLen;
+				return mMatchPos < mStrLen && (!mSplitOptions.HasFlag(StringSplitOptions.RemoveEmptyEntries) || mStrLen != 0);
 			}
 		}
 


### PR DESCRIPTION
This PR makes the `HasMore` property return false if the string being splitted is empty and the enumerator should remove empty entries.