### PR TITLE
Add Directory.Copy to corlib

### DIFF
--- a/BeefLibs/corlib/src/IO/Directory.bf
+++ b/BeefLibs/corlib/src/IO/Directory.bf
@@ -90,6 +90,23 @@ namespace System.IO
 			return .Ok;
 		}
 
+  		///Copies and overwrites the contents of fromPath into toPath.
+		public static Result<void, Platform.BfpFileResult> Copy(StringView fromPath, StringView toPath)
+		{
+			if(Directory.CreateDirectory(toPath) case .Err(let err))
+				return .Err(err);
+
+			for(var file in Directory.EnumerateFiles(fromPath))
+				if(File.Copy(file.GetFilePath(.. scope .()), scope $"{toPath}/{file.GetFileName(.. scope .())}") case .Err(let err))
+					return .Err(err);
+
+			for(var dir in Directory.EnumerateDirectories(fromPath))
+				if(Directory.Copy(dir.GetFilePath(.. scope .()), scope $"{toPath}/{dir.GetFileName(.. scope .())}") case .Err(let err))
+					return .Err(err);
+
+			return .Ok;
+		}
+
 		public static void GetCurrentDirectory(String outPath)
 		{
 			Platform.GetStrHelper(outPath, scope (outPtr, outSize, outResult) =>


### PR DESCRIPTION
This solution is a relativly elegant one imo.

The it copies fromPath onto toPath, not into. While that isnt in line with how the gui does it, its also how other copy functionality works, so it seemed fine here.

Ive also added a comment that indicates that it does this and also that it overwrites files.

The current behaviour may not play nice with deep paths, but thats not really of concern for beefs usecases so if someone needs the security they could just implement a stack safe version themselves.