### PR TITLE
Make more colors configurable and use the theme text color for tooltips.

### DIFF
--- a/BeefLibs/Beefy2D/src/theme/dark/DarkListView.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkListView.bf
@@ -978,7 +978,7 @@ namespace Beefy.theme.dark
         public float mDragOffset = 0;
         public bool mShowColumnGrid;
         public bool mShowGridLines;
-		public Color mGridLinesColor = 0x0CFFFFFF;
+		public Color mGridLinesColor;
         public bool mShowHeader = true;
 		public bool mEndInEllipsis;
 		public bool mWordWrap;
@@ -1002,6 +1002,7 @@ namespace Beefy.theme.dark
         {
             mFont = DarkTheme.sDarkTheme.mSmallFont;
             mBoldFont = DarkTheme.sDarkTheme.mSmallBoldFont;
+			mGridLinesColor = DarkTheme.COLOR_GRID;
             SetShowHeader(true);
 			
         }
@@ -1093,7 +1094,7 @@ namespace Beefy.theme.dark
 
 			if ((mShowColumnGrid) && (columnIdx < mColumns.Count - 1))
 			{
-			    DrawColumnGridColumn(g, column.mWidth, DarkTheme.sUnitSize, mHeight - DarkTheme.sUnitSize - 1, 0xFF707070);
+			    DrawColumnGridColumn(g, column.mWidth, DarkTheme.sUnitSize, mHeight - DarkTheme.sUnitSize - 1, DarkTheme.COLOR_GRID);
 			}
 
 			float sortArrowX = g.mFont.GetWidth(column.mLabel) + DarkTheme.sUnitSize/2;
@@ -1152,7 +1153,7 @@ namespace Beefy.theme.dark
 
                             if ((mShowColumnGrid) && (columnIdx < mColumns.Count - 1))
                             {
-                                DrawColumnGridColumn(g, curX, GS!(4), mHeight - GS!(8), 0xFF888888);
+                                DrawColumnGridColumn(g, curX, GS!(4), mHeight - GS!(8), DarkTheme.COLOR_GRID);
                             }
                         }
                     }

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkTheme.bf
@@ -200,6 +200,9 @@ namespace Beefy.theme.dark
 		public static uint32 COLOR_TEXT_DISABLED          = 0xFFA8A8A8;
 		public static uint32 COLOR_TEXT_SELECTED          = 0xFF2f5c88;
         public static uint32 COLOR_WINDOW                 = 0xFF595962;
+		public static uint32 COLOR_DIALOG_OUTLINE_IN      = 0xFF404040;
+		public static uint32 COLOR_DIALOG_OUTLINE_OUT     = 0xFF202020;
+		public static uint32 COLOR_GRID                   = 0x0CFFFFFF;
         public static uint32 COLOR_BKG                    = 0xFF26262A;
         public static uint32 COLOR_SELECTED_OUTLINE       = 0xFFCFAE11;
         public static uint32 COLOR_MENU_FOCUSED           = 0xFFE5A910;

--- a/BeefLibs/Beefy2D/src/theme/dark/DarkTooltip.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkTooltip.bf
@@ -178,10 +178,13 @@ namespace Beefy.theme.dark
                 g.DrawBox(DarkTheme.sDarkTheme.GetImage(DarkTheme.ImageIdx.Menu), 0, 0, mWidth, mHeight);
 
             g.SetFont(mFont);
-			if (mIsClipped)
-            	g.DrawString(mText, GS!(8), GS!(5), .Left, mWidth - GS!(16), .Ellipsis);
-			else
-				g.DrawString(mText, 0, GS!(5), .Centered, mWidth);
+			using (g.PushColor(DarkTheme.COLOR_TEXT))
+			{
+				if (mIsClipped)
+					g.DrawString(mText, GS!(8), GS!(5), .Left, mWidth - GS!(16), .Ellipsis);
+				else
+					g.DrawString(mText, 0, GS!(5), .Centered, mWidth);
+			}
 
             if (mAllowResize)
                 g.Draw(DarkTheme.sDarkTheme.GetImage(DarkTheme.ImageIdx.ResizeGrabber), mWidth - GS!(22), mHeight - GS!(22));

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -135,9 +135,6 @@ namespace IDE
 		public static readonly String sPlatform32Name = "Unknown32";
 #endif
 
-		public const uint32 cDialogOutlineLightColor = 0xFF404040;
-		public const uint32 cDialogOutlineDarkColor = 0xFF202020;
-
 		public static bool sExitTest;
 
 		public Verbosity mVerbosity = .Default;

