### PR TITLE
Fix profiling bug

### DIFF
--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -11491,6 +11491,8 @@ namespace IDE
 
 		public void QueueProfiling(int threadId, String desc, int sampleRate)
 		{
+  			if(mExecutionQueue.IsEmpty)
+				return;
 			var profileCmd = new ProfileCmd();
 			profileCmd.mThreadId = threadId;
 			profileCmd.mDesc = new String(desc);


### PR DESCRIPTION
#2010 

The core issue was Profiling being done while in the test configuration.
Compile has already failed at that point and thrown an error, but since the return value is not checked the profiler expects an entry which does not exist