### PR TITLE
Use Beep instead of MessageBeep in IDEApp

### DIFF
--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -11858,7 +11858,7 @@ namespace IDE
 						});
 					((DarkButton)dlg.mButtons[0]).Label = "Open Link";
 					dlg.PopupWindow(GetActiveWindow());
-					MessageBeep(.Error);
+					Beep(.Error);
 #endif
 				}
 			}


### PR DESCRIPTION
Fixes the use of the Windows specific MessageBeep that caused an error when building outside Windows.