### PR TITLE
Add static init priority to some classes

### DIFF
--- a/BeefLibs/corlib/src/Random.bf
+++ b/BeefLibs/corlib/src/Random.bf
@@ -21,6 +21,7 @@ namespace System
 	using System.Threading;
 
 	// This class is thread-safe for random results, but not deterministically thread-safe
+	[StaticInitPriority(100)]
 	public class Random
 	{
       //

--- a/BeefLibs/corlib/src/TimeZoneInfo.bf
+++ b/BeefLibs/corlib/src/TimeZoneInfo.bf
@@ -53,6 +53,7 @@ namespace System {
         NoThrowOnInvalidTime      = 2
     }
 
+	[StaticInitPriority(100)]
     sealed public class TimeZoneInfo : IEquatable<TimeZoneInfo>
 	{
         // ---- SECTION:  members supporting exposed properties -------------*


### PR DESCRIPTION
This pull request adds the 'StaticInitPriority' attribute to the 'Random' and 'TimeZoneInfo' classes. This ensures that they are correctly initialized when used from static initializers in user code.

I can't remember if this has been suggested before, but it might be worth considering automatically giving all classes from corlib (or any other library? I guess it would be hard to avoid this if one library depends on another) a higher priority to make problems like this less likely.