### PR TITLE
[Enhancement] Name field for test attributes

### DIFF
--- a/BeefLibs/corlib/src/Attribute.bf
+++ b/BeefLibs/corlib/src/Attribute.bf
@@ -457,6 +457,7 @@ namespace System
 		public bool Ignore;
 		public bool Profile;
 		public String Tag;
+  		public String Name;
 	}
 
 	public struct ImportAttribute : Attribute

--- a/IDE/src/TestManager.bf
+++ b/IDE/src/TestManager.bf
@@ -388,10 +388,25 @@ namespace IDE
 							testEntry.mLine = int32.Parse(cmdParts[3]).Get();
 							testEntry.mColumn = int32.Parse(cmdParts[4]).Get();
 
-							testEntry.mShouldFail = attribs.Contains("Sf");
-							testEntry.mProfile = attribs.Contains("Pr");
-							testEntry.mIgnore = attribs.Contains("Ig");
 
+							List<StringView> attributes = scope .(attribs.Split('\a'));
+							for(var i in attributes)
+							{
+								if(i.StartsWith('\v'))
+								{
+									if(i == "\vSf")
+										testEntry.mShouldFail = true;
+									else if(i == "\vPr")
+										testEntry.mProfile = true;
+									else if(i == "\vIg")
+										testEntry.mIgnore = true;
+								}
+								else if(i.StartsWith("Name"))
+								{
+									testEntry.mName.Clear();
+									scope String(i.Substring("Name".Length)).Escape(testEntry.mName);
+								}
+							}
 							testInstance.mTestEntries.Add(testEntry);
 						}
 					}

--- a/IDE/src/TestManager.bf
+++ b/IDE/src/TestManager.bf
@@ -394,11 +394,11 @@ namespace IDE
 							{
 								if(i.StartsWith('\v'))
 								{
-									if(i == "\vSf")
+									if(i == "Sf")
 										testEntry.mShouldFail = true;
-									else if(i == "\vPr")
+									else if(i == "Pr")
 										testEntry.mProfile = true;
-									else if(i == "\vIg")
+									else if(i == "Ig")
 										testEntry.mIgnore = true;
 								}
 								else if(i.StartsWith("Name"))

--- a/IDEHelper/Compiler/BfCompiler.cpp
+++ b/IDEHelper/Compiler/BfCompiler.cpp
@@ -951,15 +951,15 @@ void BfCompiler::EmitTestMethod(BfVDataModule* bfModule, Array<TestMethod>& test
 				BfFieldDef* fieldDef = field.mFieldRef;
 				if (fieldDef->mName == "ShouldFail")
 				{
-					testMethod.mName += "Sf";
+					testMethod.mName += "Sf\a";
 				}
 				else if (fieldDef->mName == "Profile")
 				{
-					testMethod.mName += "Pr";
+					testMethod.mName += "Pr\a";
 				}
 				else if (fieldDef->mName == "Ignore")
 				{
-					testMethod.mName += "Ig";
+					testMethod.mName += "Ig\a";
 				}
 			}
 			else if ((constant != NULL) && (constant->mTypeCode == BfTypeCode_StringId))

--- a/IDEHelper/Compiler/BfCompiler.cpp
+++ b/IDEHelper/Compiler/BfCompiler.cpp
@@ -961,6 +961,10 @@ void BfCompiler::EmitTestMethod(BfVDataModule* bfModule, Array<TestMethod>& test
 				{
 					testMethod.mName += "Ig";
 				}
+				else if (fieldDef->mName == "Name")
+				{
+					testMethod.mName += "Ovwn";
+				}
 			}
 		}
 

--- a/IDEHelper/Compiler/BfCompiler.cpp
+++ b/IDEHelper/Compiler/BfCompiler.cpp
@@ -961,9 +961,21 @@ void BfCompiler::EmitTestMethod(BfVDataModule* bfModule, Array<TestMethod>& test
 				{
 					testMethod.mName += "Ig";
 				}
-				else if (fieldDef->mName == "Name")
+			}
+			else if ((constant != NULL) && (constant->mTypeCode == BfTypeCode_StringId))
+			{
+				BfFieldDef* fieldDef = field.mFieldRef;
+				if (fieldDef->mName == "Name")
 				{
-					testMethod.mName += "Ovwn";
+					String* str = bfModule->GetStringPoolString(field.mParam.mValue, typeInstance->mConstHolder);
+					testMethod.mName += "Name";
+					String* temp = new String(*str);
+					temp->Replace('\t', "\\t"); //Good enough for now
+					temp->Replace('\n', "\\n");
+					temp->Replace('\a', "\\a");
+					temp->Replace('\v', "\\v");
+					testMethod.mName += *temp;
+					testMethod.mName += "\a";
 				}
 			}
 		}


### PR DESCRIPTION
This pr adds the Name field to the test attribute.

When running tests it currently uses the Typename+Methodname for the name of the test, which can sometimes
look a bit weird with longer types also this means that methods needs to have a long descriptive name for better differentiation.

However now, when the Name field is set, it will overwrite the name of the test to whichever name the user gives it.
Allowing for shorter names and better visibility on which test does what.

The name is also escaped, to avoid writing newlines and such directly to the beef output panel.