### PR TITLE
Feature: Multi-Cursors

### DIFF
--- a/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
+++ b/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
@@ -4260,7 +4260,7 @@ namespace Beefy.widgets
 			}
 		}
 
-		public void RemoveSecondaryTextCursors()
+		public virtual void RemoveSecondaryTextCursors(bool force = true)
 		{
 			if (mTextCursors.Count == 1)
 				return;
@@ -4657,7 +4657,7 @@ namespace Beefy.widgets
 			}
 			else if (keyEvent.mKeyCode == .Escape)
 			{
-				ewc.RemoveSecondaryTextCursors();
+				ewc.RemoveSecondaryTextCursors(force: false);
 				isSingleInvoke = true;
 			}
 

--- a/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
+++ b/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
@@ -2376,7 +2376,10 @@ namespace Beefy.widgets
 
 				// ...
 				ExtractString(selection.mStartPos, selection.Length, cursorText);
-				cursorText.Append('\n');
+
+				// Skip new line for last fragment
+				if (@cursor.Index+1 < mTextCursors.Count)
+					cursorText.Append('\n');
 
 				text.Append(cursorText);
 				extra.AppendF("{0}:{1};", cursorExtra, cursorText.Length);
@@ -2556,8 +2559,6 @@ namespace Beefy.widgets
 			{
 				if ((cursorExtra.Length == 0) || (HasSelection()))
 				{
-					/*if ((cursorExtra.Length == 0) && (cursorText[cursorText.Length-1] == '\n'))
-						cursorText.RemoveFromEnd(1);*/
 					PasteText(cursorText);
 				}
 				else// if (fragment.mExtra == "line")
@@ -2602,8 +2603,6 @@ namespace Beefy.widgets
 				{
 					var fragment = fragments[idx];
 					var length = fragment.mText.Length;
-					if (idx + 1 == fragments.Count)
-						length--;
 
 					PasteFragment(scope String(fragment.mText, 0, length), "");
 					if (idx + 1 < fragments.Count)
@@ -2653,7 +2652,9 @@ namespace Beefy.widgets
 
 				var fragment = fragments[idx--];
 				String cursorText = scope String(fragment.mText, 0, fragment.mText.Length);
-				cursorText.RemoveFromEnd(1);
+
+				if (@cursor.Index+1 < sortedCursors.Count)
+					cursorText.RemoveFromEnd(1);
 
 				mData.mUndoManager.Add(new SetCursorAction(this));
 				PasteFragment(cursorText, fragment.mExtra);

--- a/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
+++ b/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
@@ -2557,7 +2557,7 @@ namespace Beefy.widgets
 
 			void PasteFragment(String cursorText, StringView cursorExtra)
 			{
-				if ((cursorExtra.Length == 0) || (HasSelection()))
+				if ((cursorExtra.Length == 0) || (HasSelection()) || (!mAllowVirtualCursor))
 				{
 					PasteText(cursorText);
 				}

--- a/IDE/src/Commands.bf
+++ b/IDE/src/Commands.bf
@@ -340,6 +340,8 @@ namespace IDE
 			Add("Zoom Out", new => gApp.Cmd_ZoomOut);
 			Add("Zoom Reset", new => gApp.Cmd_ZoomReset);
 			Add("Attach to Process", new => gApp.[Friend]DoAttach);
+			Add("Select Next Match", new => gApp.Cmd_SelectNextMatch);
+			Add("Skip Current Match and Select Next", new => gApp.Cmd_SkipCurrentMatchAndSelectNext);
 
 			Add("Test Enable Console", new => gApp.Cmd_TestEnableConsole);
 		}

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -4692,7 +4692,7 @@ namespace IDE.ui
 
             if (((keyCode == KeyCode.Up) || (keyCode == KeyCode.Down) || (keyCode == KeyCode.PageUp) || (keyCode == KeyCode.PageDown)))
             {
-				if ((!autoCompleteRequireControl) || (mWidgetWindow.IsKeyDown(KeyCode.Control)))
+				if ((IsPrimaryTextCursor()) && ((!autoCompleteRequireControl) || (mWidgetWindow.IsKeyDown(KeyCode.Control))))
 				{
 	                if ((mAutoComplete != null) && (mAutoComplete.IsShowing()))
 	                {

--- a/IDE/src/ui/SourceEditWidgetContent.bf
+++ b/IDE/src/ui/SourceEditWidgetContent.bf
@@ -7322,5 +7322,13 @@ namespace IDE.ui
 
 			RehupLineCoords(animIdx, animLines);
 		}
+
+		public override void RemoveSecondaryTextCursors(bool force = true)
+		{
+			if ((!force) && (mAutoComplete != null))
+				return;
+
+			base.RemoveSecondaryTextCursors(force);
+		}
     }
 }

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -1323,7 +1323,7 @@ namespace IDE.ui
 
 								embedSource.mTypeName = new .(useTypeName);
 								if (embedHasFocus)
-									embedSource.mCursorIdx = (.)embedSourceViewPanel.mEditWidget.mEditWidgetContent.CursorTextPos;
+									embedSource.mCursorIdx = (.)embedSourceViewPanel.mEditWidget.mEditWidgetContent.mTextCursors.Front.mCursorTextPos;
 								else
 									embedSource.mCursorIdx = -1;
 								resolveParams.mEmitEmbeds.Add(embedSource);
@@ -1385,7 +1385,7 @@ namespace IDE.ui
 				{
 	                if ((useResolveType == .Autocomplete) || (useResolveType == .GetSymbolInfo) || (mIsClang))
 					{
-						resolveParams.mOverrideCursorPos = (.)mEditWidget.Content.CursorTextPos;
+						resolveParams.mOverrideCursorPos = (.)mEditWidget.Content.mTextCursors.Front.mCursorTextPos;
 						/*if (useResolveType == .Autocomplete)
 							resolveParams.mOverrideCursorPos--;*/
 					}
@@ -2042,7 +2042,7 @@ namespace IDE.ui
 
 			ProjectSource projectSource = FilteredProjectSource;
 
-			int cursorPos = mEditWidget.mEditWidgetContent.CursorTextPos;
+			int cursorPos = mEditWidget.mEditWidgetContent.mTextCursors.Front.mCursorTextPos;
 
 			if ((resolveParams != null) && (resolveParams.mOverrideCursorPos != -1))
 				cursorPos = resolveParams.mOverrideCursorPos;
@@ -5254,7 +5254,10 @@ namespace IDE.ui
 
 			var sourceEditWidgetContent = (SourceEditWidgetContent)mEditWidget.Content;
 			if (!sourceEditWidgetContent.CheckReadOnly())
+			{
+				sourceEditWidgetContent.RemoveSecondaryTextCursors();
             	ShowSymbolReferenceHelper(SymbolReferenceHelper.Kind.Rename);
+			}
         }
 
 		public void FindAllReferences()


### PR DESCRIPTION
Hi there,

This pull-request brings a feature that allows for multiple cursors to be used in the same document. Hold `Alt` and press `LeftMouseButton` in a place where you want to put a cursor. Pressing `Escape` or just clicking somewhere (without holding `Alt`) will remove any secondary cursor.

This pull-request may be rejected, while parts or whole source code could be re-used to create a version of this feature that you think will be better for the project. Also, there is no rush or time-limit on accepting/rejecting this pull-request. I wish I could say that I'll assist in fixing bugs and consulting about related stuff, but lately I started experiencing internet problems (government firewall).

Given the amount of changes, I thought that it would be easier for you to understand it by providing an excerpt of a code:
```C#
class EditWidgetContent
{
	class TextCursor
	{
		// Primary cursor ALWAYS has an ID of zero
		int32 mId;

		EditSelection? mSelection;
		EditWidgetContent.LineAndColumn? mVirtualCursorPos;
		int32 mCursorTextPos;

		bool mCursorImplicitlyMoved;
		bool mJustInsertedCharPair;
	}

	// Special UndoBatch that can merge
	MultiCursorUndoBatchStart mMultiCursorUndoBatch;

	// Primary Cursor always sits at the front of the list
	List<TextCursor> mTextCursors = new List<TextCursor>() ~ DeleteContainerAndItems!(_);
	TextCursor mCurrentTextCursor;

	// Any widget that uses those fields, can keep doing that thanks to `ref`
	ref bool mCursorImplicitlyMoved => ref mCurrentTextCursor.mCursorImplicitlyMoved;
	ref bool mJustInsertedCharPair => ref mCurrentTextCursor.mJustInsertedCharPair;
	ref EditSelection? mSelection => ref mCurrentTextCursor.mSelection;
	ref int32 mCursorTextPos => ref mCurrentTextCursor.mCursorTextPos;
	ref LineAndColumn? mVirtualCursorPos => ref mCurrentTextCursor.mVirtualCursorPos;

	virtual void AdjustCursorsAfterExternalEdit(int index, int ofs, int lineOfs)
	{
		// Here we iterate over cursors and adjust their position with exception of the
		// currently selected one (unless this widget is not in focus).
		// 'lineOfs' has been added for cases, when cursor is in a virtual position
		// When modifying this method, test for consecutive selections, meaning:
		// 4 cursors that have selection and go one right after another.
	}

	override void MouseDown(float x, float y, int32 btn, int32 btnCount)
	{
		SetPrimaryTextCursor();
		if ((mIsMultiline) && (btn == 0) && (mWidgetWindow.GetKeyFlags(true) == .Alt))
		{
			mTextCursors.Add(new TextCursor(-1, mCurrentTextCursor));
		}
		else
		{
			RemoveSecondaryTextCursors();
		}

		// ...
	}


}

class EditWidget
{
	// Overriding EditWidget's KeyDown/KeyChar allows us to catch those
	// event before SourceEditWidgetContent and others
	override void KeyDown(KeyDownEvent keyEvent)
	{
		var ewc = Content;
		var isSingleInvoke = false;
		var keyFlags = mWidgetWindow.GetKeyFlags(true);

		if (((keyEvent.mKeyCode == (.)'Z') || (keyEvent.mKeyCode == (.)'Y')) && (keyFlags.HasFlag(.Ctrl)))
		{
			// Undo/Redo
			// This might be not ideal, since we are deleting secondary cursors only
			// for them to be created again during Undo/Redo, maybe some kind
			// of pool that keeps them for a while instead of deleting immediately
			ewc.RemoveSecondaryTextCursors();
			isSingleInvoke = true;
		}
		else if (keyEvent.mKeyCode == .Escape)
		{
			// For now, when we close AutoComplete by pressing Escape,
			// it unfortunately also remove secondary cursors.
			ewc.RemoveSecondaryTextCursors();
			isSingleInvoke = true;
		}

		ewc.RemoveIntersectingTextCursors();

		for (var cursor in ewc.mTextCursors)
		{
			ewc.SetTextCursor(cursor);
			base.KeyDown(keyEvent);
			if (isSingleInvoke)
				break;
		}
		
		ewc.SetPrimaryTextCursor();
		ewc.CloseMultiCursorUndoBatch();
	}

	override void KeyChar(KeyCharEvent keyEvent)
	{
		var ewc = Content;
		ewc.RemoveIntersectingTextCursors();
		for (var cursor in ewc.mTextCursors)
		{
			ewc.SetTextCursor(cursor);
			base.KeyChar(keyEvent);
		}

		ewc.SetPrimaryTextCursor();
		ewc.CloseMultiCursorUndoBatch();
	}
}
```

Additional notes:
- `MultiCursorUndoBatch` is created either somewhere down the call stack during `KeyDown/KeyChar`, or created and closed inside a single method, for example `SEWC.DuplcateLine()`.
- Pressing `Alt+Enter` when `QuickFind` is opened, selects all matches in the document or in a selection. Pressing `Shift+Alt+Enter` does the same, but the search is case-sensitive;
- Additional features: `Select Next Match` and `Skip Current Match and Select Next`;
- `Move Statement/Line Up/Down` removes secondary cursors for now;

Things, I'm not entirely sure I've done correctly:
- Changes in `AutoComplete.GetAsyncPos()` resolved issues with flickering of the AutoComplete's window;
- `EWC.CopyText()` and `EWC.PasteText()` inside IDE works fine, but I've just noticed that copying in IDE and then pasting to notepad for example has additional `\n` symbol at the end;

It was a pleasure working on that!