### PR TITLE
Fix bf_depends_ to allow projects with a '-' in their name

### DIFF
--- a/IDEHelper/Compiler/BfParser.cpp
+++ b/IDEHelper/Compiler/BfParser.cpp
@@ -934,6 +934,7 @@ MaybeBool BfParser::HandleIfDef(const StringImpl& name)
 		{
 			StringT<64> def = "BF_DEPENDS_";
 			def.Append(project->mName);
+			def.Replace("-", "_");
 			MakeUpper(def);
 			mPreprocessorDefines[def] = BfDefineState_FromProject;
 		}


### PR DESCRIPTION
There can technically be confusion here with a project named "Project_Name" and "Project-Name" but in practice thats incredibly unlikely to happen