### PR TITLE
linux: reduce build warnings

### DIFF
--- a/BeefBoot/CMakeLists.txt
+++ b/BeefBoot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 
 ################### Variables. ####################
 # Change if you want modify path or other values. #

--- a/BeefFuzz/CMakeLists.txt
+++ b/BeefFuzz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 
 ################### Variables. ####################
 # Change if you want modify path or other values. #

--- a/BeefRT/CMakeLists.txt
+++ b/BeefRT/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 
 ################### Variables. ####################
 # Change if you want modify path or other values. #

--- a/BeefTools/BeefMem/CMakeLists.txt
+++ b/BeefTools/BeefMem/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 
 ################### Variables. ####################
 # Change if you want modify path or other values. #

--- a/BeefySysLib/CMakeLists.txt
+++ b/BeefySysLib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 
 ################### Variables. ####################
 # Change if you want modify path or other values. #

--- a/BeefySysLib/Common.h
+++ b/BeefySysLib/Common.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
+#endif
+
+#ifndef __STDC_CONSTANT_MACROS
 #define __STDC_CONSTANT_MACROS
+#endif
 
 // #include <string>
 // #include <map>

--- a/IDEHelper/CMakeLists.txt
+++ b/IDEHelper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 
 ################### Variables. ####################
 # Change if you want modify path or other values. #

--- a/extern/hunspell/CMakeLists.txt
+++ b/extern/hunspell/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5)
 
 ################### Variables. ####################
 # Change if you want modify path or other values. #


### PR DESCRIPTION
the pr fixes three build warnings:

```
CMake Deprecation Warning at BeefBoot/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

```
BeefySysLib/Common.h:3: warning: "__STDC_LIMIT_MACROS" redefined
    3 | #define __STDC_LIMIT_MACROS
```

```
BeefySysLib/Common.h:5: warning: "__STDC_CONSTANT_MACROS" redefined
    5 | #define __STDC_CONSTANT_MACROS
```