### PR TITLE
Make `ReplaceLargerHelper` private

### DIFF
--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -2125,7 +2125,7 @@ namespace System
 			return UTF8.Decode(ptr + idx, mLength - idx).c == c;
 		}
 
-		public void ReplaceLargerHelper(String find, String replace)
+		private void ReplaceLargerHelper(String find, String replace)
 		{
 			List<int> replaceEntries = scope List<int>(8192);
 			


### PR DESCRIPTION
This method should only be used through `Replace` and it doesn't work correctly if used in a way it wasn't designed for.