### PR TITLE
Make sure command line arguments with whitespace are enclosed in quotes

### DIFF
--- a/BeefySysLib/platform/posix/PosixCommon.cpp
+++ b/BeefySysLib/platform/posix/PosixCommon.cpp
@@ -600,7 +600,7 @@ BFP_EXPORT void BFP_CALLTYPE BfpSystem_SetCommandLine(int argc, char** argv)
 			gCmdLine.Append(' ');
 
 		String arg = argv[i];
-		if ((arg.Contains(' ')) || (arg.Contains('\"')))
+		if (arg.Contains(' ') || arg.Contains('\t') || arg.Contains('\r') || arg.Contains('\n') || arg.Contains('\"'))
 		{
 			arg.Replace("\"", "\\\"");
 			gCmdLine.Append("\"");


### PR DESCRIPTION
I fixed #1920 . I tested this manually:
```console
$ ./CommandLineBug/build/Debug_Linux64/CommandLineBug/CommandLineBug "$(printf '\tHello\tThere\tFriend\t')"
Arg 0 = '       Hello   There   Friend  '
$ ./CommandLineBug/build/Debug_Linux64/CommandLineBug/CommandLineBug "$(printf '\nHello\nThere\nFriend\n')"
Arg 0 = '
Hello
There
Friend'
$ ./CommandLineBug/build/Debug_Linux64/CommandLineBug/CommandLineBug "$(printf '\r\nHello\r\nThere\r\nFriend\n')"
Arg 0 = '
Hello
There
Friend'
$
```

I ran the build for the whole project via `bin/build.sh`, and everything passed with this change. Is there a way to test changes to the C++ code?