### PR TITLE
Use pre-built LLVM if available (Linux)

### DIFF
--- a/BeefBoot/CMakeLists.txt
+++ b/BeefBoot/CMakeLists.txt
@@ -44,8 +44,6 @@ if (${APPLE})
     ../BeefySysLib/
     ../BeefySysLib/third_party
     ../BeefySysLib/third_party/freetype/include
-    ../extern/llvm-project_13_0_1/llvm/include
-    ../extern/llvm-project_13_0_1/llvm/lib/Target
     ../IDEHelper
 
     ../BeefySysLib/platform/osx
@@ -57,8 +55,6 @@ else()
     ../BeefySysLib/
     ../BeefySysLib/third_party
     ../BeefySysLib/third_party/freetype/include
-    ../extern/llvm-project_13_0_1/llvm/include
-    ../extern/llvm-project_13_0_1/llvm/lib/Target
     ../IDEHelper
 
     ../BeefySysLib/platform/linux
@@ -73,19 +69,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(
     -D_DEBUG
   )
-  include_directories(
-    ../extern/llvm_linux_13_0_1/include
-    ../extern/llvm_linux_13_0_1/lib/Target/X86
-  )
   set(EXECUTABLE_OUTPUT_PATH  "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
-  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/lib")
 else()
-  include_directories(
-    ../extern/llvm_linux_rel_13_0_1/include
-    ../extern/llvm_linux_rel_13_0_1/lib/Target/X86
-  )
   set(EXECUTABLE_OUTPUT_PATH  "${CMAKE_BINARY_DIR}/${OUTPUT_RELEASE}")
-  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")
 endif()
 
 ################### Dependencies ##################
@@ -133,19 +119,52 @@ add_executable(${PROJECT_NAME}
    ${SRC_FILES}
 )
 
-execute_process(
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/bin/llvm-config --system-libs --link-static
-  OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  RESULT_VARIABLE EXEC_RESULT
-)
+find_package(LLVM 13 CONFIG COMPONENTS)
 
-if (EXEC_RESULT AND NOT EXEC_RESULT EQUAL 0)
-  if (EXEC_RESULT MATCHES "^[0-9]+$")
-    message(FATAL_ERROR "llvm-config exited with code ${EXEC_RESULT}.")
+if (LLVM_FOUND)
+  message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+  include_directories(${LLVM_INCLUDE_DIRS})
+  add_definitions(${LLVM_DEFINITIONS})
+
+  set(TARGET_LIBS_OS "-lLLVM-13")
+else()
+  include_directories(
+    ../extern/llvm-project_13_0_1/llvm/include
+    ../extern/llvm-project_13_0_1/llvm/lib/Target
+  )
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    include_directories(
+      ../extern/llvm_linux_13_0_1/include
+      ../extern/llvm_linux_13_0_1/lib/Target/X86
+    )
+    set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/lib")
   else()
-    message(FATAL_ERROR "llvm-config couldn't be executed: ${EXEC_RESULT}")
+    include_directories(
+      ../extern/llvm_linux_rel_13_0_1/include
+      ../extern/llvm_linux_rel_13_0_1/lib/Target/X86
+    )
+    set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")
   endif()
+
+  execute_process(
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/bin/llvm-config --system-libs --link-static
+    OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE EXEC_RESULT
+  )
+
+  if (EXEC_RESULT AND NOT EXEC_RESULT EQUAL 0)
+    if (EXEC_RESULT MATCHES "^[0-9]+$")
+      message(FATAL_ERROR "llvm-config exited with code ${EXEC_RESULT}.")
+    else()
+      message(FATAL_ERROR "llvm-config couldn't be executed: ${EXEC_RESULT}")
+    endif()
+  endif()
+  
+  message(STATUS "Found LLVM 13.0.1 (local build)")
 endif()
 
 if (${APPLE})
@@ -159,12 +178,10 @@ endif()
 
 # Link with other dependencies.
 if(MSVC)
-   target_link_libraries(${PROJECT_NAME} BeefySysLib IDEHelper kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib)
+    target_link_libraries(${PROJECT_NAME} BeefySysLib IDEHelper kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib)
 else()
     target_link_libraries(${PROJECT_NAME} BeefySysLib
-        IDEHelper
-        ${TARGET_LIBS_OS}
-
-        #${LLVM_LIB}/libLLVMSupport.a
-        )
+      IDEHelper
+      ${TARGET_LIBS_OS}
+    )
 endif()

