### PR TITLE
Add additional check for !BF_CRT_DISABLE when conditionally defining System.MinRuntime

### DIFF
--- a/BeefLibs/corlib/src/Runtime.bf
+++ b/BeefLibs/corlib/src/Runtime.bf
@@ -638,7 +638,7 @@ namespace System
 	}
 }
 
-#if BF_RUNTIME_DISABLE
+#if BF_RUNTIME_DISABLE && !BF_CRT_DISABLE
 namespace System
 {
 	[AlwaysInclude, StaticInitPriority(1000)]


### PR DESCRIPTION
We are running into an issue trying to compile static lib targets with runtime disabled. 

In corlib Runtime.bf, if runtime is disabled, the `System.MinRuntime` class gets defined, and it defines symbols like malloc, free, etc. When you try to link the resulting static lib into something else, those symbols generally cause a conflict with CRT symbols.

This allows us to manually omit the `System.MinRuntime` from the build by defining `BF_CRT_DISABLE` in the Workspace.