### PR TITLE
Fix autocomplete param position for multiline doc strings

### DIFF
--- a/IDE/src/ui/AutoComplete.bf
+++ b/IDE/src/ui/AutoComplete.bf
@@ -1179,14 +1179,18 @@ namespace IDE.ui
 
 						if (!docString.IsWhiteSpace)
 						{
-							curY += font.GetLineSpacing() + GS!(4);
+							
 							if (g != null)
 							{
+								let docY = curY + font.GetLineSpacing() + GS!(4);
+
 								using (g.PushColor(gApp.mSettings.mUISettings.mColors.mAutoCompleteDocText))
-									docHeight = g.DrawString(docString, curX, curY, .Left, maxDocWidth, .Wrap);
+									docHeight = g.DrawString(docString, curX, docY, .Left, maxDocWidth, .Wrap);
 							}
 							else
 								docHeight = font.GetWrapHeight(docString, maxDocWidth);
+
+							curY += docHeight;
 						}
 
 						extWidth = Math.Max(extWidth, Math.Min(font.GetWidth(docString), maxDocWidth) + GS!(48));


### PR DESCRIPTION
Autocomplete will show information for the param under the cursor, which works fine when the doc string is a single line:

![Screenshot 2025-04-12 213007](https://github.com/user-attachments/assets/653efbb5-dced-48cd-8846-f74358e60fbe)

But for multiline doc strings it is overlapping:

![image](https://github.com/user-attachments/assets/675e3a03-6dc9-4a86-9790-9d14f769f1c2)

This PR accounts for multiline strings and correctly positions the param under:

![Screenshot 2025-04-12 213129](https://github.com/user-attachments/assets/c00e1f73-8f50-4716-98d3-3724a3506249)