--- a/BeefFuzz/CMakeLists.txt
+++ b/BeefFuzz/CMakeLists.txt
@@ -44,8 +44,6 @@ if (${APPLE})
     ../BeefySysLib/
     ../BeefySysLib/third_party
     ../BeefySysLib/third_party/freetype/include
-    ../extern/llvm-project_13_0_1/llvm/include
-    ../extern/llvm-project_13_0_1/llvm/lib/Target
     ../IDEHelper
 
     ../BeefySysLib/platform/osx
@@ -57,8 +55,6 @@ else()
     ../BeefySysLib/
     ../BeefySysLib/third_party
     ../BeefySysLib/third_party/freetype/include
-    ../extern/llvm-project_13_0_1/llvm/include
-    ../extern/llvm-project_13_0_1/llvm/lib/Target
     ../IDEHelper
 
     ../BeefySysLib/platform/linux
@@ -73,19 +69,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(
     -D_DEBUG
   )
-  include_directories(
-    ../extern/llvm_linux_13_0_1/include
-    ../extern/llvm_linux_13_0_1/lib/Target/X86
-  )
   set(EXECUTABLE_OUTPUT_PATH  "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
-  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/lib")
 else()
-  include_directories(
-    ../extern/llvm_linux_rel_13_0_1/include
-    ../extern/llvm_linux_rel_13_0_1/lib/Target/X86
-  )
   set(EXECUTABLE_OUTPUT_PATH  "${CMAKE_BINARY_DIR}/${OUTPUT_RELEASE}")
-  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")
 endif()
 
 ################### Dependencies ##################
@@ -132,19 +118,52 @@ add_executable(${PROJECT_NAME}
    ${SRC_FILES}
 )
 
-execute_process(
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/bin/llvm-config --system-libs --link-static
-  OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  RESULT_VARIABLE EXEC_RESULT
-)
+find_package(LLVM 13 CONFIG COMPONENTS)
 
-if (EXEC_RESULT AND NOT EXEC_RESULT EQUAL 0)
-  if (EXEC_RESULT MATCHES "^[0-9]+$")
-    message(FATAL_ERROR "llvm-config exited with code ${EXEC_RESULT}.")
+if (LLVM_FOUND)
+  message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+  include_directories(${LLVM_INCLUDE_DIRS})
+  add_definitions(${LLVM_DEFINITIONS})
+
+  set(TARGET_LIBS_OS "-lLLVM-13")
+else()
+  include_directories(
+    ../extern/llvm-project_13_0_1/llvm/include
+    ../extern/llvm-project_13_0_1/llvm/lib/Target
+  )
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    include_directories(
+      ../extern/llvm_linux_13_0_1/include
+      ../extern/llvm_linux_13_0_1/lib/Target/X86
+    )
+    set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/lib")
   else()
-    message(FATAL_ERROR "llvm-config couldn't be executed: ${EXEC_RESULT}")
+    include_directories(
+      ../extern/llvm_linux_rel_13_0_1/include
+      ../extern/llvm_linux_rel_13_0_1/lib/Target/X86
+    )
+    set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")
   endif()
+
+  execute_process(
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/bin/llvm-config --system-libs --link-static
+    OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE EXEC_RESULT
+  )
+
+  if (EXEC_RESULT AND NOT EXEC_RESULT EQUAL 0)
+    if (EXEC_RESULT MATCHES "^[0-9]+$")
+      message(FATAL_ERROR "llvm-config exited with code ${EXEC_RESULT}.")
+    else()
+      message(FATAL_ERROR "llvm-config couldn't be executed: ${EXEC_RESULT}")
+    endif()
+  endif()
+  
+  message(STATUS "Found LLVM 13.0.1 (local build)")
 endif()
 
 if (${APPLE})
@@ -158,12 +177,10 @@ endif()
 
 # Link with other dependencies.
 if(MSVC)
-   target_link_libraries(${PROJECT_NAME} BeefySysLib IDEHelper kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib)
+    target_link_libraries(${PROJECT_NAME} BeefySysLib IDEHelper kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib)
 else()
     target_link_libraries(${PROJECT_NAME} BeefySysLib
-        IDEHelper
-        ${TARGET_LIBS_OS}
-
-        #${LLVM_LIB}/libLLVMSupport.a
-        )
+      IDEHelper
+      ${TARGET_LIBS_OS}
+    )
 endif()

