### PR TITLE
Fix static readonly warning in class body

### DIFF
--- a/IDEHelper/Compiler/BfExprEvaluator.cpp
+++ b/IDEHelper/Compiler/BfExprEvaluator.cpp
@@ -20496,9 +20496,12 @@ bool BfExprEvaluator::CheckModifyResult(BfTypedValue& typedVal, BfAstNode* refNo
 
 	if ((mResultFieldInstance != NULL) && (mResultFieldInstance->GetFieldDef()->mIsReadOnly) && (!canModify))
 	{
-		auto error = _Fail(StrFormat("Cannot %s static readonly field '%s.%s' within method '%s'", modifyType,
-			mModule->TypeToString(mResultFieldInstance->mOwner).c_str(), mResultFieldInstance->GetFieldDef()->mName.c_str(),
-			mModule->MethodToString(mModule->mCurMethodInstance).c_str()), refNode);
+		if (mModule->mCurMethodInstance != NULL)
+		{
+			auto error = _Fail(StrFormat("Cannot %s static readonly field '%s.%s' within method '%s'", modifyType,
+				mModule->TypeToString(mResultFieldInstance->mOwner).c_str(), mResultFieldInstance->GetFieldDef()->mName.c_str(),
+				mModule->MethodToString(mModule->mCurMethodInstance).c_str()), refNode);
+		}
 
 		return false;
 	}


### PR DESCRIPTION
Fixes: #2176
Just adds a null check.
While toying with this i have noticed that readonly fields are marked as modifiable in ctors / init blocks, so it won't generate an warning when used as in the issue.

Also found an another issue:
```
class Program
{
	struct Point : this(int32 x, int32 y)
	{
		public static let sValue = Point(10, 10);
	}

	static int Main(System.String[] args)
	{
		let q = Point.sValue;
		return 0;
	}
}
```
This code is enough to trigger an crash on compile. 

I have tried to fix it, but tbh i have no idea if it's even remotely right, here is link to the branch: https://github.com/Fusioon/Beef/commit/0fe47816644c0c4234b1a5ef4fbbe791cb2a7895