### PR TITLE
Fixed select next match after using `QuickFind`

### DIFF
--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -7820,7 +7820,7 @@ namespace IDE.ui
 		{
 			var ewc = mEditWidget.mEditWidgetContent as SourceEditWidgetContent;
 
-			if (mQuickFind != null)
+			if ((mQuickFind != null) && (mQuickFind.mIsShowingMatches))
 			{
 				int usedCursorCount = 0;
 				for (var range in mQuickFind.mFoundRanges)


### PR DESCRIPTION
Hi there,

This pull-request fixes an issue that prevents selecting next match from the selection after closing `QuickFind`. To reproduce this issue use code-snippet below:
1. Select `float`, then press `Ctrl+D` to select next match;
2. Select `double`, then press `Ctrl+F`;
3. Close `QuickFind`;
4. Select `float` and press `Ctrl+D` to select next match;
Instead of selecting next `float`, it will select `double`. Expected behaviour is that when `QuickFind` is closed, pressing `Ctrl+D` will work on current selection.

```C#
struct Foo
{
	float mX;  // 1. Select 'float' and press 'Ctrl+D' to select next match
	float mZ;
	double mU; // 2. Select 'double' and press 'Ctrl+F' to open QuickFind
	double mV;
	float mY;  // 3. Select 'float' and press 'Ctrl+D' to see that 'double' is selected instead
}
```

https://github.com/user-attachments/assets/1deb5033-b4e3-4005-964d-98433024db8e