--- a/IDEHelper/CMakeLists.txt
+++ b/IDEHelper/CMakeLists.txt
@@ -49,8 +49,6 @@ if (${APPLE})
     ../BeefySysLib/
     ../BeefySysLib/third_party
     ../BeefySysLib/third_party/freetype/include
-    ../extern/llvm-project_13_0_1/llvm/include
-    ../extern/llvm-project_13_0_1/llvm/lib/Target
 
     ../BeefySysLib/platform/osx
   )
@@ -61,8 +59,6 @@ else()
     ../BeefySysLib/
     ../BeefySysLib/third_party
     ../BeefySysLib/third_party/freetype/include
-    ../extern/llvm-project_13_0_1/llvm/include
-    ../extern/llvm-project_13_0_1/llvm/lib/Target
 
     ../BeefySysLib/platform/linux
   )
@@ -76,25 +72,13 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(
     -D_DEBUG
   )
-  include_directories(
-    ../extern/llvm_linux_13_0_1/include
-    ../extern/llvm_linux_13_0_1/lib/Target/X86
-    ../extern/llvm_linux_13_0_1/lib/Target/AArch64
-  )
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
   set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_DEBUG}")
-  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/lib")
 else()
-  include_directories(
-    ../extern/llvm_linux_rel_13_0_1/include
-    ../extern/llvm_linux_rel_13_0_1/lib/Target/X86
-    ../extern/llvm_linux_rel_13_0_1/lib/Target/AArch64
-  )
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_RELEASE}")
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_RELEASE}")
   set(CMAKE_EXECUTABLE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OUTPUT_RELEASE}")
-  set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")
 endif()
 
 ################### Dependencies ##################
