### PR TITLE
Add two new debug apis to System.Diagnostics.Debug. BreakIf and SafeBreakIf

### DIFF
--- a/BeefLibs/corlib/src/Diagnostics/Debug.bf
+++ b/BeefLibs/corlib/src/Diagnostics/Debug.bf
@@ -5,7 +5,7 @@ namespace System.Diagnostics
 #if !DEBUG
 		[SkipCall]
 #endif
-		public static void Assert(bool condition, String error = Compiler.CallerExpression[0], String filePath = Compiler.CallerFilePath, int line = Compiler.CallerLineNum) 
+		public static void Assert(bool condition, String error = Compiler.CallerExpression[0], String filePath = Compiler.CallerFilePath, int line = Compiler.CallerLineNum)
 		{
 			if (!condition)
 			{
@@ -106,6 +106,20 @@ namespace System.Diagnostics
 		public static void SafeBreak()
 		{
 			if (gIsDebuggerPresent)
+				Break();
+		}
+
+		[NoDebug]
+		public static void BreakIf(bool condition)
+		{
+			if (condition)
+				Break();
+		}
+
+		[NoDebug]
+		public static void SafeBreakIf(bool condition)
+		{
+			if (gIsDebuggerPresent && condition)
 				Break();
 		}
 


### PR DESCRIPTION
These work like existing Break/SafeBreak but additionally take in a conditional parameter. This allows breaks like this:

if (x==1) {
    Debug.Break();
}

To turn into:

Debug.BreakIf(x==1)

Potentially BreakAssert, or AssertBreak() might be more appropriate naming