### PR TITLE
Fix ReadBuffer

### DIFF
--- a/BeefLibs/corlib/src/IO/StreamReader.bf
+++ b/BeefLibs/corlib/src/IO/StreamReader.bf
@@ -501,9 +501,9 @@ namespace System.IO
 					}
 				}
 
-				if ((mPendingNewlineCheck) && (mCharPos < mCharLen))
+				if (mPendingNewlineCheck)
 				{
-					if (mCharBuffer[mCharPos] == '\n') mCharPos++;
+					if (mCharPos == 0 && mCharBuffer[mCharPos] == '\n') mCharPos++;
 					mPendingNewlineCheck = false;
 				}
 			}

--- a/BeefLibs/corlib/src/IO/StreamReader.bf
+++ b/BeefLibs/corlib/src/IO/StreamReader.bf
@@ -441,7 +441,7 @@ namespace System.IO
                             bytePos = byteLen = 0;*/
 						}
 
-						return mCharLen;
+						return mCharLen - mCharPos;
 					}
 
 					mByteLen += len;
@@ -461,7 +461,7 @@ namespace System.IO
                     //Contract.Assert(byteLen >= 0, "Stream.Read returned a negative number!  This is a bug in your stream class.");
 
 					if (mByteLen == 0)  // We're at EOF
-						return mCharLen;
+						return mCharLen - mCharPos;
 				}
 
                 // _isBlocked == whether we read fewer bytes than we asked for.
@@ -510,7 +510,7 @@ namespace System.IO
 			while (mCharLen == mCharPos);
 
             //Console.WriteLine("ReadBuffer called.  chars: "+char8Len);
-			return mCharLen;
+			return mCharLen - mCharPos;
 		}
 
 		int GetChars(uint8[] byteBuffer, int byteOffset, int byteLength, char8[] char8Buffer, int char8Offset)


### PR DESCRIPTION
This PR fixes an issue with ReadBuffer where it would return 1 even though the stream was at EOF.
While fixing this issue I also noticed that the `PendingNewlineCheck` probably needed to be fixed too, since it wasn't making sure the newline was at the start of the char buffer (which I guess would be the intended behavior)