### PR TITLE
Add CompactList<T> constructor when T is a class

### DIFF
--- a/BeefLibs/corlib/src/Collections/CompactList.bf
+++ b/BeefLibs/corlib/src/Collections/CompactList.bf
@@ -117,9 +117,9 @@ extension CompactList<T> where T : class
 {
 	Object mObject;
 
-    public this()
-    {
-    }
+	public this()
+	{
+	}
 
 	[Inline]
 	Object NullSentinel => Internal.UnsafeCastToObject((.)1);

--- a/BeefLibs/corlib/src/Collections/CompactList.bf
+++ b/BeefLibs/corlib/src/Collections/CompactList.bf
@@ -117,6 +117,10 @@ extension CompactList<T> where T : class
 {
 	Object mObject;
 
+    public this()
+    {
+    }
+
 	[Inline]
 	Object NullSentinel => Internal.UnsafeCastToObject((.)1);
 


### PR DESCRIPTION
This previously worked without an explicit constructor, but now it's needed.