### PR TITLE
Fix IDE crash

### DIFF
--- a/BeefLibs/Beefy2D/src/widgets/Widget.bf
+++ b/BeefLibs/Beefy2D/src/widgets/Widget.bf
@@ -367,7 +367,7 @@ namespace Beefy.widgets
         public virtual void SetFocus()
         {
 			MarkDirty();
-            mWidgetWindow.SetFocus(this);
+            mWidgetWindow?.SetFocus(this);
         }
 
         public virtual void SetVisible(bool visible)


### PR DESCRIPTION
This PR fixes an IDE crash that I had because of a null reference, not sure how it happened but this fix seems to be correct since the others methods also check for the nullity of mWidgetWindow.