### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/BeefySysLib/third_party/jpeg/rdtarga.c
+++ b/BeefySysLib/third_party/jpeg/rdtarga.c
@@ -363,7 +363,8 @@ start_input_tga (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
   if (cmaptype > 1 ||		/* cmaptype must be 0 or 1 */
       source->pixel_size < 1 || source->pixel_size > 4 ||
       (UCH(targaheader[16]) & 7) != 0 || /* bits/pixel must be multiple of 8 */
-      interlace_type != 0)	/* currently don't allow interlaced image */
+      interlace_type != 0 ||      /* currently don't allow interlaced image */
+      width == 0 || height == 0)  /* image width/height must be non-zero */
     ERREXIT(cinfo, JERR_TGA_BADPARMS);
   
   if (subtype > 8) {


### PR DESCRIPTION
Dear Development team,

I identified a vulnerability in a clone function start_input_tga() in `BeefySysLib/third_party/jpeg/rdtarga.c` sourced from [libjpeg-turbo/libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo). These issues, originally reported in [CVE-2018-11212](https://nvd.nist.gov/vuln/detail/CVE-2018-11212), were resolved in the node repository via this commit https://github.com/libjpeg-turbo/libjpeg-turbo/commit/82923eb93a2eacf4a593e00e3e672bbb86a8a3a0.

This PR applies the corresponding patch to prevent a potential integer overflow in this codebase.

Please review at your convenience. Thank you for your time and attention!