### PR TITLE
Remove secondary cursors on `Goto Method`

### DIFF
--- a/IDE/src/ui/NavigationBar.bf
+++ b/IDE/src/ui/NavigationBar.bf
@@ -175,6 +175,7 @@ namespace IDE.ui
 				*keyPtr = new String(entry.mText);
 			*valPtr = sCurrentMRUIndex++;
 
+            mSourceViewPanel.EditWidget?.Content.RemoveSecondaryTextCursors();
             mSourceViewPanel.ShowFileLocation(-1, entry.mLine, entry.mLineChar, LocatorType.Always);            
         }
 


### PR DESCRIPTION
Hi there,

This pull-request removes secondary cursors for when `Goto Method` is used, specifically `NavigationBar.ShowEntry(...)`.