### PR TITLE
Fix dangling error when typing delegate

### DIFF
--- a/IDEHelper/Compiler/BfReducer.cpp
+++ b/IDEHelper/Compiler/BfReducer.cpp
@@ -8911,10 +8911,15 @@ BfAstNode* BfReducer::CreateTopLevelObject(BfTokenNode* tokenNode, BfAttributeDi
 			methodDecl->mGenericConstraintsDeclaration = NULL;
 		}
 
+		if (methodDecl->mBody != NULL)
+		{
+			Fail("Unexpected method body after delegate/function type", methodDecl->mBody);
+		}
+
 		if (failed)
 			return typeDeclaration;
 
-		if (methodDecl->mEndSemicolon == NULL)
+		if ((methodDecl->mEndSemicolon == NULL) && (methodDecl->mCloseParen != NULL))
 			FailAfter("Expected ';'", methodDecl->mCloseParen);
 
 		//MEMBER_SET(methodDecl, mReturnType, retType);


### PR DESCRIPTION
Fixes #1968 and i also noticed that `function void Foo() {  }` is allowed so i tried to fix that, i'm not sure if my solution is correct but from my testing it seems to be doing what is expected.