### PR TITLE
Reseting `mDragSelectionUnion` after using `Add Selection to Next Find Match (Ctrl+D)`

### DIFF
--- a/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
+++ b/BeefLibs/Beefy2D/src/widgets/EditWidget.bf
@@ -3193,7 +3193,11 @@ namespace Beefy.widgets
                     SelectToCursor();                
                 }
                 else
+                {
                     CurSelection = null;
+                    mDragSelectionUnion = null;
+                    mDragSelectionKind = .None;
+                }
 
                 EnsureCursorVisible();
             }

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -7861,6 +7861,8 @@ namespace IDE.ui
 			}
 
 			ewc.AddSelectionToNextFindMatch(createCursor, exhaustiveSearch);
+			ewc.mDragSelectionUnion = null;
+			ewc.mDragSelectionKind = .None;
 		}
 
 		public void MoveLastSelectionToNextFindMatch()


### PR DESCRIPTION
Hi there,

This pull-request fixes two issues regarding `mDragSelectionUnion`.

First commit resets drag selection after `Add Selection to Next Find Match (Ctrl+D)` is used to select the word.
To reproduces this issue, follow next steps:
1. Place cursor on the word;
2. Press `Ctrl+D` to expand selection;
3. Press `Up` or `Down` arrow key to reset selection;
4. Hold `Shift` and press `Left` or `Right` arrow key;

https://github.com/user-attachments/assets/57b9d6d0-06fc-43d7-aa42-828b2820ae33

Second commit fixes issue with locked selection. To reproduce:
1. Place cursor on the word;
2. Press `Ctrl+D` to expand selection;
3. Holding `Shift`, expand selection to right with arrow keys;
4. Holding `Shift`, shrink selection with arrow keys;
On 4th step, it will stop shrinking selection at some point. In the video, I'm pressing `Shift+LeftArrow` multiple times, but selection does not change.

https://github.com/user-attachments/assets/32745999-5573-4f3f-8966-dad4cf670254