### PR TITLE
Fix uninitialized mActiveProject in BfTypeState

### DIFF
--- a/IDEHelper/Compiler/BfContext.h
+++ b/IDEHelper/Compiler/BfContext.h
@@ -205,6 +205,7 @@ public:
 		mCurAttributeTypeRef = NULL;
 		mCurTypeDef = NULL;
 		mForceActiveTypeDef = NULL;
+		mActiveProject = NULL;
 		mCurVarInitializer = NULL;
 		mArrayInitializerSize = -1;
 		mResolveKind = ResolveKind_None;


### PR DESCRIPTION
This PR fixes crashes that can occur due to access to mActiveProject when uninitialized usually leading to access violations.