### PR TITLE
Fix static payload enum switch isConst

### DIFF
--- a/IDEHelper/Compiler/BfStmtEvaluator.cpp
+++ b/IDEHelper/Compiler/BfStmtEvaluator.cpp
@@ -4678,7 +4678,7 @@ void BfModule::Visit(BfSwitchStatement* switchStmt)
 	BfPrimitiveType* intCoercibleType = GetIntCoercibleType(switchValue.mType);
 
 	bool isConstSwitch = false;
-	if ((switchValue.mValue.IsConst()) || (switchValue.mType->IsValuelessType()))
+	if ((mBfIRBuilder->IsConstValue(switchValue.mValue)) || (switchValue.mType->IsValuelessType()))
 	{
 		isConstSwitch = true;
 	}


### PR DESCRIPTION
Fixes: #2164, #1780

But there is still a slight problem I'm unsure how to fix, `mBfIRBuilder->IsConstValue` does not work reliably when we are not generating code eg. (autocomplete/mouse over), i believe the ids are not valid in the context of the IRConstHolder, same thing i noticed with https://github.com/beefytech/Beef/commit/ba558394f1530206c246ea8d853f1585a1367595 the `.Underlying` still gets red squiggles when i mouse over but does compile fine. I was able prevent this by adding `(!mBfIRBuilder->mIgnoreWrites)` before checking for const be that seems like a huge hack.