### PR TITLE
Fix infinite loop in `BfParser::NextToken`

### DIFF
--- a/IDEHelper/Compiler/BfParser.cpp
+++ b/IDEHelper/Compiler/BfParser.cpp
@@ -2146,7 +2146,7 @@ void BfParser::NextToken(int endIdx, bool outerIsInterpolate, bool disablePrepro
 									newBlock->SetSrcEnd(mSrcIdx);
 									mSrcIdx--;
 								}
-								else if ((mSyntaxToken == BfSyntaxToken_EOF) || (mSyntaxToken == BfSyntaxToken_StringQuote))
+								else if (mSyntaxToken == BfSyntaxToken_StringQuote)
 								{
 									mSrcIdx--;
 									mPassInstance->FailAfterAt("Expected '}'", mSourceData, newBlock->GetSrcEnd() - 1);


### PR DESCRIPTION
Fixes https://github.com/beefytech/Beef/issues/1771

This should be safe because EOF is already handled in:
https://github.com/beefytech/Beef/blob/master/IDEHelper/Compiler/BfParser.cpp#L1884