### PR TITLE
Add new overloads for Break/SafeBreak

### DIFF
--- a/BeefLibs/corlib/src/Diagnostics/Debug.bf
+++ b/BeefLibs/corlib/src/Diagnostics/Debug.bf
@@ -5,7 +5,7 @@ namespace System.Diagnostics
 #if !DEBUG
 		[SkipCall]
 #endif
-		public static void Assert(bool condition, String error = Compiler.CallerExpression[0], String filePath = Compiler.CallerFilePath, int line = Compiler.CallerLineNum) 
+		public static void Assert(bool condition, String error = Compiler.CallerExpression[0], String filePath = Compiler.CallerFilePath, int line = Compiler.CallerLineNum)
 		{
 			if (!condition)
 			{
@@ -106,6 +106,20 @@ namespace System.Diagnostics
 		public static void SafeBreak()
 		{
 			if (gIsDebuggerPresent)
+				Break();
+		}
+
+		[NoDebug]
+		public static void Break(bool condition)
+		{
+			if (condition)
+				Break();
+		}
+
+		[NoDebug]
+		public static void SafeBreak(bool condition)
+		{
+			if (condition && gIsDebuggerPresent)
 				Break();
 		}
 


### PR DESCRIPTION
These work like existing Break/SafeBreak but additionally take in a conditional parameter. This allows breaks like this:

if (x==1) {
    Debug.Break();
}

To turn into:

Debug.Break(x==1)