@@ -137,9 +121,6 @@ file(GLOB SRC_FILES
     NetManager.cpp
     SpellChecker.cpp
     Targets.cpp
-    X64.cpp
-    X86.cpp
-    X86Target.cpp
     X86XmmInfo.cpp
 
     LinuxDebugger.cpp
@@ -187,102 +168,144 @@ file(GLOB SRC_FILES
     Backend/BeModule.cpp
 )
 
+find_package(LLVM 13 CONFIG COMPONENTS)
+
+if (LLVM_FOUND)
+  message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+  include_directories(${LLVM_INCLUDE_DIRS})
+  add_definitions(${LLVM_DEFINITIONS})
+
+  set(TARGET_LIBS_OS "-lLLVM-13 ${LLVM_SYSTEM_LIBS}")
+else()
+  list(APPEND SRC_FILES
+    X64.cpp
+    X86.cpp
+    X86Target.cpp
+  )
+
+  include_directories(
+    ../extern/llvm-project_13_0_1/llvm/include
+    ../extern/llvm-project_13_0_1/llvm/lib/Target
+  )
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    include_directories(
+      ../extern/llvm_linux_13_0_1/include
+      ../extern/llvm_linux_13_0_1/lib/Target/X86
+      ../extern/llvm_linux_13_0_1/lib/Target/AArch64
+    )
+    set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/lib")
+  else()
+    include_directories(
+      ../extern/llvm_linux_rel_13_0_1/include
+      ../extern/llvm_linux_rel_13_0_1/lib/Target/X86
+      ../extern/llvm_linux_rel_13_0_1/lib/Target/AArch64
+    )
+    set(LLVM_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_rel_13_0_1/lib")
+  endif()
+
+  execute_process(
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/bin/llvm-config --system-libs --link-static
+    OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE EXEC_RESULT
+  )
+
+  if (EXEC_RESULT AND NOT EXEC_RESULT EQUAL 0)
+    if (EXEC_RESULT MATCHES "^[0-9]+$")
+      message(FATAL_ERROR "llvm-config exited with code ${EXEC_RESULT}.")
+    else()
+      message(FATAL_ERROR "llvm-config couldn't be executed: ${EXEC_RESULT}")
+    endif()
+  endif()
+  
+  message(STATUS "Found LLVM 13.0.1 (local build)")
+
+  set(TARGET_LIBS_OS "${LLVM_SYSTEM_LIBS}")
+
+  list(APPEND LLVM_LIBS
+    ${LLVM_LIB}/libLLVMCore.a
+    ${LLVM_LIB}/libLLVMCodeGen.a
+    ${LLVM_LIB}/libLLVMMC.a
+    ${LLVM_LIB}/libLLVMMCParser.a
+    ${LLVM_LIB}/libLLVMMCDisassembler.a
+    ${LLVM_LIB}/libLLVMObject.a
+    ${LLVM_LIB}/libLLVMBitReader.a
+    ${LLVM_LIB}/libLLVMAsmParser.a
+    ${LLVM_LIB}/libLLVMTarget.a
+    ${LLVM_LIB}/libLLVMScalarOpts.a
+    ${LLVM_LIB}/libLLVMInstCombine.a
+    ${LLVM_LIB}/libLLVMSelectionDAG.a
+    ${LLVM_LIB}/libLLVMProfileData.a
+
+    ${LLVM_LIB}/libLLVMAnalysis.a
+    ${LLVM_LIB}/libLLVMAsmPrinter.a
+    ${LLVM_LIB}/libLLVMBitWriter.a
+    ${LLVM_LIB}/libLLVMVectorize.a
+    ${LLVM_LIB}/libLLVMipo.a
+    ${LLVM_LIB}/libLLVMInstrumentation.a
+    ${LLVM_LIB}/libLLVMDebugInfoDWARF.a
+    ${LLVM_LIB}/libLLVMDebugInfoPDB.a
+    ${LLVM_LIB}/libLLVMDebugInfoCodeView.a
+    ${LLVM_LIB}/libLLVMGlobalISel.a
+    ${LLVM_LIB}/libLLVMTransformUtils.a
+    ${LLVM_LIB}/libLLVMBinaryFormat.a
+    ${LLVM_LIB}/libLLVMIRReader.a
+    ${LLVM_LIB}/libLLVMLinker.a
+    ${LLVM_LIB}/libLLVMAggressiveInstCombine.a
+
+    ${LLVM_LIB}/libLLVMBitstreamReader.a
+    ${LLVM_LIB}/libLLVMCFGuard.a
+    ${LLVM_LIB}/libLLVMTextAPI.a
+    ${LLVM_LIB}/libLLVMRemarks.a
+
+    ${LLVM_LIB}/libLLVMX86Info.a
+    ${LLVM_LIB}/libLLVMX86Desc.a
+    ${LLVM_LIB}/libLLVMX86CodeGen.a
+    ${LLVM_LIB}/libLLVMX86AsmParser.a
+    ${LLVM_LIB}/libLLVMX86Disassembler.a
+
+    ${LLVM_LIB}/libLLVMARMDesc.a
+    ${LLVM_LIB}/libLLVMARMUtils.a
+    ${LLVM_LIB}/libLLVMARMInfo.a
+    ${LLVM_LIB}/libLLVMARMCodeGen.a
+    ${LLVM_LIB}/libLLVMARMAsmParser.a
+    ${LLVM_LIB}/libLLVMARMDisassembler.a
+
+    ${LLVM_LIB}/libLLVMAArch64Desc.a
+    ${LLVM_LIB}/libLLVMAArch64Utils.a
+    ${LLVM_LIB}/libLLVMAArch64Info.a
+    ${LLVM_LIB}/libLLVMAArch64CodeGen.a
+    ${LLVM_LIB}/libLLVMAArch64AsmParser.a
+    ${LLVM_LIB}/libLLVMAArch64Disassembler.a
+
+    ${LLVM_LIB}/libLLVMWebAssemblyDesc.a
+    ${LLVM_LIB}/libLLVMWebAssemblyInfo.a
+    ${LLVM_LIB}/libLLVMWebAssemblyCodeGen.a
+    ${LLVM_LIB}/libLLVMWebAssemblyAsmParser.a
+    ${LLVM_LIB}/libLLVMWebAssemblyDisassembler.a
+    ${LLVM_LIB}/libLLVMWebAssemblyUtils.a
+
+    ${LLVM_LIB}/libLLVMSupport.a
+    ${LLVM_LIB}/libLLVMDemangle.a
+  )
+
+  FOREACH (lib ${LLVM_LIBS})
+    string(APPEND TARGET_LIBS_OS " " ${lib})
+  ENDFOREACH()
+endif()
+
 # Add library to build.
 add_library(${PROJECT_NAME} SHARED
    ${SRC_FILES}
 )
 
-execute_process(
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../extern/llvm_linux_13_0_1/bin/llvm-config --system-libs --link-static
-  OUTPUT_VARIABLE LLVM_SYSTEM_LIBS
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  RESULT_VARIABLE EXEC_RESULT
-)
-
-if (EXEC_RESULT AND NOT EXEC_RESULT EQUAL 0)
-  if (EXEC_RESULT MATCHES "^[0-9]+$")
-    message(FATAL_ERROR "llvm-config exited with code ${EXEC_RESULT}.")
-  else()
-    message(FATAL_ERROR "llvm-config couldn't be executed: ${EXEC_RESULT}")
-  endif()
-endif()
-
-set(TARGET_LIBS_OS "${LLVM_SYSTEM_LIBS}")
-
 if (HAVE_BACKTRACE_HEADERS)
   string(APPEND TARGET_LIBS_OS " -lbacktrace")
   string(STRIP ${TARGET_LIBS_OS} TARGET_LIBS_OS)
 endif()
-
-list(APPEND LLVM_LIBS
-  ${LLVM_LIB}/libLLVMCore.a
-  ${LLVM_LIB}/libLLVMCodeGen.a
-  ${LLVM_LIB}/libLLVMMC.a
-  ${LLVM_LIB}/libLLVMMCParser.a
-  ${LLVM_LIB}/libLLVMMCDisassembler.a
-  ${LLVM_LIB}/libLLVMObject.a
-  ${LLVM_LIB}/libLLVMBitReader.a
-  ${LLVM_LIB}/libLLVMAsmParser.a
-  ${LLVM_LIB}/libLLVMTarget.a
-  ${LLVM_LIB}/libLLVMScalarOpts.a
-  ${LLVM_LIB}/libLLVMInstCombine.a
-  ${LLVM_LIB}/libLLVMSelectionDAG.a
-  ${LLVM_LIB}/libLLVMProfileData.a
-
-  ${LLVM_LIB}/libLLVMAnalysis.a
-  ${LLVM_LIB}/libLLVMAsmPrinter.a
-  ${LLVM_LIB}/libLLVMBitWriter.a
-  ${LLVM_LIB}/libLLVMVectorize.a
-  ${LLVM_LIB}/libLLVMipo.a
-  ${LLVM_LIB}/libLLVMInstrumentation.a
-  ${LLVM_LIB}/libLLVMDebugInfoDWARF.a
-  ${LLVM_LIB}/libLLVMDebugInfoPDB.a
-  ${LLVM_LIB}/libLLVMDebugInfoCodeView.a
-  ${LLVM_LIB}/libLLVMGlobalISel.a
-  ${LLVM_LIB}/libLLVMTransformUtils.a
-  ${LLVM_LIB}/libLLVMBinaryFormat.a
-  ${LLVM_LIB}/libLLVMIRReader.a
-  ${LLVM_LIB}/libLLVMLinker.a
-  ${LLVM_LIB}/libLLVMAggressiveInstCombine.a
-
-  ${LLVM_LIB}/libLLVMBitstreamReader.a
-  ${LLVM_LIB}/libLLVMCFGuard.a
-  ${LLVM_LIB}/libLLVMTextAPI.a
-  ${LLVM_LIB}/libLLVMRemarks.a
-
-  ${LLVM_LIB}/libLLVMX86Info.a
-  ${LLVM_LIB}/libLLVMX86Desc.a
-  ${LLVM_LIB}/libLLVMX86CodeGen.a
-  ${LLVM_LIB}/libLLVMX86AsmParser.a
-  ${LLVM_LIB}/libLLVMX86Disassembler.a
-
-  ${LLVM_LIB}/libLLVMARMDesc.a
-  ${LLVM_LIB}/libLLVMARMUtils.a
-  ${LLVM_LIB}/libLLVMARMInfo.a
-  ${LLVM_LIB}/libLLVMARMCodeGen.a
-  ${LLVM_LIB}/libLLVMARMAsmParser.a
-  ${LLVM_LIB}/libLLVMARMDisassembler.a
-
-  ${LLVM_LIB}/libLLVMAArch64Desc.a
-  ${LLVM_LIB}/libLLVMAArch64Utils.a
-  ${LLVM_LIB}/libLLVMAArch64Info.a
-  ${LLVM_LIB}/libLLVMAArch64CodeGen.a
-  ${LLVM_LIB}/libLLVMAArch64AsmParser.a
-  ${LLVM_LIB}/libLLVMAArch64Disassembler.a
-
-  ${LLVM_LIB}/libLLVMWebAssemblyDesc.a
-  ${LLVM_LIB}/libLLVMWebAssemblyInfo.a
-  ${LLVM_LIB}/libLLVMWebAssemblyCodeGen.a
-  ${LLVM_LIB}/libLLVMWebAssemblyAsmParser.a
-  ${LLVM_LIB}/libLLVMWebAssemblyDisassembler.a
-  ${LLVM_LIB}/libLLVMWebAssemblyUtils.a
-
-  ${LLVM_LIB}/libLLVMSupport.a
-  ${LLVM_LIB}/libLLVMDemangle.a)
-
-FOREACH (lib ${LLVM_LIBS})
-  string(APPEND TARGET_LIBS_OS " " ${lib})
-ENDFOREACH()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug" )
   FILE(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/../IDE/dist/IDEHelper_libs_d.txt" ${TARGET_LIBS_OS})
@@ -294,7 +317,5 @@ endif()
 if(MSVC)
   target_link_libraries(${PROJECT_NAME} BeefySysLib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib LLVMX86Disassembler.lib LLVMMCDisassembler.lib LLVMSupport.lib LLVMX86Info.lib LLVMX86Desc.lib %(AdditionalDependencies) LLVMMC.lib LLVMObject.lib LLVMCore.lib LLVMBitReader.lib LLVMAsmParser.lib LLVMMCParser.lib LLVMCodeGen.lib LLVMTarget.lib LLVMX86CodeGen.lib LLVMScalarOpts.lib LLVMInstCombine.lib LLVMSelectionDAG.lib LLVMProfileData.lib LLVMTransformUtils.lib LLVMAnalysis.lib LLVMX86AsmParser.lib LLVMAsmPrinter.lib LLVMBitWriter.lib LLVMVectorize.lib LLVMipo.lib LLVMInstrumentation.lib LLVMDebugInfoDWARF.lib LLVMDebugInfoPDB.lib LLVMDebugInfoCodeView.lib LLVMGlobalISel.lib LLVMBinaryFormat.lib LLVMAggressiveInstCombine.lib libcurl_a.lib)
 else()
-  target_link_libraries(${PROJECT_NAME} BeefySysLib hunspell pthread dl ${TARGET_LIBS_OS}
-
-  )
+  target_link_libraries(${PROJECT_NAME} BeefySysLib hunspell pthread dl ${TARGET_LIBS_OS})
 endif()

--- a/IDEHelper/LinuxDebugger.cpp
+++ b/IDEHelper/LinuxDebugger.cpp
@@ -19,8 +19,8 @@ Beefy::Debugger* CreateDebugger32(DebugManager* debugManager, DbgMiniDump* miniD
 
 Beefy::Debugger* CreateDebugger64(DebugManager* debugManager, DbgMiniDump* miniDump)
 {
-	if (gX86Target == NULL)
-		gX86Target = new X86Target();
+	//if (gX86Target == NULL)
+	//	gX86Target = new X86Target();
 	return NULL;
 }
 

--- a/IDEHelper/Targets.cpp
+++ b/IDEHelper/Targets.cpp
@@ -6,11 +6,15 @@ USING_NS_BF;
 
 BF_EXPORT void BF_CALLTYPE Targets_Create()
 {
+#ifndef __linux__
 	gX86Target = new X86Target();
+#endif
 }
 
 BF_EXPORT void BF_CALLTYPE Targets_Delete()
 {
+#ifndef __linux__
 	delete gX86Target;
 	gX86Target = NULL;
+#endif
 }

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -56,11 +56,21 @@ if [ ! -f ../BeefySysLib/third_party/libffi/Makefile ]; then
 	cd $SCRIPTPATH
 fi
 
-if [ ! -f ../extern/llvm_linux_13_0_1/_Done.txt ]; then
-	echo Building LLVM...
-	cd ../extern
-	./llvm_build.sh
-	cd $SCRIPTPATH
+LLVM_FOUND=0
+LLVM_CONFIG=$(which llvm-config-13 2>/dev/null || which llvm-config 2>/dev/null)
+
+if [ -n "$LLVM_CONFIG" ]; then
+  LLVM_VERSION=$($LLVM_CONFIG --version)
+  LLVM_MAJOR_VERSION=$(echo "$LLVM_VERSION" | cut -d. -f1)
+  if [ "$LLVM_MAJOR_VERSION" = "13" ]; then
+    LLVM_FOUND=1
+  fi
+fi
+
+if [ ! -f ../extern/llvm_linux_13_0_1/_Done.txt ] && [ $LLVM_FOUND == 0 ]; then
+	echo "ERROR: LLVM 13 was not detected on your system. Please install the package 'llvm-13-dev' and try again." >&2
+	echo "ERROR: As an alternative, you can compile LLVM from source using the script 'extern/llvm_build.sh'." >&2
+	exit
 fi
 
 ### LIBS ###

--- a/extern/llvm_build.sh
+++ b/extern/llvm_build.sh
@@ -6,6 +6,14 @@ if command -v ninja >/dev/null 2>&1 ; then
     USE_NINJA="-GNinja"
 fi
 
+FORCE_BUILD=0
+for i in "$@"
+do
+	if [[ $i == "force" ]]; then
+		FORCE_BUILD=1
+	fi
+done
+
 if [ ! -d llvm-project_13_0_1 ]; then
 	if [ -f llvm-13.0.1.src.tar.xz ]; then # if user downloaded llvm-13.0.1.src.tar.xz then use it instead
 		tar -xf llvm-13.0.1.src.tar.xz
@@ -20,7 +28,7 @@ if [ ! -d llvm_linux_13_0_1 ]; then
 	mkdir llvm_linux_13_0_1
 fi
 
-if [ ! -d llvm_linux_13_0_1/bin ]; then
+if [ ! -d llvm_linux_13_0_1/bin ] || [ $FORCE_BUILD == 1 ]; then
 	cd llvm_linux_13_0_1
 	cmake $USE_NINJA ../llvm-project_13_0_1/llvm -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86;WebAssembly" -DCMAKE_BUILD_TYPE:String="Debug"
 	cmake --build . -t $(cat ../llvm_targets.txt)
@@ -31,7 +39,7 @@ if [ ! -d llvm_linux_rel_13_0_1 ]; then
 	mkdir llvm_linux_rel_13_0_1
 fi
 
-if [ ! -d llvm_linux_rel_13_0_1/bin ]; then
+if [ ! -d llvm_linux_rel_13_0_1/bin ] || [ $FORCE_BUILD == 1 ]; then
 	cd llvm_linux_rel_13_0_1
 	cmake $USE_NINJA ../llvm-project_13_0_1/llvm -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86;WebAssembly" -DCMAKE_BUILD_TYPE:String="Release"
 	cmake --build . -t $(cat ../llvm_targets.txt)


### PR DESCRIPTION
It's common to see people complain about the build times for LLVM, so I'm submitting this pull request to simplify the compilation process of Beef on Linux.
The build scripts have been modified to support pre-built LLVM. However, if LLVM is not installed, or if it's not version 13, the scripts will default to using the LLVM compiled from the source.