### PR TITLE
Fix codegen emitting wrong instructions for double vector types

### DIFF
--- a/IDEHelper/Compiler/BfIRCodeGen.cpp
+++ b/IDEHelper/Compiler/BfIRCodeGen.cpp
@@ -3103,7 +3103,7 @@ void BfIRCodeGen::HandleNextCmd()
 						{
 							auto vecType = llvm::dyn_cast<llvm::VectorType>(val0->getType());
 							auto elemType = vecType->getElementType();
-							bool isFP = elemType->isFloatTy();
+							bool isFP = elemType->isFloatingPointTy();
 
 							llvm::Value* val1;
 							if (args.size() < 2)


### PR DESCRIPTION
Closes #1820

Also while fixing the bug I noticed another bug in file `BfIrCodeGen.cpp` at line 515. The first check also runs if the type is double so the second check never runs. I didn't fix it immediately because I wasn't sure if I should just swap the order or change the `isFloatingPointTy()` call to `isFloatTy()`.
![image](https://user-images.githubusercontent.com/25082624/228910871-89bdab28-cdb6-4d32-82cc-983c067dc6b4.png)
