### PR TITLE
Fixed errors in sized array constructor

### DIFF
--- a/IDEHelper/Compiler/BfExprEvaluator.cpp
+++ b/IDEHelper/Compiler/BfExprEvaluator.cpp
@@ -18840,10 +18840,7 @@ void BfExprEvaluator::Visit(BfInvocationExpression* invocationExpr)
 			checkTarget = indexerExpr->mTarget;
 		}
 
-		SetAndRestoreValue<bool> prevIgnoreError(mModule->mIgnoreErrors, true);
-		auto resolvedType = mModule->ResolveTypeRef(checkTarget, NULL, BfPopulateType_Identity);
-		prevIgnoreError.Restore();
-
+		auto resolvedType = mModule->ResolveTypeRef(checkTarget, NULL, BfPopulateType_Identity, BfResolveTypeRefFlag_IgnoreLookupError);
 		if (resolvedType != NULL)
 		{
 			BfType* curType = resolvedType;


### PR DESCRIPTION
Before this change the `"string" alias not supported` error wouldn't show up in sized array constructors.
![image](https://user-images.githubusercontent.com/86157825/235496988-8361f61b-b7a7-4a6c-87b7-a833206bb4ee.png)

I based this change on [this commit](https://github.com/beefytech/Beef/commit/71f677d902875c4543999afc9ce2e3263de404df) so hopefully it's correct.