### PR TITLE
Fix build_wasm.bat, was missing Hash.cpp

### DIFF
--- a/wasm/build_wasm.bat
+++ b/wasm/build_wasm.bat
@@ -32,13 +32,13 @@ copy ..\BeefySysLib\third_party\putty\* src\BeefySysLib\third_party\putty
 
 IF "%1" EQU "setup" GOTO SUCCESS
 
-call emcc src\rt\Chars.cpp src\rt\Math.cpp src\rt\Object.cpp src\rt\Thread.cpp src\rt\Internal.cpp src\BeefySysLib\platform\wasm\WasmCommon.cpp src\BeefySysLib\Common.cpp src\BeefySysLib\util\String.cpp src\BeefySysLib\util\UTF8.cpp src\BeefySysLib\third_party\utf8proc\utf8proc.c src\BeefySysLib\third_party\putty\wildcard.c -Isrc\ -Isrc\BeefySysLib -Isrc\BeefySysLib\platform\wasm -g -DBF_DISABLE_FFI -c
+call emcc src\rt\Chars.cpp src\rt\Math.cpp src\rt\Object.cpp src\rt\Thread.cpp src\rt\Internal.cpp src\BeefySysLib\platform\wasm\WasmCommon.cpp src\BeefySysLib\Common.cpp src\BeefySysLib\util\String.cpp src\BeefySysLib\util\UTF8.cpp src\BeefySysLib\util\Hash.cpp src\BeefySysLib\third_party\utf8proc\utf8proc.c src\BeefySysLib\third_party\putty\wildcard.c -Isrc\ -Isrc\BeefySysLib -Isrc\BeefySysLib\platform\wasm -g -DBF_DISABLE_FFI -c
 @IF %ERRORLEVEL% NEQ 0 GOTO HADERROR
-call emar r %LIBPATH%\Beef042RT32_wasm.a Common.o Internal.o Chars.o Math.o Object.o String.o Thread.o UTF8.o utf8proc.o wildcard.o WasmCommon.o
+call emar r %LIBPATH%\Beef042RT32_wasm.a Common.o Internal.o Chars.o Math.o Object.o String.o Thread.o UTF8.o Hash.o utf8proc.o wildcard.o WasmCommon.o
 @IF %ERRORLEVEL% NEQ 0 GOTO HADERROR
-call emcc src\rt\Chars.cpp src\rt\Math.cpp src\rt\Object.cpp src\rt\Thread.cpp src\rt\Internal.cpp src\BeefySysLib\platform\wasm\WasmCommon.cpp src\BeefySysLib\Common.cpp src\BeefySysLib\util\String.cpp src\BeefySysLib\util\UTF8.cpp src\BeefySysLib\third_party\utf8proc\utf8proc.c src\BeefySysLib\third_party\putty\wildcard.c -Isrc\ -Isrc\BeefySysLib -Isrc\BeefySysLib\platform\wasm -g -DBF_DISABLE_FFI -c -pthread
+call emcc src\rt\Chars.cpp src\rt\Math.cpp src\rt\Object.cpp src\rt\Thread.cpp src\rt\Internal.cpp src\BeefySysLib\platform\wasm\WasmCommon.cpp src\BeefySysLib\Common.cpp src\BeefySysLib\util\String.cpp src\BeefySysLib\util\UTF8.cpp src\BeefySysLib\util\Hash.cpp src\BeefySysLib\third_party\utf8proc\utf8proc.c src\BeefySysLib\third_party\putty\wildcard.c -Isrc\ -Isrc\BeefySysLib -Isrc\BeefySysLib\platform\wasm -g -DBF_DISABLE_FFI -c -pthread
 @IF %ERRORLEVEL% NEQ 0 GOTO HADERROR
-call emar r %LIBPATH%\Beef042RT32_wasm_pthread.a Common.o Internal.o Chars.o Math.o Object.o String.o Thread.o UTF8.o utf8proc.o wildcard.o WasmCommon.o
+call emar r %LIBPATH%\Beef042RT32_wasm_pthread.a Common.o Internal.o Chars.o Math.o Object.o String.o Thread.o UTF8.o Hash.o utf8proc.o wildcard.o WasmCommon.o
 @IF %ERRORLEVEL% NEQ 0 GOTO HADERROR
 
 :SUCCESS


### PR DESCRIPTION
This fixes the wasm build errors regarding missing HashContext symbols:

wasm-ld: error: c:/beef/bin/Beef042RT32_wasm.a(WasmCommon.o): undefined symbol: Beefy::HashContext::Finish64()
wasm-ld: error: c:/beef/bin/Beef042RT32_wasm.a(WasmCommon.o): undefined symbol: Beefy::HashContext::~HashContext()
wasm-ld: error: c:/beef/bin/Beef042RT32_wasm.a(WasmCommon.o): undefined symbol: Beefy::HashContext::Mixin(void const*, int)
wasm-ld: error: c:/beef/bin/Beef042RT32_wasm.a(WasmCommon.o): undefined symbol: Beefy::HashContext::Mixin(void const*, int)
wasm-ld: error: c:/beef/bin/Beef042RT32_wasm.a(WasmCommon.o): undefined symbol: Beefy::HashContext::Mixin(void const*, int)

It's not clear to me why I was not getting these errors until recent nightly builds though. Possibly I was not making use of these symbols before.

With this fix wasm builds and emscripten project runs fine again.