### PR TITLE
Better interface method matching when names match

### DIFF
--- a/IDEHelper/Compiler/BfModule.cpp
+++ b/IDEHelper/Compiler/BfModule.cpp
@@ -26733,12 +26733,17 @@ bool BfModule::SlotVirtualMethod(BfMethodInstance* methodInstance, BfAmbiguityCo
 
 					bool isBetter = false;
 					bool isWorse = false;
-					isBetter = (methodInstance->mMethodInfoEx != NULL) && (methodInstance->mMethodInfoEx->mExplicitInterface != NULL);
-					isWorse = (prevMethod->mMethodInfoEx != NULL) && (prevMethod->mMethodInfoEx->mExplicitInterface != NULL);
+					isBetter = methodInstance->mReturnType == iMethodInst->mReturnType;
+					isWorse = prevMethod->mReturnType == iMethodInst->mReturnType;
 					if (isBetter == isWorse)
 					{
-						isBetter = methodInstance->mReturnType == iMethodInst->mReturnType;
-						isWorse = prevMethod->mReturnType == iMethodInst->mReturnType;
+						isBetter = (methodInstance->mMethodInfoEx != NULL) && (methodInstance->mMethodInfoEx->mExplicitInterface != NULL);
+						isWorse = (prevMethod->mMethodInfoEx != NULL) && (prevMethod->mMethodInfoEx->mExplicitInterface != NULL);
+						if ((isBetter) && (isWorse))
+						{
+							isBetter = methodInstance->mMethodInfoEx->mExplicitInterface == ifaceInst;
+							isWorse = prevMethod->mMethodInfoEx->mExplicitInterface == ifaceInst;
+						}
 					}
 
 					if (isBetter == isWorse)


### PR DESCRIPTION
Fixes: #1865 
Changes how the interface methods are matched when ambiguous names are used, also adds support for multiple explicit interface  implementations.
Example code:
```
interface IPool1
{
	int8 Retrieve();
}
interface IPool2
{
	int16 Retrieve();
}
interface IPool3
{
	uint Retrieve();
}

class Pool : IPool1, IPool2, IPool3
{
	int8 IPool1.Retrieve() => 1;
	int16 IPool2.Retrieve() => 2;
	public uint Retrieve() => 10; // matches IPool3
}

class Program
{
	public static int Main()
	{
		Pool poolInstance = scope .();

		IPool1 _1 = poolInstance; 
		IPool2 _2 = poolInstance; 
		IPool3 _3 = poolInstance; 

		Console.WriteLine(_1.Retrieve());
		Console.WriteLine(_2.Retrieve());
		Console.WriteLine(_3.Retrieve());
		Console.WriteLine(poolInstance.Retrieve());

		return 0;
	}
}
```