--- a/IDE/src/IDEUtils.bf
+++ b/IDE/src/IDEUtils.bf
@@ -307,8 +307,8 @@ namespace IDE
 
 		public static void DrawOutline(Graphics g, Widget widget, int inflateX = 0, int32 inflateY = 0)
 		{
-		    DrawOutline(g, widget, inflateX, inflateY, IDEApp.cDialogOutlineLightColor);
-			DrawOutline(g, widget, inflateX - 1, inflateY - 1, IDEApp.cDialogOutlineDarkColor);
+		    DrawOutline(g, widget, inflateX, inflateY, DarkTheme.COLOR_DIALOG_OUTLINE_OUT);
+			DrawOutline(g, widget, inflateX - 1, inflateY - 1, DarkTheme.COLOR_DIALOG_OUTLINE_IN);
 		}
 
 		public static void ClampMenuCoords(ref float x, ref float y, ScrollableWidget scrollableWidget, Insets insets = null)

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -314,6 +314,9 @@ namespace IDE
 			public Color mTextDisabled = 0xFFA8A8A8;
 			public Color mTextSelected = 0xFF2f5c88;
 			public Color mWindow = 0xFF44444D;
+			public Color mDialogOutlineIn = 0xFF404040;
+			public Color mDialogOutlineOut = 0xFF202020;
+			public Color mGrid = 0x0CFFFFFF;
 			public Color mBackground = 0xFF1C1C24;
 			public Color mSelectedOutline = 0xFFCFAE11;
 			public Color mMenuFocused = 0xFFE5A910;
@@ -369,6 +372,9 @@ namespace IDE
 				GetColor("TextDisabled", ref mTextDisabled);
 				GetColor("TextSelected", ref mTextSelected);
 				GetColor("Window", ref mWindow);
+				GetColor("DialogOutlineIn", ref mDialogOutlineIn);
+				GetColor("DialogOutlineOut", ref mDialogOutlineOut);
+				GetColor("Grid", ref mGrid);
 				GetColor("Background", ref mBackground);
 				GetColor("SelectedOutline", ref mSelectedOutline);
 				GetColor("MenuFocused", ref mMenuFocused);
@@ -457,6 +463,9 @@ namespace IDE
 				DarkTheme.COLOR_TEXT_DISABLED = mTextDisabled;
 				DarkTheme.COLOR_TEXT_SELECTED = mTextSelected;
 				DarkTheme.COLOR_WINDOW = mWindow;
+				DarkTheme.COLOR_DIALOG_OUTLINE_IN = mDialogOutlineIn;
+				DarkTheme.COLOR_DIALOG_OUTLINE_OUT = mDialogOutlineOut;
+				DarkTheme.COLOR_GRID = mGrid;
 				DarkTheme.COLOR_BKG = mBackground;
 				DarkTheme.COLOR_SELECTED_OUTLINE = mSelectedOutline;
 				DarkTheme.COLOR_MENU_FOCUSED = mMenuFocused;

--- a/IDE/src/ui/AttachDialog.bf
+++ b/IDE/src/ui/AttachDialog.bf
@@ -308,8 +308,8 @@ namespace IDE.ui
 		    //Outline(g, mCategorySelector, 0, 0, 0xFF404040);
 		    //Outline(g, mCategorySelector, -1, -1, 0xFF202020);
 
-		    Outline(g, mFileList, 0, 0, IDEApp.cDialogOutlineLightColor);
-		    Outline(g, mFileList, -1, -1, IDEApp.cDialogOutlineDarkColor);
+		    Outline(g, mFileList, 0, 0, DarkTheme.COLOR_DIALOG_OUTLINE_OUT);
+		    Outline(g, mFileList, -1, -1, DarkTheme.COLOR_DIALOG_OUTLINE_IN);
 		}
 
 		void CheckFileDates()

--- a/IDE/src/ui/OpenFileInSolutionDialog.bf
+++ b/IDE/src/ui/OpenFileInSolutionDialog.bf
@@ -365,8 +365,8 @@ namespace IDE.ui
             //Outline(g, mCategorySelector, 0, 0, 0xFF404040);
             //Outline(g, mCategorySelector, -1, -1, 0xFF202020);
 
-            Outline(g, mFileList, 0, 0, IDEApp.cDialogOutlineLightColor);
-            Outline(g, mFileList, -1, -1, IDEApp.cDialogOutlineDarkColor);
+            Outline(g, mFileList, 0, 0, DarkTheme.COLOR_DIALOG_OUTLINE_OUT);
+            Outline(g, mFileList, -1, -1, DarkTheme.COLOR_DIALOG_OUTLINE_IN);
         }
 
         void CheckFileDates()


### PR DESCRIPTION
This PR makes the outline and grid colors for list views configurable from themes.

I use the same `Grid` color for both rows and columns, which will result in the following changes for the default theme:
Before:
![image](https://github.com/user-attachments/assets/6430a4c0-e916-42a3-baea-e63f8122f722)

After:
![image](https://github.com/user-attachments/assets/82508ad7-90ea-432f-86c0-fe5ac4497758)

I did this to avoid cluttering the themes with options for every single thing but if such change is unacceptable i'd be happy to separate row/column colors.