### PR TITLE
Fix cursor positioning after select

### DIFF
--- a/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
+++ b/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
@@ -847,6 +847,7 @@ namespace Beefy.widgets
 				{
 					mSelection = null;
 					MoveCursorToCoord(x, y);
+					ClampCursor();
 				}
 				mDragSelectionKind = .None;
 		    }


### PR DESCRIPTION
If the user clicks outside of a selection box, the cursor won't clamp to the line.

## Before
![ezgif-3-e6189d573b](https://github.com/beefytech/Beef/assets/24588691/34e49888-1182-4fc0-b278-51edd2e8aa2e)

## After
![ezgif-3-5ff462beba](https://github.com/beefytech/Beef/assets/24588691/531c5763-f507-45d8-a95d-ce48a97f7b9b)
