### PR TITLE
Add intrinsic for emscripten assembly/javascript.

### DIFF
--- a/BeefLibs/corlib/src/WebAssembly.bf
+++ b/BeefLibs/corlib/src/WebAssembly.bf
@@ -1,0 +1,121 @@
+#if BF_PLATFORM_WASM
+
+namespace System;
+
+using System.Interop;
+
+class WebAssembly
+{
+	[CLink]
+	private static extern int32 emscripten_asm_const_int(char8* code, char8* arg_sigs, ...);
+	[CLink]
+	private static extern void emscripten_asm_const_ptr(char8* code, char8* arg_sigs, ...);
+	[CLink]
+	private static extern double emscripten_asm_const_double(char8* code, char8* arg_sigs, ...);
+
+	[Intrinsic(":add_string_to_section")]
+	private static extern char8* add_string_to_section(uint8* string, uint8* section);
+
+	private static Span<uint8> GetStringData(String value)
+	{
+	    return StringView(value).ToRawData();
+	}
+
+	/**
+	* Returns the string added to the specified data section. 
+	*/
+	private static char8* AddStringToSection<T0, T1>(T0 value, T1 section) where T0 : const String where T1 : const String
+	{
+		static uint8[?] data = GetStringData(value);
+		static uint8[?] sectionStr = GetStringData(section);
+
+	    #unwarn
+		return add_string_to_section(&data, &sectionStr);
+	}
+
+	private static void GetArgSigInternal(Type t, String s)
+	{
+		switch(t)
+		{
+		case typeof(float):
+			s.Append('f');
+		case typeof(double):
+			s.Append('d');
+		case typeof(c_ulong): fallthrough;
+		case typeof(c_ulonglong):
+		case typeof(c_longlong):
+		case typeof(c_long):
+			s.Append('j');
+		default:
+#if BF_32_BIT
+			s.Append('i');
+#else
+			s.Append('p');
+#endif
+		}
+	}
+
+	[Comptime]
+	static void JSGetArgSig(Type t, String s)
+	{
+		if(t.IsTuple)
+		{
+			int count = t.FieldCount;
+			for(int i = 0; i < count; i++)
+			{
+				var type =	t.GetField(i).Get().FieldType;
+				GetArgSigInternal(type, s);
+			}
+		}else
+			GetArgSigInternal(t, s);
+	}
+
+	private static String JSGetResultName(Type t)
+	{
+		if(t.IsPointer)
+			return "ptr";
+	    else if (t.IsFloatingPoint)
+	        return "double";
+	    else
+	        return "int";
+	}
+
+	[Comptime]
+	private static void GetArgString<T>(String s)
+	{
+		Type type = typeof(T);
+		int fieldCount = 0;
+		if (type.IsTuple)
+		{
+			fieldCount = type.FieldCount;
+			for(int i = 0; i< fieldCount; i++)
+			{
+				if(i == fieldCount-1)
+					s.AppendF("p0.{}", i);
+				else
+					s.AppendF("p0.{}, ", i);
+			}
+		}
+		else
+			s.Append("p0");
+	}
+
+	private static String JSGetCallString<TResult, TCall, T0>() where TCall : const String
+	{
+	    if (TCall == null)
+	        return "";
+	    var argSigs = JSGetArgSig(typeof(T0), .. scope .());
+		var argString = GetArgString<T0>(.. scope .());
+	    return new $"result = emscripten_asm_const_{JSGetResultName(typeof(TResult))}(AddStringToSection({TCall.Quote(.. scope .())}, \"em_asm\"), \"{argSigs}\", {argString});";
+	}
+
+	public static TResult JSCall<TResult, TCall, T0>(TCall callString, T0 p0) where TCall : const String
+	{
+	    TResult result = default;
+	    Compiler.Mixin(JSGetCallString<TResult, const TCall, T0>());
+	    return result;
+	}
+}
+
+
+#endif

--- a/BeefLibs/corlib/src/WebAssembly.bf
+++ b/BeefLibs/corlib/src/WebAssembly.bf
@@ -109,13 +109,26 @@ class WebAssembly
 	    return new $"result = emscripten_asm_const_{JSGetResultName(typeof(TResult))}(AddStringToSection({TCall.Quote(.. scope .())}, \"em_asm\"), \"{argSigs}\", {argString});";
 	}
 
+	private static String JSGetCallString<TResult, TCall>() where TCall : const String
+	{
+	    if (TCall == null)
+	        return "";
+	    return new $"result = emscripten_asm_const_{JSGetResultName(typeof(TResult))}(AddStringToSection({TCall.Quote(.. scope .())}, \"em_asm\"), \"i\");";
+	}
+
 	public static TResult JSCall<TResult, TCall, T0>(TCall callString, T0 p0) where TCall : const String
 	{
 	    TResult result = default;
 	    Compiler.Mixin(JSGetCallString<TResult, const TCall, T0>());
 	    return result;
 	}
