### PR TITLE
Added "In" to RefKind

### DIFF
--- a/BeefLibs/corlib/src/Type.bf
+++ b/BeefLibs/corlib/src/Type.bf
@@ -1187,6 +1187,7 @@ namespace System.Reflection
 		public enum RefKind
 		{
 			Ref,
+			In,
 			Out,
 			Mut
 		}
@@ -1209,6 +1210,7 @@ namespace System.Reflection
 			switch (mRefKind)
 			{
 			case .Ref: strBuffer.Append("ref ");
+			case .In: strBuffer.Append("in ");
 			case .Out: strBuffer.Append("out ");
 			case .Mut: strBuffer.Append("mut ");
 			}


### PR DESCRIPTION
This PR adds the "In" case to the `RefType.RefKind` enum to correctly match `BfRefType::RefKind` on the C++ side. `GetFullName` has been changed accordingly.

This fixes any instance where `GetFullName` could be called on a RefType, such as `GetParamsDecl`.