### PR TITLE
Fix: Scrolling inside DarkListView and DarkMenuContainer based on Font.GetLineSpacing()

### DIFF
--- a/BeefLibs/Beefy2D/src/theme/dark/DarkListView.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkListView.bf
@@ -1028,6 +1028,12 @@ namespace Beefy.theme.dark
                 mScrollContentInsets.mBottom += GS!(2);
 
             base.InitScrollbars(wantHorz, wantVert);
+
+			float scrollIncrement = this.mFont.GetLineSpacing();
+			if (mHorzScrollbar != null)
+			    mHorzScrollbar.mScrollIncrement = scrollIncrement;
+			if (mVertScrollbar != null)
+			    mVertScrollbar.mScrollIncrement = scrollIncrement;
         }
 
         protected override ListViewItem CreateListViewItem()

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkMenu.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkMenu.bf
@@ -239,6 +239,23 @@ namespace Beefy.theme.dark
 				MarkDirty();
             }
         }        
+
+		public override void InitScrollbars(bool wantHorz, bool wantVert)
+		{
+		    if (!wantHorz)
+		        mScrollContentInsets.mBottom += GS!(2);
+
+		    base.InitScrollbars(wantHorz, wantVert);
+
+			float scrollIncrement = 0;
+			if (var darkMenuWidget = mScrollContent as DarkMenuWidget)
+				scrollIncrement = darkMenuWidget.mFont.GetLineSpacing();
+
+			if (mHorzScrollbar != null)
+			    mHorzScrollbar.mScrollIncrement = scrollIncrement;
+			if (mVertScrollbar != null)
+			    mVertScrollbar.mScrollIncrement = scrollIncrement;
+		}
     }
 
     public class DarkMenuWidget : MenuWidget


### PR DESCRIPTION
Hi there,
This pull-request fixes an issue with scrolling inside some of the panels.

`class ProjectPanel` contains vertical scrollbar with `mScrollIncrement` set to 0. In this case, scrolling amount will be equal to `mPageSize / 10.0f` calculated by `Scrollbar.GetScrollIncrement()`. If workspace contains a lot of files, scrolling become a bit unpredictable. This has been fixed in `DarkMenuWidget` as you requested.

Same behaviour was in `class NavigationBar`, which is fixed in `DarkMenuContainer`.