### PR TITLE
Support for space indentation when splitting line with enter key

### DIFF
--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -4090,10 +4090,16 @@ namespace IDE.ui
 						}
                         if (column > 0)
                         {
-							String tabStr = scope String();
-							tabStr.Append('\t', column / gApp.mSettings.mEditorSettings.mTabSize);
-							tabStr.Append(' ', column % gApp.mSettings.mEditorSettings.mTabSize);
-                            InsertAtCursor(tabStr);
+                            String indentationStr = scope String();
+                            switch (gApp.mSettings.mEditorSettings.mTabsOrSpaces)
+							{
+                            case .Spaces:
+                                indentationStr.Append(' ', column);
+                            case .Tabs:
+                                indentationStr.Append('\t', column / gApp.mSettings.mEditorSettings.mTabSize);
+                                indentationStr.Append(' ', column % gApp.mSettings.mEditorSettings.mTabSize);
+                            }
+                            InsertAtCursor(indentationStr);
 						}
 
 						// Insert extra blank line if we're breaking between a { and a }


### PR DESCRIPTION
When pressing enter in the middle of the line, the added indentation is always using tabs, even when `Tabs or Spaces` setting is set to `Spaces`.

This adds support for spaces.