### PR TITLE
Fixed memory leak of temporary tab

### DIFF
--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -6355,6 +6355,12 @@ namespace IDE
 
             public override void MouseDown(float x, float y, int32 btn, int32 btnCount)
             {
+				if ((mIsRightTab) && (btn == 0) && (btnCount > 1))
+				{
+					IDEApp.sApp.MakeTabPermanent(this);
+					return;
+				}
+
                 base.MouseDown(x, y, btn, btnCount);
 
 				if (btn == 1)
@@ -6420,11 +6426,6 @@ namespace IDE
 					else
 						delete menu;
 				}
-                
-                if ((mIsRightTab) && (btn == 0) && (btnCount > 1))
-                {
-                    IDEApp.sApp.MakeTabPermanent(this);
-                }
             }
 
             public override void Update()


### PR DESCRIPTION
Hi there,

`TabButton` adds a listener to the `mMouseDownWindow.mOnMouseLeftWindow` on the `MouseDown` event and removes it on the `MouseUp` event.

This pull request fixes the issue with temporary tabs not receiving the `MouseUp` event and thus not freeing the callback, allocated during the `MouseDown` event. After closing such a tab, an assertion will fail at the destruction of the `TabButton`, because `mMouseDownWindow` is not null. This behavior happens only through a mouse double-click.

Theoretically, an alternative solution would be to modify the `MouseUp` of the `Widget` class so that it will receive `btnCount` to detect mouse double-click. Then, instead of checking double-click in `MouseDown`, it would be possible to do this in the `MouseUp`, which will lead to `TabButton` being able to allocate and deallocate callback properly.