### PR TITLE
Fixed crash when defer scope target doesn't exist

### DIFF
--- a/IDEHelper/Compiler/BfStmtEvaluator.cpp
+++ b/IDEHelper/Compiler/BfStmtEvaluator.cpp
@@ -7283,7 +7283,16 @@ void BfModule::Visit(BfDeferStatement* deferStmt)
 			scope = &mCurMethodState->mHeadScope;
 	}
 	else if (deferStmt->mScopeName != NULL)
+	{
 		scope = FindScope(deferStmt->mScopeName, true);
+
+		if (scope == NULL)
+		{
+			AssertErrorState();
+			// The scope doesn't exist, continue with the current scope so we still get an evaluation of the deferred code
+			scope = mCurMethodState->mCurScope;
+		}
+	}
 	else
 		scope = mCurMethodState->mCurScope;
 


### PR DESCRIPTION
This small change fixes a crash when the specified scope of a defer-statement couldn't be found.

Example Code that crashes without this fix:
```bf
public static int Main(String[] args)
{
	defer:MyScope Console.WriteLine();
	return 0;
}
```