### PR TITLE
Bug fix for empty command-line arguments

### DIFF
--- a/BeefySysLib/platform/posix/PosixCommon.cpp
+++ b/BeefySysLib/platform/posix/PosixCommon.cpp
@@ -600,7 +600,7 @@ BFP_EXPORT void BFP_CALLTYPE BfpSystem_SetCommandLine(int argc, char** argv)
 			gCmdLine.Append(' ');
 
 		String arg = argv[i];
-		if (arg.Contains(' ') || arg.Contains('\t') || arg.Contains('\r') || arg.Contains('\n') || arg.Contains('\"'))
+		if (arg.IsEmpty() || arg.Contains(' ') || arg.Contains('\t') || arg.Contains('\r') || arg.Contains('\n') || arg.Contains('\"'))
 		{
 			arg.Replace("\"", "\\\"");
 			gCmdLine.Append("\"");


### PR DESCRIPTION
I fixed #1924 . I manually test this:
```console
$ CommandLineBug/build/Debug_Linux64/CommandLineBug/CommandLineBug ""
Arg 0 = ''
$ CommandLineBug/build/Debug_Linux64/CommandLineBug/CommandLineBug "Hello" ""
Arg 0 = 'Hello'
Arg 1 = ''
$ CommandLineBug/build/Debug_Linux64/CommandLineBug/CommandLineBug "Hello" "" "There"
Arg 0 = 'Hello'
Arg 1 = ''
Arg 2 = 'There'
$ 
```