### PR TITLE
Fix Console.Write not working when linux terminal buffers by line

### DIFF
--- a/BeefRT/rt/Internal.cpp
+++ b/BeefRT/rt/Internal.cpp
@@ -306,6 +306,7 @@ void bf::System::Console::PutChars(char* ptr, int len)
 
 	for (int i = 0; i < len; i++)
 		putchar(ptr[i]);
+	fflush(stdout);
 }
 
 void bf::System::Console::ReopenHandles()


### PR DESCRIPTION
Sometimes the terminal only displays the buffer whenever a newline occurs, this fixes that issue by manually flushing after every Console.WriteCall