### PR TITLE
Feature: Content of Dialog can be copied into clipboard

### DIFF
--- a/BeefLibs/Beefy2D/src/widgets/Dialog.bf
+++ b/BeefLibs/Beefy2D/src/widgets/Dialog.bf
@@ -387,6 +387,14 @@ namespace Beefy.widgets
 					evt.mHandled = true;
 				}
             }
+
+			if (evt.mKeyFlags.HasFlag(.Ctrl) && (evt.mKeyCode == (KeyCode)'C'))
+			{
+				var clipboardText = scope String();
+				clipboardText.AppendF("{}\n{}", mTitle, mText);
+				BFApp.sApp.SetClipboardText(clipboardText, "");
+				evt.mHandled = true;
+			}
         }
     }
 }


### PR DESCRIPTION
Hi there,
On Windows, with standard `MessageBox` it is possible to copy content of it into clipboard with `CTRL+C` shortcut.
This pull-request does exactly that. For any `Dialog`, if we press `CTRL+C`, it will copy content of it into clipboard.
Specifically `mTitle` and `mText`.

If something is wrong, do not hesitate to reject.

https://github.com/user-attachments/assets/f685dc96-5754-462f-ae66-aacf0e564f4a

