### PR TITLE
Consider 'params' for DelegateBind method matching

### DIFF
--- a/IDEHelper/Compiler/BfExprEvaluator.cpp
+++ b/IDEHelper/Compiler/BfExprEvaluator.cpp
@@ -6019,6 +6019,8 @@ void BfExprEvaluator::ResolveArgValues(BfResolvedArgs& resolvedArgs, BfResolveAr
 		{
 			BfResolvedArg resolvedArg;
 			resolvedArg.mTypedValue = typedValueExpr->mTypedValue;
+			if (resolvedArg.mTypedValue.IsParams())
+				resolvedArg.mArgFlags = BfArgFlag_ParamsExpr;
 			resolvedArg.mExpression = typedValueExpr->mRefNode;
 			resolvedArgs.mResolvedArgs.push_back(resolvedArg);
 			continue;
@@ -13393,6 +13395,8 @@ void BfExprEvaluator::Visit(BfDelegateBindExpression* delegateBindExpr)
 		auto typedValueExpr = &typedValueExprs[i];
 		typedValueExpr->mTypedValue.mValue = BfIRValue(BfIRValueFlags_Value, -1);
 		typedValueExpr->mTypedValue.mType = methodInstance->GetParamType(i + paramOffset);
+		if (methodInstance->GetParamKind(i + paramOffset) == BfParamKind_Params)
+			typedValueExpr->mTypedValue.mKind = BfTypedValueKind_Params;
 		typedValueExpr->mRefNode = NULL;
 		args[i] = typedValueExpr;
 	}


### PR DESCRIPTION
Fixes https://github.com/beefytech/Beef/issues/1970

This PR is my attempt at fixing the aforementioned issue. From what I understood of the issue, it happens because the `params` ArgFlag never reaches the MethodMatcher because it simply wasn't being taken into consideration in the `BfDelegateBindExpression` visitor.