### PR TITLE
Remove some hardcoded colors to make the IDE more friendly to light themes.

### DIFF
--- a/BeefLibs/Beefy2D/src/theme/dark/DarkCheckBox.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkCheckBox.bf
@@ -121,7 +121,8 @@ namespace Beefy.theme.dark
             {
 				g.SetFont(mFont);
 
-				DarkTheme.DrawUnderlined(g, mLabel, GS!(22), GS!(-1));
+				using(g.PushColor(DarkTheme.COLOR_TEXT))
+					DarkTheme.DrawUnderlined(g, mLabel, GS!(22), GS!(-1));
 
 				/*int underlinePos = mLabel.IndexOf('&');
 				if ((underlinePos != -1) && (underlinePos < mLabel.Length - 1))

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkDialog.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkDialog.bf
@@ -119,7 +119,8 @@ namespace Beefy.theme.dark
 
             g.SetFont(mFont);
             if (mText != null)
-                g.DrawString(mText, mTextInsets.mLeft, mTextInsets.mTop, FontAlign.Left, mWidth - mTextInsets.Horz, FontOverflowMode.Wrap);
+				using (g.PushColor(DarkTheme.COLOR_TEXT))
+                	g.DrawString(mText, mTextInsets.mLeft, mTextInsets.mTop, FontAlign.Left, mWidth - mTextInsets.Horz, FontOverflowMode.Wrap);
         }
     }
 }

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
@@ -80,6 +80,7 @@ namespace Beefy.theme.dark
             mHorzJumpSize = GS!(40);
             mFont = DarkTheme.sDarkTheme?.mSmallFont;
 			mTextColors[0] = DarkTheme.COLOR_TEXT;
+			mHiliteColor = DarkTheme.COLOR_TEXT_SELECTED;
         }
 
 		protected override EditWidgetContent.Data CreateEditData()

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkEditWidget.bf
@@ -79,6 +79,7 @@ namespace Beefy.theme.dark
             mHeight = GS!(24);
             mHorzJumpSize = GS!(40);
             mFont = DarkTheme.sDarkTheme?.mSmallFont;
+			mTextColors[0] = DarkTheme.COLOR_TEXT;
         }
 
 		protected override EditWidgetContent.Data CreateEditData()

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkMenu.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkMenu.bf
@@ -32,7 +32,7 @@ namespace Beefy.theme.dark
 				let darkMenuWidget = (DarkMenuWidget)mMenuWidget;
 				g.SetFont(mMenuItem.mBold ? darkMenuWidget.mBoldFont : darkMenuWidget.mFont);
 
-				using (g.PushColor(mMenuItem.mDisabled ? 0xFFA8A8A8 : 0xFFFFFFFF))
+				using (g.PushColor(mMenuItem.mDisabled ? DarkTheme.COLOR_TEXT_DISABLED : DarkTheme.COLOR_TEXT))
 				{
 					StringView leftStr = mMenuItem.mLabel;
 					StringView rightStr = default;
@@ -43,12 +43,9 @@ namespace Beefy.theme.dark
 						leftStr.RemoveToEnd(barIdx);
 					}
 
-					using (g.PushColor(DarkTheme.COLOR_TEXT))
-					{
-						g.DrawString(leftStr, GS!(36), 0);
-						if (!rightStr.IsEmpty)
-							g.DrawString(rightStr, mWidth - GS!(8), 0, .Right);
-					}
+					g.DrawString(leftStr, GS!(36), 0);
+					if (!rightStr.IsEmpty)
+						g.DrawString(rightStr, mWidth - GS!(8), 0, .Right);
 				}
 
                 if (mMenuItem.mIconImage != null)
@@ -57,7 +54,7 @@ namespace Beefy.theme.dark
 
             if (mMenuItem.IsParent)
             {
-				using (g.PushColor(mMenuItem.mDisabled ? 0xFFA8A8A8 : 0xFFFFFFFF))
+				using (g.PushColor(mMenuItem.mDisabled ? DarkTheme.COLOR_TEXT_DISABLED : DarkTheme.COLOR_TEXT))
                 	g.Draw(DarkTheme.sDarkTheme.GetImage(DarkTheme.ImageIdx.RightArrow), mWidth - GS!(16), 0);
             }
         }

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
@@ -197,6 +197,7 @@ namespace Beefy.theme.dark
         };
 
 		public static uint32 COLOR_TEXT                   = 0xFFFFFFFF;
+		public static uint32 COLOR_TEXT_DISABLED          = 0xFFA8A8A8;
         public static uint32 COLOR_WINDOW                 = 0xFF595962;
         public static uint32 COLOR_BKG                    = 0xFF26262A;
         public static uint32 COLOR_SELECTED_OUTLINE       = 0xFFCFAE11;

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
@@ -198,6 +198,7 @@ namespace Beefy.theme.dark
 
 		public static uint32 COLOR_TEXT                   = 0xFFFFFFFF;
 		public static uint32 COLOR_TEXT_DISABLED          = 0xFFA8A8A8;
+		public static uint32 COLOR_TEXT_SELECTED          = 0xFF2f5c88;
         public static uint32 COLOR_WINDOW                 = 0xFF595962;
         public static uint32 COLOR_BKG                    = 0xFF26262A;
         public static uint32 COLOR_SELECTED_OUTLINE       = 0xFFCFAE11;

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -6906,8 +6906,8 @@ namespace IDE
 
 			var editWidgetContent = (SourceEditWidgetContent)editWidget.Content;
 			//mEditWidget.mVertScrollbar.mScrollIncrement = editWidgetContent.mFont.GetLineSpacing();
-			editWidgetContent.mHiliteColor = 0xFF384858;
-			editWidgetContent.mUnfocusedHiliteColor = 0x80384858;
+			editWidgetContent.mHiliteColor = mSettings.mUISettings.mColors.mCodeHighlight;
+			editWidgetContent.mUnfocusedHiliteColor = mSettings.mUISettings.mColors.mCodeHighlightUnfocused;
 			editWidgetContent.mHiliteCurrentLine = mSettings.mEditorSettings.mHiliteCurrentLine;
 
 			return editWidget;

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -311,6 +311,7 @@ namespace IDE
 		public class Colors
 		{
 			public Color mText = 0xFFFFFFFF;
+			public Color mTextDisabled = 0xFFA8A8A8;
 			public Color mWindow = 0xFF44444D;
 			public Color mBackground = 0xFF1C1C24;
 			public Color mSelectedOutline = 0xFFCFAE11;
@@ -364,6 +365,7 @@ namespace IDE
 				}
 
 				GetColor("Text", ref mText);
+				GetColor("TextDisabled", ref mTextDisabled);
 				GetColor("Window", ref mWindow);
 				GetColor("Background", ref mBackground);
 				GetColor("SelectedOutline", ref mSelectedOutline);
@@ -450,6 +452,7 @@ namespace IDE
 				SourceEditWidgetContent.sTextColors[(.)SourceElementType.VisibleWhiteSpace] = mVisibleWhiteSpace;
 
 				DarkTheme.COLOR_TEXT = mText;
+				DarkTheme.COLOR_TEXT_DISABLED = mTextDisabled;
 				DarkTheme.COLOR_WINDOW = mWindow;
 				DarkTheme.COLOR_BKG = mBackground;
 				DarkTheme.COLOR_SELECTED_OUTLINE = mSelectedOutline;

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -350,6 +350,8 @@ namespace IDE
 			public Color mCurrentLineHilite = 0xFF4C4C54;
 			public Color mCurrentLineNumberHilite = 0x18FFFFFF;
 			public Color mCharPairHilite = 0x1DFFFFFF;
+			public Color mCodeHighlight = 0xFF384858;
+			public Color mCodeHighlightUnfocused = 0x80384858;
 
 			public void Deserialize(StructuredData sd)
 			{
@@ -418,6 +420,8 @@ namespace IDE
 				GetColor("CurrentLineHilite", ref mCurrentLineHilite);
 				GetColor("CurrentLineNumberHilite", ref mCurrentLineNumberHilite);
 				GetColor("CharPairHilite", ref mCharPairHilite);
+				GetColor("CodeHighlight", ref mCodeHighlight);
+				GetColor("CodeHighlightUnfocused", ref mCodeHighlightUnfocused);
 			}
 
 			public void Apply()

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -352,8 +352,8 @@ namespace IDE
 			public Color mCurrentLineHilite = 0xFF4C4C54;
 			public Color mCurrentLineNumberHilite = 0x18FFFFFF;
 			public Color mCharPairHilite = 0x1DFFFFFF;
-			public Color mCodeHighlight = 0xFF384858;
-			public Color mCodeHighlightUnfocused = 0x80384858;
+			public Color mCodeHilite = 0xFF384858;
+			public Color mCodeHiliteUnfocused = 0x80384858;
 
 			public void Deserialize(StructuredData sd)
 			{
@@ -424,8 +424,8 @@ namespace IDE
 				GetColor("CurrentLineHilite", ref mCurrentLineHilite);
 				GetColor("CurrentLineNumberHilite", ref mCurrentLineNumberHilite);
 				GetColor("CharPairHilite", ref mCharPairHilite);
-				GetColor("CodeHighlight", ref mCodeHighlight);
-				GetColor("CodeHighlightUnfocused", ref mCodeHighlightUnfocused);
+				GetColor("CodeHilite", ref mCodeHilite);
+				GetColor("CodeHiliteUnfocused", ref mCodeHiliteUnfocused);
 			}
 
 			public void Apply()

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -312,6 +312,7 @@ namespace IDE
 		{
 			public Color mText = 0xFFFFFFFF;
 			public Color mTextDisabled = 0xFFA8A8A8;
+			public Color mTextSelected = 0xFF2f5c88;
 			public Color mWindow = 0xFF44444D;
 			public Color mBackground = 0xFF1C1C24;
 			public Color mSelectedOutline = 0xFFCFAE11;
@@ -366,6 +367,7 @@ namespace IDE
 
 				GetColor("Text", ref mText);
 				GetColor("TextDisabled", ref mTextDisabled);
+				GetColor("TextSelected", ref mTextSelected);
 				GetColor("Window", ref mWindow);
 				GetColor("Background", ref mBackground);
 				GetColor("SelectedOutline", ref mSelectedOutline);
@@ -453,6 +455,7 @@ namespace IDE
 
 				DarkTheme.COLOR_TEXT = mText;
 				DarkTheme.COLOR_TEXT_DISABLED = mTextDisabled;
+				DarkTheme.COLOR_TEXT_SELECTED = mTextSelected;
 				DarkTheme.COLOR_WINDOW = mWindow;
 				DarkTheme.COLOR_BKG = mBackground;
 				DarkTheme.COLOR_SELECTED_OUTLINE = mSelectedOutline;

--- a/IDE/src/ui/AutoComplete.bf
+++ b/IDE/src/ui/AutoComplete.bf
@@ -413,6 +413,11 @@ namespace IDE.ui
 							g.PushColor(DarkTheme.COLOR_MENU_FOCUSED);
 							defer:loop g.PopColor();
 						}
+						else
+						{
+							g.PushColor(DarkTheme.COLOR_TEXT);
+							defer:loop g.PopColor();
+						}
 
 						let str = StringView(mEntryDisplay, index, @c.NextIndex - index);
 

--- a/IDE/src/ui/BinaryDataWidget.bf
+++ b/IDE/src/ui/BinaryDataWidget.bf
@@ -877,7 +877,7 @@ namespace IDE.ui
             // column header
             using (g.PushClip(0, 0, mWidth, GS!(mColumnHeaderHeight)))
             {
-                using (g.PushColor(0xFFFFFFFF))
+                using (g.PushColor(DarkTheme.COLOR_TEXT))
                 {
                     g.SetFont(mFont);
                     float strViewColumnStart = GS!(mColumnDisplayStart) + mBytesPerDisplayLine*GS!(mColumnDisplayStride) + GS!(mStrViewDisplayStartOffset);
@@ -908,7 +908,7 @@ namespace IDE.ui
                 float displayAdj = (float)(-mShowPositionDisplayOffset * lineSpacing);
                 using (g.PushTranslate(0, displayAdj))
                 {
-                    using (g.PushColor(0xFFFFFFFF))
+                    using (g.PushColor(DarkTheme.COLOR_TEXT))
                     {
                         //ulong lineStart = mCurPosition / mBytesPerDisplayLine;
                         int lockSize = lineCount * mBytesPerDisplayLine;

--- a/IDE/src/ui/BreakpointPanel.bf
+++ b/IDE/src/ui/BreakpointPanel.bf
@@ -652,17 +652,15 @@ namespace IDE.ui
 					subItem.mOnMouseClick.Add(new => ListViewItemClicked);
                 }
                 var listViewItem = (BreakpointListViewItem)root.GetChildAtIndex(breakIdx);
-                listViewItem.mTextColor = Color.White;
+                listViewItem.mTextColor = DarkTheme.COLOR_TEXT;
 
 				listViewItem.mIsBold = breakpoint.IsActiveBreakpoint();
 
 				var locString = scope String();
 				breakpoint.ToString_Location(locString);
 				listViewItem.Label = locString;
-				if (breakpoint.IsBound())
-					listViewItem.mTextColor = 0xFFFFFFFF;
-				else
-					listViewItem.mTextColor = 0x80FFFFFF;
+				if (!breakpoint.IsBound())
+					listViewItem.mTextColor = (0x00FFFFFF & DarkTheme.COLOR_TEXT) | 0x80000000;
 
 				// Condition
 				var subItem = listViewItem.GetSubItem(2);

--- a/IDE/src/ui/ConditionDialog.bf
+++ b/IDE/src/ui/ConditionDialog.bf
@@ -369,14 +369,17 @@ namespace IDE.ui
         {
             base.Draw(g);
 
-            g.DrawString("Breakpoint Condition", mConditionEdit.mX, mConditionEdit.mY - GS!(20));
-			g.DrawString("Thread Id", mThreadEdit.mX, mThreadEdit.mY - GS!(20));
-            g.DrawString("Log String", mLogEdit.mX, mLogEdit.mY - GS!(20));
-			g.DrawString("Break on Hit Count", mHitCountCombo.mX, mHitCountEdit.mY - GS!(19));
+			using (g.PushColor(DarkTheme.COLOR_TEXT))
+			{
+				g.DrawString("Breakpoint Condition", mConditionEdit.mX, mConditionEdit.mY - GS!(20));
+				g.DrawString("Thread Id", mThreadEdit.mX, mThreadEdit.mY - GS!(20));
+				g.DrawString("Log String", mLogEdit.mX, mLogEdit.mY - GS!(20));
+				g.DrawString("Break on Hit Count", mHitCountCombo.mX, mHitCountEdit.mY - GS!(19));
 
-			var str = scope String();
-			str.AppendF("Current: {0}", mStartingHitCount);
-			g.DrawString(str, mWidth - GS!(16) - GS!(8), mHitCountEdit.mY - GS!(19), .Right);
+				var str = scope String();
+				str.AppendF("Current: {0}", mStartingHitCount);
+				g.DrawString(str, mWidth - GS!(16) - GS!(8), mHitCountEdit.mY - GS!(19), .Right);
+			}
         }
     }
 }

--- a/IDE/src/ui/DiagnosticsPanel.bf
+++ b/IDE/src/ui/DiagnosticsPanel.bf
@@ -255,7 +255,8 @@ namespace IDE.ui
 					{
 						using (g.PushClip(0, 0, width, height))
 						{
-							using (g.PushColor(0xFF00FF00))
+							// Using override to prevent the color turning black when using a dark text color.
+							using (g.PushColorOverride(0xFF00FF00))
 							{
 								float prevY = 0;
 
@@ -439,10 +440,13 @@ namespace IDE.ui
 				using (g.PushColor(0x20FFFFFF))
 					g.FillRect(0, 0, mWidth, mHeight);
 
-				DrawData(g, mData, mTimes, dataRect.mX, dataRect.mY, dataRect.mWidth, dataRect.mHeight);
+				using (g.PushColor(DarkTheme.COLOR_TEXT))
+				{
+					DrawData(g, mData, mTimes, dataRect.mX, dataRect.mY, dataRect.mWidth, dataRect.mHeight);
 
-				g.SetFont(DarkTheme.sDarkTheme.mSmallBoldFont);
-				g.DrawString(mLabel, -GS!(0), -GS!(0), .Centered, dataRect.mX);
+					g.SetFont(DarkTheme.sDarkTheme.mSmallBoldFont);
+					g.DrawString(mLabel, -GS!(0), -GS!(0), .Centered, dataRect.mX);
+				}
 			}
 		}
 

--- a/IDE/src/ui/FindAndReplaceDialog.bf
+++ b/IDE/src/ui/FindAndReplaceDialog.bf
@@ -322,11 +322,14 @@ namespace IDE.ui
         {
             base.Draw(g);
 
-            g.DrawString("Find what:", 6, mEditWidget.mY - GS!(18));
-			if (mReplaceWidget != null)
-				g.DrawString("Replace with:", GS!(6), mReplaceWidget.mY - GS!(18));
-            g.DrawString("Look in:", GS!(6), mLocationCombo.mY - GS!(18));
-			g.DrawString("Look at these file types:", GS!(6), mFileTypesCombo.mY - GS!(18));
+			using (g.PushColor(DarkTheme.COLOR_TEXT))
+			{
+				g.DrawString("Find what:", 6, mEditWidget.mY - GS!(18));
+				if (mReplaceWidget != null)
+					g.DrawString("Replace with:", GS!(6), mReplaceWidget.mY - GS!(18));
+				g.DrawString("Look in:", GS!(6), mLocationCombo.mY - GS!(18));
+				g.DrawString("Look at these file types:", GS!(6), mFileTypesCombo.mY - GS!(18));
+			}
         }
 
 		public override void Update()

--- a/IDE/src/ui/GenerateDialog.bf
+++ b/IDE/src/ui/GenerateDialog.bf
@@ -834,9 +834,12 @@ namespace IDE.ui
 				g.DrawString(label, widget.mX + GS!(6), widget.mY - GS!(20));
 			}
 
-			DrawLabel(mKindBar, mRegenerating ? "Regenerating ..." : "Generator");
-			for (var uiEntry in mUIEntries)
-				DrawLabel(uiEntry.mWidget, uiEntry.mLabel);
+			using (g.PushColor(DarkTheme.COLOR_TEXT))
+			{
+				DrawLabel(mKindBar, mRegenerating ? "Regenerating ..." : "Generator");
+				for (var uiEntry in mUIEntries)
+					DrawLabel(uiEntry.mWidget, uiEntry.mLabel);
+			}
 		}
 
 		public override void DrawAll(Graphics g)

--- a/IDE/src/ui/NewBreakpointDialog.bf
+++ b/IDE/src/ui/NewBreakpointDialog.bf
@@ -140,7 +140,8 @@ namespace IDE.ui
         {
             base.Draw(g);
 
-            g.DrawString((mBreakpointKind == .Memory) ? "Breakpoint Address" : "Symbol Name", mAddressEdit.mX, mAddressEdit.mY - GS!(20));
+			using (g.PushColor(DarkTheme.COLOR_TEXT))
+            	g.DrawString((mBreakpointKind == .Memory) ? "Breakpoint Address" : "Symbol Name", mAddressEdit.mX, mAddressEdit.mY - GS!(20));
             //g.DrawString("Project Directory", mDialogEditWidget.mX, mDialogEditWidget.mY - 20);
         }
 

--- a/IDE/src/ui/ProfileDialog.bf
+++ b/IDE/src/ui/ProfileDialog.bf
@@ -95,9 +95,12 @@ namespace IDE.ui
 		{
 			base.Draw(g);
 
-			DrawLabel(g, mDescEdit, "Profile Description (Optional)");
-			DrawLabel(g, mThreadCombo, "Thread");
-			DrawLabel(g, mSampleRateEdit, "Sample Rate");
+			using (g.PushColor(DarkTheme.COLOR_TEXT))
+			{
+				DrawLabel(g, mDescEdit, "Profile Description (Optional)");
+				DrawLabel(g, mThreadCombo, "Thread");
+				DrawLabel(g, mSampleRateEdit, "Sample Rate");
+			}
 		}
 
 		public override void CalcSize()

--- a/IDE/src/ui/ProfilePanel.bf
+++ b/IDE/src/ui/ProfilePanel.bf
@@ -684,6 +684,9 @@ namespace IDE.ui
 		{
 			base.Draw(g);
 
+			g.PushColor(DarkTheme.COLOR_TEXT);
+			defer g.PopColor();
+
 			g.SetFont(DarkTheme.sDarkTheme.mSmallFont);
 			g.DrawString("Session", mSessionComboBox.mX - GS!(2), mSessionComboBox.mY, .Right);
 			g.DrawString("Thread", mThreadComboBox.mX - GS!(2), mThreadComboBox.mY, .Right);

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -4746,7 +4746,8 @@ namespace IDE.ui
 								case 2: lineStr.AppendF("{0}", (lineIdx + 1) % 100);
 								default: lineStr.AppendF("{0}", lineIdx + 1);
 								}
-						        g.DrawString(lineStr, 0, GS!(2) + ewc.mLineCoords[lineIdx], FontAlign.Right, editX - GS!(14));
+								using (g.PushColor(DarkTheme.COLOR_TEXT))
+						        	g.DrawString(lineStr, 0, GS!(2) + ewc.mLineCoords[lineIdx], FontAlign.Right, editX - GS!(14));
 						    }
 						}
 					}

--- a/IDE/src/ui/StartupPanel.bf
+++ b/IDE/src/ui/StartupPanel.bf
@@ -92,7 +92,8 @@ namespace IDE.ui
 				}
 
 				g.SetFont(s_Font);
-				g.DrawString(mPath, 10, 0, .Left, mWidth - 10);
+				using (g.PushColor(gApp.mSettings.mUISettings.mColors.mText))
+					g.DrawString(mPath, 10, 0, .Left, mWidth - 10);
 			}
 
 			public override void MouseEnter()


### PR DESCRIPTION
During the day i work in a very bright room and i prefer using light colors until the evening. In an attempt to create a light theme, i discovered several places where text colors were hardcoded to white, making it impossible to read that text in a light theme. To help with this, i changed most of these to use the `DarkTheme.COLOR_TEXT` color and i had to introduce 4 new theme options and 2 new colors on the `DarkTheme` struct.

In every single change, i made sure the default dark theme stayed the same by using the previously hardcoded colors as defaults for the new settings/color options.

I'm sure i missed a few spots here and there but i prioritized immediate problems and if this PR is accepted, i could open another one changing what's left over.

*I noticed that the word 'hilite' was used instead of 'highlight' in multiple places, so i assume it is a deliberate decision but i didn't use it for the 'mCodeHighlight' and 'mCodeHighlightUnfocused' options. Please let me know if you want me to change the names.*