### PR TITLE
Add Mixin methog flag

### DIFF
--- a/BeefLibs/corlib/src/Reflection/MethodInfo.bf
+++ b/BeefLibs/corlib/src/Reflection/MethodInfo.bf
@@ -56,6 +56,9 @@ namespace System.Reflection
 		public bool CanReflect => Compiler.IsComptime ?
 			Type.[Friend]Comptime_Method_GetInfo(mData.mComptimeMethodInstance).mComptimeMethodFlags.HasFlag(.NoReflect) :
 			mData.mMethodData.[Friend]mFlags.HasFlag(.SpecialName);
+		public bool IsMixin => Compiler.IsComptime ?
+			Type.[Friend]Comptime_Method_GetInfo(mData.mComptimeMethodInstance).mMethodFlags.HasFlag(.Mixin) :
+			mData.mMethodData.[Friend]mFlags.HasFlag(.Mixin);
 
 		public StringView Name => Compiler.IsComptime ?
 			Type.[Friend]Comptime_Method_GetName(mData.mComptimeMethodInstance) :

--- a/BeefLibs/corlib/src/Type.bf
+++ b/BeefLibs/corlib/src/Type.bf
@@ -1533,6 +1533,7 @@ namespace System.Reflection
 		Virtual             	= 0x0040,     // Method virtual.
 		HideBySig           	= 0x0080,     // Method hides by name+sig, else just by name.
 		ReadOnly				= 0x0100,
+		Mixin                   = 0x0200,
 		Abstract            	= 0x0400,     // Method does not provide an implementation.
 		SpecialName         	= 0x0800,     // Method is special.  Name describes how.
 		StdCall					= 0x1000,

--- a/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
@@ -830,6 +830,8 @@ BfMethodFlags BfMethodInstance::GetMethodFlags()
 		methodFlags = (BfMethodFlags)(methodFlags | BfMethodFlags_Constructor);
 	if (mMethodDef->mIsReadOnly)
 		methodFlags = (BfMethodFlags)(methodFlags | BfMethodFlags_ReadOnly);
+	if (mMethodDef->mMethodType == BfMethodType_Mixin)
+		methodFlags = (BfMethodFlags)(methodFlags | BfMethodFlags_Mixin);
 
 	auto callingConvention = GetOwner()->mModule->GetIRCallingConvention(this);
 	if (callingConvention == BfIRCallingConv_ThisCall)

--- a/IDEHelper/Compiler/BfSystem.h
+++ b/IDEHelper/Compiler/BfSystem.h
@@ -240,6 +240,7 @@ enum BfMethodFlags
 	BfMethodFlags_Static = 0x10,
 	BfMethodFlags_Virtual = 0x40,
 	BfMethodFlags_ReadOnly = 0x100,
+	BfMethodFlags_Mixin = 0x200,
 	BfMethodFlags_StdCall = 0x1000,
 	BfMethodFlags_FastCall = 0x2000,
 	BfMethodFlags_ThisCall = 0x3000,


### PR DESCRIPTION
This PR adds a flag to methods' data in order to tell if a method is a mixin.