### PR TITLE
Don't consider cursor in open space when in literal

### DIFF
--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -4193,8 +4193,10 @@ namespace IDE.ui
                 //int cursorTextPos = CursorTextPos;
                 if (cursorTextPos < mData.mTextLength)
                 {
-                    charUnderCursor = (char8)mData.mText[cursorTextPos].mChar;
-					cursorInOpenSpace = ((charUnderCursor == ')') || (charUnderCursor == ']') || (charUnderCursor == ';') || (charUnderCursor == (char8)0) || (charUnderCursor.IsWhiteSpace));
+                    let charData = mData.mText[cursorTextPos];
+                    let cursorInLiteral = (SourceElementType)charData.mDisplayTypeId == .Literal;
+                    charUnderCursor = (char8)charData.mChar;
+					cursorInOpenSpace = ((!cursorInLiteral) && ((charUnderCursor == ')') || (charUnderCursor == ']') || (charUnderCursor == ';') || (charUnderCursor == (char8)0) || (charUnderCursor.IsWhiteSpace)));
 
 					if (((keyChar == '(') && (charUnderCursor == ')')) ||
 						((keyChar == '[') && (charUnderCursor == ']')))
@@ -4229,7 +4231,7 @@ namespace IDE.ui
 	                        }
 							else
 							{
-								if ((keyChar == '"') || (keyChar == '\''))
+								if ((!cursorInLiteral) && ((keyChar == '"') || (keyChar == '\'')))
 									cursorInOpenSpace = true;
 							}
 						}


### PR DESCRIPTION
Fixes #2128

**Change**
When in a literal, the cursor is no longer considered in open space.
This prevents auto-closing characters to trigger, which could happen in string templates under certain conditions.
See fixed bug for examples.

**Not fixed**
Actually closing a string template is still not working, but the outcome has changed slightly.
Example when writing out `let a = $"{args}";`:

Old behavior: `let a = $"{args}";""`
New behavior: `let a = $"{args}";"`



