### PR TITLE
Optimization: Pop unused children in class view instead of removing from specific index

### DIFF
--- a/IDE/src/ui/ClassViewPanel.bf
+++ b/IDE/src/ui/ClassViewPanel.bf
@@ -883,7 +883,7 @@ namespace IDE.ui
 			}
 
 			while (curIdx < listViewItem.GetChildCount())
-				listViewItem.RemoveChildItemAt(curIdx);
+				listViewItem.RemoveChildItemAt(listViewItem.GetChildCount() - 1);
 			listViewItem.TryUnmakeParent();
 		}
 


### PR DESCRIPTION
There are a few other places where this happens, but those cases are rare.