### PR TITLE
Avoid recalc of string length in integer ToString()

### DIFF
--- a/BeefLibs/corlib/src/Int32.bf
+++ b/BeefLibs/corlib/src/Int32.bf
@@ -66,7 +66,7 @@ namespace System
 		public override void ToString(String strBuffer)
 		{
 			// Dumb, make better.
-			char8[] strChars = scope:: char8[16];
+			char8[16] strChars = ?;
 			int32 char8Idx = 14;
 			int32 valLeft = (int32)this;
 			bool isNeg = true;

--- a/BeefLibs/corlib/src/Int32.bf
+++ b/BeefLibs/corlib/src/Int32.bf
@@ -86,7 +86,7 @@ namespace System
 			if (isNeg)
 				strChars[char8Idx--] = '-';
 			char8* char8Ptr = &strChars[char8Idx + 1];
-			strBuffer.Append(char8Ptr);
+			strBuffer.Append(char8Ptr, 14 - char8Idx);
 		}
 
 		void ToString(String strBuffer, int minNumerals)

--- a/BeefLibs/corlib/src/Int64.bf
+++ b/BeefLibs/corlib/src/Int64.bf
@@ -78,7 +78,7 @@ namespace System
 		public override void ToString(String strBuffer)
 		{
 			// Dumb, make better.
-			char8[] strChars = scope:: char8[22];
+			char8[22] strChars = ?;
 			int32 char8Idx = 20;
 			int64 valLeft = (int64)this;
 			bool isNeg = true;

--- a/BeefLibs/corlib/src/Int64.bf
+++ b/BeefLibs/corlib/src/Int64.bf
@@ -82,25 +82,23 @@ namespace System
 			int32 char8Idx = 20;
 			int64 valLeft = (int64)this;
 			bool isNeg = true;
-			int minNumeralsLeft = 0;
 			if (valLeft >= 0)
 			{
 				valLeft = -valLeft;
 				isNeg = false;
 			}
-			while ((valLeft < 0) || (minNumeralsLeft > 0))
+			while (valLeft < 0)
 			{
 				strChars[char8Idx] = (char8)('0' &- (valLeft % 10));
 				valLeft /= 10;
 				char8Idx--;
-				minNumeralsLeft--;
 			}
 			if (char8Idx == 20)
 				strChars[char8Idx--] = '0';
 			if (isNeg)
 				strChars[char8Idx--] = '-';
 			char8* char8Ptr = &strChars[char8Idx + 1];
-			strBuffer.Append(char8Ptr);
+			strBuffer.Append(char8Ptr, 20 - char8Idx);
 		}
 
 		public static Result<int64, ParseError> Parse(StringView val, NumberStyles style = .Number, CultureInfo cultureInfo = null)

--- a/BeefLibs/corlib/src/UInt32.bf
+++ b/BeefLibs/corlib/src/UInt32.bf
@@ -73,7 +73,7 @@ namespace System
 			if (char8Idx == 14)
 				strChars[char8Idx--] = '0';
 			char8* char8Ptr = &strChars[char8Idx + 1];
-			strBuffer.Append(char8Ptr);
+			strBuffer.Append(char8Ptr, 14 - char8Idx);
 		}
 
 		void ToString(String strBuffer, int minNumerals)

--- a/BeefLibs/corlib/src/UInt32.bf
+++ b/BeefLibs/corlib/src/UInt32.bf
@@ -61,7 +61,7 @@ namespace System
 		public override void ToString(String strBuffer)
 		{
 			// Dumb, make better.
-			char8[] strChars = scope:: char8[16];
+			char8[16] strChars = ?;
 			int32 char8Idx = 14;
 			uint32 valLeft = (uint32)this;
 			while (valLeft > 0)

--- a/BeefLibs/corlib/src/UInt64.bf
+++ b/BeefLibs/corlib/src/UInt64.bf
@@ -85,7 +85,7 @@ namespace System
 		    if (char8Idx == 20)
 		        strChars[char8Idx--] = '0';
 		    char8* char8Ptr = &strChars[char8Idx + 1];
-		    strBuffer.Append(char8Ptr);
+		    strBuffer.Append(char8Ptr, 20 - char8Idx);
 		}
 
 		public static Result<uint64, ParseError> Parse(StringView val, NumberStyles style = .Number, CultureInfo cultureInfo = null)

--- a/BeefLibs/corlib/src/UInt64.bf
+++ b/BeefLibs/corlib/src/UInt64.bf
@@ -73,7 +73,7 @@ namespace System
 		public override void ToString(String strBuffer)
 		{
 		    // Dumb, make better.
-		    char8[] strChars = scope:: char8[22];
+		    char8[22] strChars = ?;
 		    int32 char8Idx = 20;
 		    uint64 valLeft = (uint64)this;
 		    while (valLeft > 0)


### PR DESCRIPTION
- Use `strBuffer.Append(ptr, length)` instead of `strBuffer.Append(ptr)` when copying from internal to output buffer
- Internal buffer no longer zeroed (Not sure why it had `scope::` before)
- Removed `minNumeralsLeft` variable in `int64.ToString()` as it was unused.

Speed goes from 977ms to 626ms in the following test:
```beef
        const int TEST_COUNT = 100000000;
        let str = scope String(32);

        Stopwatch sw = scope .(true);
        for (int64 i < TEST_COUNT) {
            str.[Friend]mLength = 0;
            i.ToString(str);
        }
        System.Diagnostics.Debug.WriteLine($"1: {sw.ElapsedMilliseconds}ms");
```