### PR TITLE
added IParseable interface and applied it to all applicable types

### DIFF
--- a/BeefLibs/corlib/src/Boolean.bf
+++ b/BeefLibs/corlib/src/Boolean.bf
@@ -1,6 +1,6 @@
 namespace System
 {
-	struct Boolean : bool, IHashable
+	struct Boolean : bool, IHashable, IParseable<bool>
 	{
 		//
 		// Public Constants

--- a/BeefLibs/corlib/src/Double.bf
+++ b/BeefLibs/corlib/src/Double.bf
@@ -10,7 +10,7 @@ namespace System
 	using System.Diagnostics;
 
 #unwarn
-    public struct Double : double, IFloating, ISigned, IFormattable, IHashable, ICanBeNaN
+    public struct Double : double, IFloating, ISigned, IFormattable, IHashable, ICanBeNaN, IParseable<double>
     {
         public const double MinValue = -1.7976931348623157E+308;
         public const double MaxValue = 1.7976931348623157E+308;

--- a/BeefLibs/corlib/src/Float.bf
+++ b/BeefLibs/corlib/src/Float.bf
@@ -3,7 +3,7 @@ using System.Globalization;
 namespace System
 {
 #unwarn
-	struct Float : float, IFloating, ISigned, IFormattable, IHashable, IEquatable<float>, ICanBeNaN
+	struct Float : float, IFloating, ISigned, IFormattable, IHashable, IEquatable<float>, ICanBeNaN, IParseable<float>
     {
 		public const float MinValue = (float)-3.40282346638528859e+38;
 		public const float Epsilon = (float)1.4e-45;

--- a/BeefLibs/corlib/src/Guid.bf
+++ b/BeefLibs/corlib/src/Guid.bf
@@ -1,6 +1,6 @@
 namespace System
 {
-	struct Guid : IHashable
+	struct Guid : IHashable, IParseable<Guid>
 	{
 		public static readonly Guid Empty = Guid();
         
@@ -58,7 +58,7 @@ namespace System
 				(val1.mK == val2.mK);
 		}
 
-		public static Result<Guid> Parse(String str)
+		public static Result<Guid> Parse(StringView val)
 		{
 			return .Err;
 		}

--- a/BeefLibs/corlib/src/IParseable.bf
+++ b/BeefLibs/corlib/src/IParseable.bf
@@ -1,0 +1,11 @@
+namespace System;
+
+interface IParseable<T>
+{
+	public static Result<T> Parse(StringView val);
+}
+
+interface IParseable<T, TErr>
+{
+	public static Result<T,TErr> Parse(StringView val);
+}

--- a/BeefLibs/corlib/src/Int.bf
+++ b/BeefLibs/corlib/src/Int.bf
@@ -3,7 +3,7 @@ using System;
 namespace System
 {
 #unwarn
-	struct Int : int, IInteger, IHashable, IFormattable, IIsNaN
+	struct Int : int, IInteger, IHashable, IFormattable, IIsNaN, IParseable<int, ParseError>, IParseable<int>
     {
 		public enum ParseError
 		{
@@ -96,6 +96,20 @@ namespace System
 				var result = Int32.Parse(val);
 				return *(Result<int, ParseError>*)&result;
 			}
+		}
+
+		public static Result<int, ParseError> IParseable<int, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<int> IParseable<int>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/Int16.bf
+++ b/BeefLibs/corlib/src/Int16.bf
@@ -3,7 +3,7 @@ using System.Globalization;
 namespace System
 {
 #unwarn
-	struct Int16 : int16, IInteger, ISigned, IHashable, IFormattable, IIsNaN
+	struct Int16 : int16, IInteger, ISigned, IHashable, IFormattable, IIsNaN, IParseable<int16, ParseError>, IParseable<int16>
 	{
 		public enum ParseError
 		{
@@ -138,6 +138,20 @@ namespace System
 			}
 
 			return isNeg ? -result : result;
+		}
+
+		public static Result<int16, ParseError> IParseable<int16, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<int16> IParseable<int16>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/Int32.bf
+++ b/BeefLibs/corlib/src/Int32.bf
@@ -3,7 +3,7 @@ using System.Globalization;
 namespace System
 {
 #unwarn
-	struct Int32 : int32, IInteger, ISigned, IHashable, IFormattable, IIsNaN
+	struct Int32 : int32, IInteger, ISigned, IHashable, IFormattable, IIsNaN, IParseable<int32, ParseError>, IParseable<int32>
 	{
 		public enum ParseError
 		{
@@ -187,6 +187,20 @@ namespace System
 			}
 
 			return isNeg ? -result : result;
+		}
+
+		public static Result<int32, ParseError> IParseable<int32, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<int32> IParseable<int32>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/Int64.bf
+++ b/BeefLibs/corlib/src/Int64.bf
@@ -3,7 +3,7 @@ using System.Globalization;
 namespace System
 {
 #unwarn
-	struct Int64 : int64, IInteger, ISigned, IFormattable, IHashable, IIsNaN
+	struct Int64 : int64, IInteger, ISigned, IFormattable, IHashable, IIsNaN, IParseable<int64, ParseError>, IParseable<int64>
 	{
 		public enum ParseError
 		{
@@ -168,6 +168,20 @@ namespace System
 			}
 
 			return isNeg ? -result : result;
+		}
+
+		public static Result<int64, ParseError> IParseable<int64, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<int64> IParseable<int64>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/Int8.bf
+++ b/BeefLibs/corlib/src/Int8.bf
@@ -3,7 +3,7 @@ using System.Globalization;
 namespace System
 {
 #unwarn
-	struct Int8 : int8, IInteger, ISigned, IHashable, IFormattable, IIsNaN
+	struct Int8 : int8, IInteger, ISigned, IHashable, IFormattable, IIsNaN, IParseable<int8, ParseError>, IParseable<int8>
 	{
 		public enum ParseError
 		{
@@ -138,6 +138,20 @@ namespace System
 			}
 
 			return isNeg ? -result : result;
+		}
+
+		public static Result<int8, ParseError> IParseable<int8, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<int8> IParseable<int8>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/Security/Cryptography/MD5.bf
+++ b/BeefLibs/corlib/src/Security/Cryptography/MD5.bf
@@ -32,7 +32,7 @@ namespace System.Security.Cryptography
 		}
 	}
 
-	struct MD5Hash
+	struct MD5Hash : IParseable<MD5Hash>
 	{
 		public uint8[16] mHash;
 

--- a/BeefLibs/corlib/src/Security/Cryptography/SHA256.bf
+++ b/BeefLibs/corlib/src/Security/Cryptography/SHA256.bf
@@ -2,7 +2,7 @@ using System.IO;
 
 namespace System.Security.Cryptography
 {
-	struct SHA256Hash
+	struct SHA256Hash : IParseable<SHA256Hash>
 	{
 		public uint8[32] mHash;
 

--- a/BeefLibs/corlib/src/UInt.bf
+++ b/BeefLibs/corlib/src/UInt.bf
@@ -1,7 +1,7 @@
 namespace System
 {
 #unwarn
-	struct UInt : uint, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN
+	struct UInt : uint, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN, IParseable<uint, ParseError>, IParseable<uint>
 	{
 		public enum ParseError
 		{
@@ -86,6 +86,20 @@ namespace System
 				var result = UInt32.Parse(val);
 				return *(Result<uint, ParseError>*)&result;
 			}
+		}
+
+		public static Result<uint, ParseError> IParseable<uint, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<uint> IParseable<uint>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/UInt16.bf
+++ b/BeefLibs/corlib/src/UInt16.bf
@@ -3,7 +3,7 @@ using System.Globalization;
 namespace System
 {
 #unwarn
-	struct UInt16 : uint16, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN
+	struct UInt16 : uint16, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN, IParseable<uint16, ParseError>, IParseable<uint16>
 	{
 		public enum ParseError
 		{
@@ -133,6 +133,20 @@ namespace System
 			}
 
 			return result;
+		}
+
+		public static Result<uint16, ParseError> IParseable<uint16, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<uint16> IParseable<uint16>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/UInt32.bf
+++ b/BeefLibs/corlib/src/UInt32.bf
@@ -3,7 +3,7 @@ using System.Globalization;
 namespace System
 {
 #unwarn
-	struct UInt32 : uint32, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN
+	struct UInt32 : uint32, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN, IParseable<uint32, ParseError>, IParseable<uint32>
 	{
 		public enum ParseError
 		{
@@ -161,6 +161,20 @@ namespace System
 			}
 
 			return result;
+		}
+
+		public static Result<uint32, ParseError> IParseable<uint32, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<uint32> IParseable<uint32>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/UInt64.bf
+++ b/BeefLibs/corlib/src/UInt64.bf
@@ -3,7 +3,7 @@ using System.Globalization;
 namespace System
 {
 #unwarn
-	struct UInt64 : uint64, IInteger, IUnsigned, IHashable, IIsNaN, IFormattable
+	struct UInt64 : uint64, IInteger, IUnsigned, IHashable, IIsNaN, IFormattable, IParseable<uint64, ParseError>, IParseable<uint64>
 	{
 		public enum ParseError
 		{
@@ -145,6 +145,20 @@ namespace System
 			}
 
 			return result;
+		}
+
+		public static Result<uint64, ParseError> IParseable<uint64, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<uint64> IParseable<uint64>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/UInt8.bf
+++ b/BeefLibs/corlib/src/UInt8.bf
@@ -3,7 +3,7 @@ using System.Globalization;
 namespace System
 {
 #unwarn
-	struct UInt8 : uint8, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN
+	struct UInt8 : uint8, IInteger, IUnsigned, IHashable, IFormattable, IIsNaN, IParseable<uint8, ParseError>, IParseable<uint8>
 	{
 		public enum ParseError
 		{
@@ -133,6 +133,20 @@ namespace System
 			}
 
 			return result;
+		}
+
+		public static Result<uint8, ParseError> IParseable<uint8, ParseError>.Parse(StringView val)
+		{
+			return Parse(val);
+		}
+
+		public static Result<uint8> IParseable<uint8>.Parse(StringView val)
+		{
+			var res = Parse(val);
+			if(res case .Err)
+				return .Err;
+			else
+				return .Ok(res.Value);
 		}
 	}
 }

--- a/BeefLibs/corlib/src/Version.bf
+++ b/BeefLibs/corlib/src/Version.bf
@@ -1,6 +1,6 @@
 namespace System
 {
-	struct Version
+	struct Version : IParseable<Version>
 	{
 		public uint32 Major;
 		public uint32 Minor;


### PR DESCRIPTION
this adds 2 interfaces to the corlib
IParseable<T>(StringView)
and IParseable<T,TErr>(StringView)
it applies it to all types in the corlib that currently have a parse function

this allows users to generically check wether something can be parsed and makes types able to do it for the user.

Guid is currently not implemented, I might implement it at a later date.
And im not able to find a way to implement it in enum since
Result<int64> Enum.Parse takes in additional parameters
and Enum.Parse<T> also doesnt fit the requirements.
If an implementation that generically applies to Enum.Parse<T> is possible, someone smarter than me would have to write that.
Otherwise it can probably be added to specific enums, but im not sure if corlib should do that for all of its enums