### PR TITLE
Allow method reference as the Sort comparer

### DIFF
--- a/BeefLibs/corlib/src/Array.bf
+++ b/BeefLibs/corlib/src/Array.bf
@@ -159,19 +159,40 @@ namespace System
 
 		public static void Sort<T>(T[] array, Comparison<T> comp)
 		{
-			var sorter = Sorter<T, void>(&array.[Friend]mFirstElement, null, array.[Friend]mLength, comp);
+			var sorter = Sorter<T, void, Comparison<T>>(&array.[Friend]mFirstElement, null, array.[Friend]mLength, comp);
+			sorter.[Friend]Sort(0, array.[Friend]mLength);
+		}
+
+		public static void Sort<T, TComparer>(T[] array, TComparer comp)
+			where TComparer : Comparison<T>
+		{
+			var sorter = Sorter<T, void, TComparer>(&array.[Friend]mFirstElement, null, array.[Friend]mLength, comp);
 			sorter.[Friend]Sort(0, array.[Friend]mLength);
 		}
 
 		public static void Sort<T, T2>(T[] keys, T2[] items, Comparison<T> comp)
 		{
-			var sorter = Sorter<T, T2>(&keys.[Friend]mFirstElement, &items.[Friend]mFirstElement, keys.[Friend]mLength, comp);
+			var sorter = Sorter<T, T2, Comparison<T>>(&keys.[Friend]mFirstElement, &items.[Friend]mFirstElement, keys.[Friend]mLength, comp);
+			sorter.[Friend]Sort(0, keys.[Friend]mLength);
+		}
+
+		public static void Sort<T, T2, TComparer>(T[] keys, T2[] items, Comparison<T> comp)
+			where TComparer : Comparison<T>
+		{
+			var sorter = Sorter<T, T2, TComparer>(&keys.[Friend]mFirstElement, &items.[Friend]mFirstElement, keys.[Friend]mLength, comp);
 			sorter.[Friend]Sort(0, keys.[Friend]mLength);
 		}
 
 		public static void Sort<T>(T[] array, int index, int count, Comparison<T> comp)
 		{
-			var sorter = Sorter<T, void>(&array.[Friend]mFirstElement, null, array.[Friend]mLength, comp);
+			var sorter = Sorter<T, void, Comparison<T>>(&array.[Friend]mFirstElement, null, array.[Friend]mLength, comp);
+			sorter.[Friend]Sort(index, count);
+		}
+
+		public static void Sort<T, TComparer>(T[] array, int index, int count, Comparison<T> comp)
+			where TComparer : Comparison<T>
+		{
+			var sorter = Sorter<T, void, TComparer>(&array.[Friend]mFirstElement, null, array.[Friend]mLength, comp);
 			sorter.[Friend]Sort(index, count);
 		}
 

--- a/BeefLibs/corlib/src/Collections/List.bf
+++ b/BeefLibs/corlib/src/Collections/List.bf
@@ -789,14 +789,29 @@ namespace System.Collections
 
 		public void Sort(Comparison<T> comp)
 		{
-			var sorter = Sorter<T, void>(mItems, null, mSize, comp);
+			var sorter = Sorter<T, void, Comparison<T>>(mItems, null, mSize, comp);
+			sorter.[Friend]Sort(0, mSize);
+		}
+
+		public void Sort<TComparer>(TComparer comp)
+			where TComparer : Comparison<T>
+		{
+			var sorter = Sorter<T, void, TComparer>(mItems, null, mSize, comp);
 			sorter.[Friend]Sort(0, mSize);
 		}
 
 		public void Sort(Comparison<T> comp, int index, int count)
 		{
 			Debug.Assert((uint)index + (uint)count <= (uint)mSize);
-			var sorter = Sorter<T, void>(mItems, null, mSize, comp);
+			var sorter = Sorter<T, void, Comparison<T>>(mItems, null, mSize, comp);
+			sorter.[Friend]Sort(index, count);
+		}
+
+		public void Sort<TComparer>(TComparer comp, int index, int count)
+			where TComparer : Comparison<T>
+		{
+			Debug.Assert((uint)index + (uint)count <= (uint)mSize);
+			var sorter = Sorter<T, void, TComparer>(mItems, null, mSize, comp);
 			sorter.[Friend]Sort(index, count);
 		}
 
@@ -1137,7 +1152,7 @@ namespace System.Collections
 
 		public void Sort()
 		{
-			Sort(scope (lhs, rhs) => lhs <=> rhs);
+			Sort((lhs, rhs) => lhs <=> rhs);
 		}
 	}
 

--- a/BeefLibs/corlib/src/Collections/Sorter.bf
+++ b/BeefLibs/corlib/src/Collections/Sorter.bf
@@ -4,7 +4,8 @@
 
 namespace System.Collections
 {
-	struct Sorter<T, T2>
+	struct Sorter<T, T2, TComparer>
+		where TComparer : Comparison<T>
 	{
 		// This is the threshold where Introspective sort switches to Insertion sort.
 		// Empirically, 16 seems to speed up most cases without slowing down others, at least for integers.
@@ -14,9 +15,9 @@ namespace System.Collections
 	    private T* keys;
 	    private T2* items;
 		private int mCount;
-	    private Comparison<T> comparer;    
+	    private TComparer comparer;    
 
-	    public this(T* keys, T2* items, int count, Comparison<T> comparer) 
+	    public this(T* keys, T2* items, int count, TComparer comparer) 
 	    {
 	        this.keys = keys;
 	        this.items = items;

--- a/BeefLibs/corlib/src/Span.bf
+++ b/BeefLibs/corlib/src/Span.bf
@@ -301,7 +301,14 @@ namespace System
 
 		public void Sort(Comparison<T> comp)
 		{
-			var sorter = Sorter<T, void>(Ptr, null, Length, comp);
+			var sorter = Sorter<T, void, Comparison<T>>(Ptr, null, Length, comp);
+			sorter.[Friend]Sort(0, Length);
+		}
+
+		public void Sort<TComparer>(TComparer comp)
+			where TComparer : Comparison<T>
+		{
+			var sorter = Sorter<T, void, TComparer>(Ptr, null, Length, comp);
 			sorter.[Friend]Sort(0, Length);
 		}
 


### PR DESCRIPTION
This PR allows the use of method references as the Sort comparer, from my tests this almost doubles the sorting speed (depending on the data being compared).

## Delegate
```cs
let rand = scope Random();

let nums = new List<int>();
defer delete nums;

nums.Resize(10000000);
for (int32 i = 0; i < nums.Count; i++)
{
	nums[i] = rand.NextI64();
}

let sw = Stopwatch.StartNew();
defer delete sw;

nums.Sort(scope (lhs, rhs) => lhs <=> rhs);

Console.WriteLine(sw.ElapsedMilliseconds); // 1208
Console.Read();
```

## Method Reference
```cs
let rand = scope Random();

let nums = new List<int>();
defer delete nums;

nums.Resize(10000000);
for (int32 i = 0; i < nums.Count; i++)
{
	nums[i] = rand.NextI64();
}

let sw = Stopwatch.StartNew();
defer delete sw;

nums.Sort((lhs, rhs) => lhs <=> rhs);

Console.WriteLine(sw.ElapsedMilliseconds); // 746
Console.Read();
```