### PR TITLE
Fixed generated methods for enums with CRepr attribute

### DIFF
--- a/IDEHelper/Tests/src/Enums.bf
+++ b/IDEHelper/Tests/src/Enums.bf
@@ -118,6 +118,14 @@ namespace Tests
 		    case C;
 		}
 
+		[CRepr]
+		public enum EnumN
+		{
+			A,
+			B,
+			C
+		}
+
 		[Test]
 		static void TestBasic()
 		{
@@ -275,6 +283,25 @@ namespace Tests
 
 			EnumL el = .A;
 			Test.Assert(el == 0);
+		}
+
+		[Test]
+		static void TestCrepr()
+		{
+			EnumN value = .B;
+
+			Test.Assert(sizeof(EnumN) == sizeof(System.Interop.c_int));
+
+			Test.Assert(value.Underlying == 1);
+
+			ref System.Interop.c_int valueRef = ref value.UnderlyingRef;
+			valueRef = 2;
+			Test.Assert(value == .C);
+
+			String str = scope String();
+			value.ToString(str);
+
+			Test.Assert(str == "C");
 		}
 	}
 }

--- a/IDEHelper/Tests/src/Enums.bf
+++ b/IDEHelper/Tests/src/Enums.bf
@@ -292,6 +292,9 @@ namespace Tests
 
 			Test.Assert(sizeof(EnumN) == sizeof(System.Interop.c_int));
 
+			Test.Assert(value.HasFlag(.A) == false);
+			Test.Assert(value.HasFlag(.B) == true);
+
 			Test.Assert(value.Underlying == 1);
 
 			ref System.Interop.c_int valueRef = ref value.UnderlyingRef;


### PR DESCRIPTION
The recent changes to `CRepr` which make it so that `this` is always passed to methods as a pointer, broke the methods `HasFlag`, `GetUnderlying`, `GetUnderlyingRef` and `ToString` of enums that have the `CRepr`-Attribute. The compiler crashes during code gen because it receives a value of pointer type where it expected an integer value.

This PR fixes these issues by emitting load instructions (if necessary) while generating the IR for the methods in BfModule.
It also adds a test case. Without the changes in this PR the compiler crashes while compiling the test.
