### PR TITLE
using Beef042RT32_wasm_pthread.a in addition to Beef042RT32_wasm.a

### DIFF
--- a/IDE/src/BuildContext.bf
+++ b/IDE/src/BuildContext.bf
@@ -704,10 +704,10 @@ namespace IDE
 
 					compilerExePath.Append(@"/upstream/emscripten/emcc.bat");
 					//linkLine.Append(" c:\\Beef\\wasm\\BeefRT.a -s STRICT=1 -s USE_PTHREADS=1 -s ALIASING_FUNCTION_POINTERS=1 -s ASSERTIONS=0 -s DISABLE_EXCEPTION_CATCHING=0 -s DEMANGLE_SUPPORT=0 -s EVAL_CTORS=1 -s WASM=1 -s \"EXPORTED_FUNCTIONS=['_BeefMain','_BeefDone','_pthread_mutexattr_init','_pthread_mutex_init','_emscripten_futex_wake','_calloc','_sbrk']\"");
-					linkLine.Append("-s DISABLE_EXCEPTION_CATCHING=0 -s DEMANGLE_SUPPORT=0 -s WASM=1");
+					linkLine.Append("-s DISABLE_EXCEPTION_CATCHING=0 -s DEMANGLE_SUPPORT=0");
 
 					if (project.mWasmOptions.mEnableThreads)
-						linkLine.Append(" -s USE_PTHREADS=1");
+						linkLine.Append(" -pthread");
 
 					if (workspaceOptions.mEmitDebugInfo != .No)
 						linkLine.Append(" -g");

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -10281,7 +10281,10 @@ namespace IDE
 										newString.Append(mInstallDir);
 										newString.Append("Beef", IDEApp.sRTVersionStr, "RT");
 										newString.Append((Workspace.PlatformType.GetPtrSizeByName(gApp.mPlatformName) == 4) ? "32" : "64");
-										newString.Append("_wasm.a\"");
+										newString.Append("_wasm");
+	  									if (project.mWasmOptions.mEnableThreads)
+	    										newString.Append("_pthread");
+	       									newString.Append(".a\"");
 									default:
 									}	
 

--- a/wasm/build_wasm.bat
+++ b/wasm/build_wasm.bat
@@ -32,9 +32,13 @@ copy ..\BeefySysLib\third_party\putty\* src\BeefySysLib\third_party\putty
 
 IF "%1" EQU "setup" GOTO SUCCESS
 
-call emcc src\rt\Chars.cpp src\rt\Math.cpp src\rt\Object.cpp src\rt\Thread.cpp src\rt\Internal.cpp src\BeefySysLib\platform\wasm\WasmCommon.cpp src\BeefySysLib\Common.cpp src\BeefySysLib\util\String.cpp src\BeefySysLib\util\UTF8.cpp src\BeefySysLib\third_party\utf8proc\utf8proc.c src\BeefySysLib\third_party\putty\wildcard.c -Isrc\ -Isrc\BeefySysLib -Isrc\BeefySysLib\platform\wasm -g -DBF_DISABLE_FFI -c -s WASM=1 -s USE_PTHREADS=1
+call emcc src\rt\Chars.cpp src\rt\Math.cpp src\rt\Object.cpp src\rt\Thread.cpp src\rt\Internal.cpp src\BeefySysLib\platform\wasm\WasmCommon.cpp src\BeefySysLib\Common.cpp src\BeefySysLib\util\String.cpp src\BeefySysLib\util\UTF8.cpp src\BeefySysLib\third_party\utf8proc\utf8proc.c src\BeefySysLib\third_party\putty\wildcard.c -Isrc\ -Isrc\BeefySysLib -Isrc\BeefySysLib\platform\wasm -g -DBF_DISABLE_FFI -c
 @IF %ERRORLEVEL% NEQ 0 GOTO HADERROR
 call emar r %LIBPATH%\Beef042RT32_wasm.a Common.o Internal.o Chars.o Math.o Object.o String.o Thread.o UTF8.o utf8proc.o wildcard.o WasmCommon.o
+@IF %ERRORLEVEL% NEQ 0 GOTO HADERROR
+call emcc src\rt\Chars.cpp src\rt\Math.cpp src\rt\Object.cpp src\rt\Thread.cpp src\rt\Internal.cpp src\BeefySysLib\platform\wasm\WasmCommon.cpp src\BeefySysLib\Common.cpp src\BeefySysLib\util\String.cpp src\BeefySysLib\util\UTF8.cpp src\BeefySysLib\third_party\utf8proc\utf8proc.c src\BeefySysLib\third_party\putty\wildcard.c -Isrc\ -Isrc\BeefySysLib -Isrc\BeefySysLib\platform\wasm -g -DBF_DISABLE_FFI -c -pthread
+@IF %ERRORLEVEL% NEQ 0 GOTO HADERROR
+call emar r %LIBPATH%\Beef042RT32_wasm_pthread.a Common.o Internal.o Chars.o Math.o Object.o String.o Thread.o UTF8.o utf8proc.o wildcard.o WasmCommon.o
 @IF %ERRORLEVEL% NEQ 0 GOTO HADERROR
 
 :SUCCESS


### PR DESCRIPTION
This fixes crash with linking static libraries with webassembly build.

Multithreading doesn't quite work yet, but I think it works better than it was. I think webassembly programs didn't even compile when multithreading was enabled in project options. Right now Thread.Sleep(1000) sleeps way longer than one second for some reason.