-}
 
+	public static TResult JSCall<TResult, TCall>(TCall callString) where TCall : const String
+	{
+	    TResult result = default;
+	    Compiler.Mixin(JSGetCallString<TResult, const TCall>());
+	    return result;
+	}
+}
 
 #endif

--- a/BeefLibs/corlib/src/WebAssembly.bf
+++ b/BeefLibs/corlib/src/WebAssembly.bf
@@ -42,8 +42,8 @@ class WebAssembly
 		case typeof(double):
 			s.Append('d');
 		case typeof(c_ulong): fallthrough;
-		case typeof(c_ulonglong):
-		case typeof(c_longlong):
+		case typeof(c_ulonglong): fallthrough;
+		case typeof(c_longlong): fallthrough;
 		case typeof(c_long):
 			s.Append('j');
 		default:
@@ -63,7 +63,7 @@ class WebAssembly
 			int count = t.FieldCount;
 			for(int i = 0; i < count; i++)
 			{
-				var type =	t.GetField(i).Get().FieldType;
+				var type = t.GetField(i).Get().FieldType;
 				GetArgSigInternal(type, s);
 			}
 		}else

--- a/IDEHelper/Compiler/BfIRCodeGen.cpp
+++ b/IDEHelper/Compiler/BfIRCodeGen.cpp
@@ -3099,6 +3099,8 @@ void BfIRCodeGen::HandleNextCmd()
 								FatalError("Value is not ConstantExpr");
 						}
 						
+						static int symbolCount = 0;
+						symbolCount++;
 
 						auto charType = llvm::IntegerType::get(*mLLVMContext, 8);
 						std::vector<llvm::Constant*> chars(strContent[0].size());
@@ -3109,8 +3111,11 @@ void BfIRCodeGen::HandleNextCmd()
 						
 						chars.push_back(llvm::ConstantInt::get(charType, 0));
 						auto stringType = llvm::ArrayType::get(charType, chars.size());
-						
-						auto globalVar = (llvm::GlobalVariable*)mLLVMModule->getOrInsertGlobal("", stringType);
+
+						std::string symbolName = strContent[1].str() + "_" + std::to_string(symbolCount);
+						llvm::StringRef resultStringRef(symbolName);
+
+						auto globalVar = (llvm::GlobalVariable*)mLLVMModule->getOrInsertGlobal(symbolName, stringType);
 						globalVar->setSection(strContent[1]);
 						globalVar->setInitializer(llvm::ConstantArray::get(stringType, chars));
 						globalVar->setConstant(true);


### PR DESCRIPTION
Using emscripten there are three main ways of calling javascript code. 

The first one is the slowest, which is to use the emscripten_run_script export, which is essentially running all code through javascripts 'eval' function. This is not ideal if you are looking to get any sort of good performance.

The other two ways are through em_asm and em_js.

Both of these require that strings are put into their own data section in the binary called 'em_asm' and 'em_js'. If this is not the case, emscripten will not allow linking to the required exports for javascript code execution other than 'emscripten_run_script'. The commit attached to this PR adds a em_asm_internal intrinsic which adds strings to the em_asm data section of the binary, and returns a pointer to that string. 

You can read more about this here
[https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-call-javascript-from-native](url)
[https://github.com/emscripten-core/emscripten/blob/main/system/include/emscripten/em_asm.h](url)
[https://github.com/emscripten-core/emscripten/blob/main/system/include/emscripten/em_js.h](url)

It would be used more or less in this way:

```beef
        [Intrinsic(":em_asm_internal")]
	public static extern char8* em_asm_internal(uint8* s);

	[CLink]
	public static extern void emscripten_asm_const_int(char8* code, char8* arg_sigs, ...);

	static Span<uint8> GetStringData(String value)
	{
	    return StringView(value).ToRawData();
	}

	static void em_asm<T>(T value, ...) where T : const String
	{
	    static uint8[?] data = GetStringData(value);

	    #unwarn
	    char8* str = em_asm_internal(&data);
	    emscripten_asm_const_int(str, "i");
	}

	public static void Main(String[] args)
	{
            em_asm("alert('hi');");
	}
```

There are a few things that could and maybe should be changed. 

The first thing being that we could rename em_asm_internal to something more generic and allow adding strings/data to any data section by specifying the data section as a second parameter. That way we could use the same intrinsic for both em_asm and em_js.

There also needs to be some helper code like seen in the example above. Should there be an emscripten library that contains all of emscriptens exports, or should this functionality be added to corelib somehow? 

For em_asm alone, there would at least need to be the importing of emscripten_asm_const_int as well as a call to the em_asm_internal intrinsic, as well as a call to figure out arg_sig for the emscripten_asm_const_int call, as seen in the em_asm header file linked to above. It might be cleaner to have all of it as its own library. 