### PR TITLE
Expanded documentation support while hovering over a function

### DIFF
--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -5627,6 +5627,64 @@ namespace IDE.ui
 									debugExpr.AppendF("\n{}", Font.EncodeColor(0xFFC0C0C0));
 									debugExpr.Append(showString);
 								}
+
+								// Display Author if there is one documented
+								if (!String.IsNullOrEmpty(docParser.mAuthorString))
+								{
+									debugExpr.AppendF("\n{}", Font.EncodeColor(0xFFC0C0C0));
+									debugExpr.Append(scope $"Author: {docParser.mAuthorString}");
+								}
+
+								// Display version if there is any documented
+								if (!String.IsNullOrEmpty(docParser.mTODOString))
+								{
+									debugExpr.AppendF("\n{}", Font.EncodeColor(0xFFC0C0C0));
+									debugExpr.Append(scope $"Version: {docParser.mVersionString}");
+								}
+
+								// Display remarks if there is any documented
+								if (!String.IsNullOrEmpty(docParser.mRemarksString))
+								{
+									debugExpr.AppendF("\n{}", Font.EncodeColor(0xFFC0C0C0));
+									debugExpr.Append(scope $"Remarks: {docParser.mRemarksString}");
+								}
+
+								// Display note if there is any documented
+								if (!String.IsNullOrEmpty(docParser.mNoteString))
+								{
+									debugExpr.AppendF("\n{}", Font.EncodeColor(0xFFC0C0C0));
+									debugExpr.Append(scope $"Note: {docParser.mNoteString}");
+								}
+
+								// Display todo if there is any documented
+								if (!String.IsNullOrEmpty(docParser.mTODOString))
+								{
+									debugExpr.AppendF("\n{}", Font.EncodeColor(0xFFC0C0C0));
+									debugExpr.Append(scope $"TODO: {docParser.mTODOString}");
+								}
+
+								// Display all parameters on hover
+								if (docParser.mParamInfo.Count > 0)
+								{
+									debugExpr.Append("\n");
+									debugExpr.Append("Parameters:");
+
+									for (var param in docParser.mParamInfo)
+									{
+										debugExpr.AppendF("\n{}", Font.EncodeColor(0xFFC0C0C0));
+										debugExpr.Append(scope $"{param.key} {param.value}");
+									}
+								}
+
+								// Display Return value if there is one documented
+								if (!String.IsNullOrEmpty(docParser.mReturnString))
+								{
+									debugExpr.Append("\n");
+									debugExpr.Append("Returns:");
+
+									debugExpr.AppendF("\n{}", Font.EncodeColor(0xFFC0C0C0));
+									debugExpr.Append(scope $"{docParser.mReturnString}");
+								}
 							}
 						}
 					}

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -5636,7 +5636,7 @@ namespace IDE.ui
 								}
 
 								// Display version if there is any documented
-								if (!String.IsNullOrEmpty(docParser.mTODOString))
+								if (!String.IsNullOrEmpty(docParser.mVersionString))
 								{
 									debugExpr.AppendF("\n{}", Font.EncodeColor(0xFFC0C0C0));
 									debugExpr.Append(scope $"Version: {docParser.mVersionString}");


### PR DESCRIPTION
## Context
Our team is currently working on improving the internal documentation throughout our codebase, And we've opted to use doxygen-style comments to add details and explanations to functions. While working on the documentation I've noticed that beef has very minimal support for said doxygen-style comments: just showning the brief description when hovered, or in the auto-complete list and just showing the parameters when typing them out.

## Solution
To that end, I thought it'd be generally useful to expand upon the behavior shown when a function is hovered and show various bits of detail about the function, instead of just the "brief", as shown below:
![image](https://github.com/user-attachments/assets/1687f375-2728-4fd8-951c-d25b43302036)

I have left the behavior for the description in the auto-complete list and the behavior when typing out function parameters untouched, as I believe they serve their purpose well as-is.

## Notes
If there are too many lines in the popup window, the vertical scroll bar widget will appear as expected but will _not_ allow any scrolling to occur: I believe this is due to the text internally being considered a `ListItem` as part of a `ListView`, and from what I can tell, the height of a list item is expected to be the height of one line in the displayed font, rather than something akin to `fontHeight * lineCount`. I am open to making any fixes required, but opted to first bring it up as a point of discussion as I am unfamiliar with the codebase as a whole and would like to to ensure the changes in this PR are easy to understand the reasoning behind rather than making what could be major changes and having to explain them in post
![image](https://github.com/user-attachments/assets/e8fdf8bf-f81f-420d-bfb8-a46c17299fde)