### PR TITLE
Fixed BfParser::GetIndexAtLine

### DIFF
--- a/IDEHelper/Compiler/BfParser.cpp
+++ b/IDEHelper/Compiler/BfParser.cpp
@@ -465,7 +465,7 @@ int BfParser::GetIndexAtLine(int line)
 		{
 			curLine++;
 			if (line == curLine)
-				return i;
+				return i + 1;
 		}
 	}
 


### PR DESCRIPTION
Previously it returned the index for the newline character which is still part of the previous line.