### PR TITLE
Fix IDE starting in normal window instead of maximized

### DIFF
--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -12248,7 +12248,7 @@ namespace IDE
 				if (mRunningTestScript)
 					flags |= .NoActivate;
 
-				if (mRequestedShowKind == .Maximized)
+				if (mRequestedShowKind == .Maximized || mRequestedShowKind == .ShowMaximized)
 					flags |= .ShowMaximized;
 
 				scope AutoBeefPerf("IDEApp.Init:CreateMainWindow");


### PR DESCRIPTION
Since 2428fe8 the IDE doesn't start correctly in Maximized state because `BFWindow.mShowKind` on maximized window has a value of `ShowMaximized` instead of `Maximized`