### PR TITLE
Set focus to class name when opening Class Generator

### DIFF
--- a/BeefLibs/corlib/src/Compiler.bf
+++ b/BeefLibs/corlib/src/Compiler.bf
@@ -63,7 +63,7 @@ namespace System
 				mCmdInfo.Append("\n");
 			}
 
-			public void AddEdit(StringView dataName, StringView label, StringView defaultValue)
+			public void AddEdit(StringView dataName, StringView label, StringView defaultValue, bool focus = false)
 			{
 				mCmdInfo.AppendF($"addEdit\t");
 				dataName.QuoteString(mCmdInfo);
@@ -71,7 +71,7 @@ namespace System
 				label.QuoteString(mCmdInfo);
 				mCmdInfo.Append("\t");
 				defaultValue.QuoteString(mCmdInfo);
-				mCmdInfo.Append("\n");
+				mCmdInfo.AppendF($"\t{focus}\n");
 			}
 
 			public void AddFilePath(StringView dataName, StringView label, StringView defaultValue)
@@ -216,7 +216,7 @@ namespace System
 			
 			public override void InitUI()
 			{
-				AddEdit("name", "Class Name", "");
+				AddEdit("name", "Class Name", "", true);
 			}
 
 			public override void Generate(String outFileName, String outText, ref Flags generateFlags)

--- a/IDE/src/ui/GenerateDialog.bf
+++ b/IDE/src/ui/GenerateDialog.bf
@@ -581,12 +581,15 @@ namespace IDE.ui
 								uiEntry.mName = partItr.GetNext().Value.UnQuoteString(.. new .());
 								uiEntry.mLabel = partItr.GetNext().Value.UnQuoteString(.. new .());
 								var defaultValue = partItr.GetNext().Value.UnQuoteString(.. scope .());
+								var focus = partItr.GetNext().Value;
 								DarkEditWidget editWidget = new DarkEditWidget();
 								uiEntry.mWidget = editWidget;
 								editWidget.SetText(defaultValue);
 								editWidget.mEditWidgetContent.SelectAll();
 								editWidget.mOnSubmit.Add(new => EditSubmitHandler);
 								AddWidget(editWidget);
+								if (focus == "True")
+									editWidget.SetFocus();
 								mUIEntries.Add(uiEntry);
 								mTabWidgets.Add(editWidget);
 							case "addFilePath", "addFolderPath":


### PR DESCRIPTION
I often find myself opening the Class Generator and typing in the generator field instead of the class name, and it’s always annoying. For some reason, I’ve never tried to make a pull request for it, but hey, better late than never.