### PR TITLE
Fix: `PasteText()` one-to-many

### DIFF
--- a/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
+++ b/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
@@ -2625,7 +2625,7 @@ namespace Beefy.widgets
 			}
 
 			// Case, when we have multiple cursors
-			var identicalCountOfCusrors = ((mTextCursors.Count == fragments.Count) || (mTextCursors.Count == 1 && fragments.Count == 0));
+			var identicalCountOfCursors = ((mTextCursors.Count == fragments.Count) || (mTextCursors.Count == 1 && fragments.Count == 0));
 			var sortedCursors = GetSortedCursors(.. scope List<TextCursor>());
 			var idx = sortedCursors.Count-1;
 
@@ -2633,11 +2633,6 @@ namespace Beefy.widgets
 			UndoBatchStart undoBatchStart = null;
 			if (sortedCursors.Count == 1)
 				undoBatchStart = mData.mUndoManager.Add(.. new UndoBatchStart("paste"));
-
-			if (!identicalCountOfCusrors)
-			{
-				text.RemoveFromEnd(1);
-			}
 
 			for (var cursor in sortedCursors.Reversed)
 			{
@@ -2648,7 +2643,7 @@ namespace Beefy.widgets
 					PasteFragment(text, extra);
 					continue;
 				}
-				else if (!identicalCountOfCusrors)
+				else if (!identicalCountOfCursors)
 				{
 					PasteFragment(text, fragments[0].mExtra);
 					continue;


### PR DESCRIPTION
Hi there,

Last fix to copy/paste behaviour introduced a bug that can be reproduced like this:
```C#
enum MyEnum
{
   case Foo;
   case Bar;
}
```
1. Copy 'Foo';
2. Make at least two cursors;
3. Paste text;

This would result in pasting 'Fo' instead of 'Foo' (one character shorter). This pull-request fixes this issue.
Previously, all fragments had `\n` character at the end. Last fix removed `\n` from the last fragment (or when that was the only fragment).