### PR TITLE
Override DarkTabButton.DragEnd

### DIFF
--- a/BeefLibs/Beefy2D/src/theme/dark/DarkTabbedView.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkTabbedView.bf
@@ -159,6 +159,22 @@ namespace Beefy.theme.dark
                         ((DarkTabbedView)mTabbedView).DrawDockPreview(g, this);
                 }
             }            
+
+			public override void DragEnd()
+			{
+				if (mIsRightTab == true)
+				{
+					mTextColor = Color.White;
+
+					DarkTabbedView darkTabbedView = mTabbedView as DarkTabbedView;
+					darkTabbedView.SetRightTab(null, false);
+					darkTabbedView.AddTab(this, darkTabbedView.GetInsertPositionFromCursor());
+
+					Activate();
+				}
+
+				base.DragEnd();
+			}
         }
 
         public class DarkTabDock : ICustomDock

--- a/BeefLibs/Beefy2D/src/widgets/TabbedView.bf
+++ b/BeefLibs/Beefy2D/src/widgets/TabbedView.bf
@@ -143,7 +143,7 @@ namespace Beefy.widgets
                 }            
             }
 
-            public void DragStart()            
+            public virtual void DragStart()            
             {                
                 mSrcDraggingWindow = mWidgetWindow;
 
@@ -157,7 +157,7 @@ namespace Beefy.widgets
                 }                
             }
 
-            public void DragEnd()
+            public virtual void DragEnd()
             {
                 //mWidgetWindow.mMouseLeftWindowDelegate.Remove(scope => MouseLeftWindow, true);
 				AdjustPinnedState();


### PR DESCRIPTION
Hi there,

This pull request does n-things:
- Changes `TabButton` methods `DragStart` and `DragEnd` to be virtual;
- Overrides `DarkTabButton.DragEnd` to make it possible to drag a temporary tab onto the same `TabbedView` it resides on;
- Override `DragEnd` fixes the issue with temporary tabs becoming pinned when they are dragged to the same `TabbedView` they are in;

Double-clicking on the temporary tab makes it permanent, but dragging does the same only if the `TabbedView` is different than the current temporary tab resides in.

An alternative approach to solving pinned state issue could be just checking if `mTabs.IndexOf` returns `-1` and exiting `AdjustPinnedState` without changing the state.

If this behavior was intentional or for any other reason, - pull request may be rejected and I'll make a different pull request to fix the issue inside `AdjustPinnedState` method.