### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/IDEHelper/CMakeLists.txt
+++ b/IDEHelper/CMakeLists.txt
@@ -177,7 +177,7 @@ if (LLVM_FOUND)
   include_directories(${LLVM_INCLUDE_DIRS})
   add_definitions(${LLVM_DEFINITIONS})
 
-  set(TARGET_LIBS_OS "-lLLVM-18 ${LLVM_SYSTEM_LIBS}")
+  set(STRIP ${TARGET_LIBS_OS} "-lLLVM-18 ${LLVM_SYSTEM_LIBS}")
 else()
   message(FATAL_ERROR "LLVM not found")
 endif()


### PR DESCRIPTION
In order to prevent the following:

CMake Error at IDEHelper/CMakeLists.txt:186 (add_library):
  Target "IDEHelper" links to item "-lLLVM-18 " which has leading or trailing
  whitespace.  This is now an error according to policy CMP0004.

Noticed on Arch Linux.