### PR TITLE
Improvements to Number parsing

### DIFF
--- a/BeefLibs/corlib/src/Int.bf
+++ b/BeefLibs/corlib/src/Int.bf
@@ -9,11 +9,12 @@ namespace System
 		{
 			case Ok;
 			case NoValue;
+			case Overflow;
 			case InvalidChar(int partialResult);
 		}
 
-		public const int MaxValue = (sizeof(uint) == 8) ? 0x7FFFFFFFFFFFFFFFL : 0x7FFFFFFF;
-		public const int MinValue = (sizeof(uint) == 8) ? -0x8000000000000000L : -0x80000000;
+		public const int MaxValue = (sizeof(int) == 8) ? 0x7FFFFFFFFFFFFFFFL : 0x7FFFFFFF;
+		public const int MinValue = (sizeof(int) == 8) ? -0x8000000000000000L : -0x80000000;
 
 		public static int operator<=>(Self a, Self b)
 		{

--- a/BeefLibs/corlib/src/Int16.bf
+++ b/BeefLibs/corlib/src/Int16.bf
@@ -1,10 +1,20 @@
+using System.Globalization;
+
 namespace System
 {
 #unwarn
 	struct Int16 : int16, IInteger, ISigned, IHashable, IFormattable, IIsNaN
 	{
-		public const int32 MaxValue = 0x7FFF;
-		public const int32 MinValue = -0x8000;
+		public enum ParseError
+		{
+			case Ok;
+			case NoValue;
+			case Overflow;
+			case InvalidChar(int16 partialResult);
+		}
+
+		public const int16 MaxValue = 0x7FFF;
+		public const int16 MinValue = -0x8000;
 
  		public static int operator<=>(Self a, Self b)
 		{
@@ -65,6 +75,69 @@ namespace System
 			{
 				NumberFormatter.NumberToString(format, (int32)this, formatProvider, outString);
 			}
+		}
+
+		public static Result<int16, ParseError> Parse(StringView val, NumberStyles style = .Number, CultureInfo cultureInfo = null)
+		{
+			if (val.IsEmpty)
+				return .Err(.NoValue);
+
+			bool isNeg = false;
+			int16 result = 0;
+
+			int16 radix = style.HasFlag(.AllowHexSpecifier) ? 0x10 : 10;
+
+			for (int32 i = 0; i < val.Length; i++)
+			{
+				char8 c = val[i];
+
+				if ((i == 0) && (c == '-'))
+				{
+					isNeg = true;
+					continue;
+				}
+
+				if ((c >= '0') && (c <= '9'))
+				{
+					result &*= radix;
+					result &+= (int16)(c - '0');
+				}
+				else if ((c >= 'a') && (c <= 'f'))
+				{
+					if (radix != 0x10)
+						return .Err(.InvalidChar(result));
+					result &*= radix;
+					result &+= c - 'a' + 10;
+				}
+				else if ((c >= 'A') && (c <= 'F'))
+				{
+					if (radix != 0x10)
+						return .Err(.InvalidChar(result));
+					result &*= radix;
+					result &+= c - 'A' + 10;
+				}
+				else if ((c == 'X') || (c == 'x'))
+				{
+					if ((!style.HasFlag(.AllowHexSpecifier)) || (i == 0) || (result != 0))
+						return .Err(.InvalidChar(result));
+					radix = 0x10;
+				}
+				else if (c == '\'')
+				{
+					// Ignore
+				}
+				else if ((c == '+') && (i == 0))
+				{
+					// Ignore
+				}
+				else
+					return .Err(.InvalidChar(result));
+
+				if (isNeg ? (uint16)result > (uint16)MinValue : (uint16)result > (uint16)MaxValue)
+					return .Err(.Overflow);
+			}
+
+			return isNeg ? -result : result;
 		}
 	}
 }

--- a/BeefLibs/corlib/src/UInt.bf
+++ b/BeefLibs/corlib/src/UInt.bf
@@ -7,11 +7,12 @@ namespace System
 		{
 			case Ok;
 			case NoValue;
+			case Overflow;
 			case InvalidChar(uint partialResult);
 		}
 
-		public const uint64 MaxValue = (sizeof(uint) == 8) ? 0xFFFFFFFFFFFFFFFFUL : 0xFFFFFFFFL;
-		public const uint64 MinValue = 0;
+		public const uint MaxValue = (sizeof(uint) == 8) ? 0xFFFFFFFFFFFFFFFFUL : 0xFFFFFFFFL;
+		public const uint MinValue = 0;
 
 	    public bool IsNull()
 	    {

--- a/BeefLibs/corlib/src/UInt16.bf
+++ b/BeefLibs/corlib/src/UInt16.bf
@@ -1,9 +1,19 @@
+using System.Globalization;
+
 namespace System
 {
 #unwarn
 	struct UInt16 : uint16, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN
 	{
-		public const uint16 MaxValue = (uint16)0xFFFF;
+		public enum ParseError
+		{
+			case Ok;
+			case NoValue;
+			case Overflow;
+			case InvalidChar(uint16 partialResult);
+		}
+
+		public const uint16 MaxValue = 0xFFFF;
 		public const uint16 MinValue = 0;
 
 		public static int operator<=>(Self a, Self b)
@@ -65,6 +75,64 @@ namespace System
 			{
 				NumberFormatter.NumberToString(format, (uint32)this, formatProvider, outString);
 			}
+		}
+
+		public static Result<uint16, ParseError> Parse(StringView val, NumberStyles style = .Number, CultureInfo cultureInfo = null)
+		{
+			if (val.IsEmpty)
+				return .Err(.NoValue);
+
+			uint16 result = 0;
+			uint16 prevResult = 0;
+
+			uint16 radix = style.HasFlag(.AllowHexSpecifier) ? 0x10 : 10;
+
+			for (int32 i = 0; i < val.Length; i++)
+			{
+				char8 c = val[i];
+
+				if ((c >= '0') && (c <= '9'))
+				{
+					result &*= radix;
+					result &+= (uint16)(c - '0');
+				}
+				else if ((c >= 'a') && (c <= 'f'))
+				{
+					if (radix != 0x10)
+						return .Err(.InvalidChar(result));
+					result &*= radix;
+					result &+= (uint16)(c - 'a' + 10);
+				}
+				else if ((c >= 'A') && (c <= 'F'))
+				{
+					if (radix != 0x10)
+						return .Err(.InvalidChar(result));
+					result &*= radix;
+					result &+= (uint16)(c - 'A' + 10);
+				}
+				else if ((c == 'X') || (c == 'x'))
+				{
+					if ((!style.HasFlag(.AllowHexSpecifier)) || (i == 0) || (result != 0))
+						return .Err(.InvalidChar(result));
+					radix = 0x10;
+				}
+				else if (c == '\'')
+				{
+					// Ignore
+				}
+				else if ((c == '+') && (i == 0))
+				{
+					// Ignore
+				}
+				else
+					return .Err(.InvalidChar(result));
+
+				if (result < prevResult)
+					return .Err(.Overflow);
+				prevResult = result;
+			}
+
+			return result;
 		}
 	}
 }

--- a/BeefLibs/corlib/src/UInt8.bf
+++ b/BeefLibs/corlib/src/UInt8.bf
@@ -1,9 +1,19 @@
+using System.Globalization;
+
 namespace System
 {
 #unwarn
 	struct UInt8 : uint8, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN
 	{
-	    public const uint8 MaxValue = (uint8)0xFF;        
+		public enum ParseError
+		{
+			case Ok;
+			case NoValue;
+			case Overflow;
+			case InvalidChar(uint8 partialResult);
+		}
+
+	    public const uint8 MaxValue = 0xFF;
 	    public const uint8 MinValue = 0;
 
 		public static int operator<=>(Self a, Self b)
@@ -65,6 +75,64 @@ namespace System
 			{
 				NumberFormatter.NumberToString(format, (uint32)this, formatProvider, outString);
 			}
+		}
+
+		public static Result<uint8, ParseError> Parse(StringView val, NumberStyles style = .Number, CultureInfo cultureInfo = null)
+		{
+			if (val.IsEmpty)
+				return .Err(.NoValue);
+
+			uint8 result = 0;
+			uint8 prevResult = 0;
+
+			uint8 radix = style.HasFlag(.AllowHexSpecifier) ? 0x10 : 10;
+
+			for (int32 i = 0; i < val.Length; i++)
+			{
+				char8 c = val[i];
+
+				if ((c >= '0') && (c <= '9'))
+				{
+					result &*= radix;
+					result &+= (uint8)(c - '0');
+				}
+				else if ((c >= 'a') && (c <= 'f'))
+				{
+					if (radix != 0x10)
+						return .Err(.InvalidChar(result));
+					result &*= radix;
+					result &+= (uint8)(c - 'a' + 10);
+				}
+				else if ((c >= 'A') && (c <= 'F'))
+				{
+					if (radix != 0x10)
+						return .Err(.InvalidChar(result));
+					result &*= radix;
+					result &+= (uint8)(c - 'A' + 10);
+				}
+				else if ((c == 'X') || (c == 'x'))
+				{
+					if ((!style.HasFlag(.AllowHexSpecifier)) || (i == 0) || (result != 0))
+						return .Err(.InvalidChar(result));
+					radix = 0x10;
+				}
+				else if (c == '\'')
+				{
+					// Ignore
+				}
+				else if ((c == '+') && (i == 0))
+				{
+					// Ignore
+				}
+				else
+					return .Err(.InvalidChar(result));
+
+				if (result < prevResult)
+					return .Err(.Overflow);
+				prevResult = result;
+			}
+
+			return result;
 		}
 	}
 }


### PR DESCRIPTION
This PR makes some improvements to the Parse method of all Integer types:
- Normalizes all Parse methods.
- Adds an overflow check to all Parse methods.
- Modifies all Parse methods to accept Hex input only when the AllowHexSpecifier flag is set.
- Adds the Parse method for the types int8, int16, uint8, and uint16.