### PR TITLE
added remnant property

### DIFF
--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -3118,7 +3118,10 @@ namespace System
 		{
 			get
 			{
-				return .(mPtr + mMatchPos + 1, mStrLen - mMatchPos);
+				int offset = 0;
+				if(mMatchPos < mStrLen)
+					offset = 1;
+				return .(mPtr + mMatchPos + offset, mStrLen - (mMatchPos+offset));
 			}
 		}
 		
@@ -3303,6 +3306,17 @@ namespace System
 			get
 			{
 				return mMatchPos < mStrLen && (!mSplitOptions.HasFlag(StringSplitOptions.RemoveEmptyEntries) || mStrLen != 0);
+			}
+		}
+
+		public StringView Remnant
+		{
+			get
+			{
+				int offset = 0;
+				if(mMatchPos < mStrLen)
+					offset = mMatchLen;
+				return .(mPtr + mMatchPos + offset, mStrLen - (mMatchPos+offset));
 			}
 		}
 

--- a/BeefLibs/corlib/src/String.bf
+++ b/BeefLibs/corlib/src/String.bf
@@ -3113,6 +3113,14 @@ namespace System
 				return mMatchPos < mStrLen && (!mSplitOptions.HasFlag(StringSplitOptions.RemoveEmptyEntries) || mStrLen != 0);
 			}
 		}
+
+		public StringView Remnant
+		{
+			get
+			{
+				return .(mPtr + mMatchPos + 1, mStrLen - mMatchPos);
+			}
+		}
 		
 		public bool MoveNext() mut
 		{


### PR DESCRIPTION
The property returns a string view of what remains in the current string split enumerator.
The second commit adds a variant for StringStringSplitEnumerator and also fixes a potential offset error, for things like empty strings