### PR TITLE
Fix enum underlying const eval on static fields

### DIFF
--- a/IDEHelper/Compiler/BfExprEvaluator.cpp
+++ b/IDEHelper/Compiler/BfExprEvaluator.cpp
@@ -20095,7 +20095,7 @@ BfTypedValue BfExprEvaluator::GetResult(bool clearResult, bool resolveGenericTyp
 
 				auto methodDef = methodInstance.mMethodInstance->mMethodDef;
 				if ((methodDef->mMethodDeclaration == NULL) && (mPropTarget.mValue.IsConst()) &&
-					(methodDef->mName == "get__Underlying"))
+					(mPropTarget.mKind == BfTypedValueKind_Value) && (methodDef->mName == "get__Underlying"))
 				{					
 					mBfEvalExprFlags = (BfEvalExprFlags)(mBfEvalExprFlags | BfEvalExprFlags_Comptime);
 				}


### PR DESCRIPTION
Using `.Underlying` on static fields makes the compiler error out with `Non-constant argument for param 'this'`
I don't think it should be const evaluated so here is a fix

Code to better visualize what i'm talking about:
```
enum TestEnum
{
	Zero,
	One
}

static TestEnum Value = .One;
static void Example(int i) => Console.WriteLine(i);

public static void Main(String[] args)
{
	Example(TestEnum.Zero.Underlying);
	Example(Value.Underlying); // currently an error, fixed by this PR
}
```