### PR TITLE
Fix Console.ResetColor() not actually applying the original colors when called.

### DIFF
--- a/BeefLibs/corlib/src/Console.bf
+++ b/BeefLibs/corlib/src/Console.bf
@@ -396,6 +396,7 @@ namespace System
 		{
 			sForegroundColor = sOriginalForegroundColor;
 			sBackgroundColor = sOriginalBackgroundColor;
+			SetColors();
 
 #if !BF_PLATFORM_WINDOWS
 			Write("\x1B[0m");


### PR DESCRIPTION
I spent about twenty minutes trying to figure out why it wasn't working. Turns out the colors just aren't being applied to the console when the function is called. Now it matches how it functions in C#.

### Before
![image](https://github.com/user-attachments/assets/e7ff8310-e4a4-4b47-9249-5be8de2a65d7)

### After
![image](https://github.com/user-attachments/assets/b5ffc883-f44d-4c24-8173-3c7638a888db)

---

### C# Reference
![image](https://github.com/user-attachments/assets/976113fd-d020-4f7c-bb85-c2e21a7906cd)