### PR TITLE
Fix cursor swap in `QuickFind.SelectAllMatches()`

### DIFF
--- a/IDE/src/ui/QuickFind.bf
+++ b/IDE/src/ui/QuickFind.bf
@@ -279,7 +279,7 @@ namespace IDE.ui
 
 			bool Matches(int32 idx)
 			{
-				if (idx + findText.Length >= ewc.mData.mTextLength)
+				if (idx + findText.Length > ewc.mData.mTextLength)
 					return false;
 
 				for (var i = 0; i < findText.Length; i++)


### PR DESCRIPTION
Hi there,

There was an issue with `QuickFind.SelectAllMatches()`, where after selecting all matches and pressing `Shift+Home/End`, selections will be incorrect, because the swap of `EditSelection?` was on `Value` and not on `ValueRef`. This pull-request fixes this issue.

Steps to reproduce issue:
1. Select word;
2. Press `Ctrl+F`;
3. Press `Alt+Enter`;
4. Press `Shift+End`;
5. Type any character;

Demonstration of issue:

https://github.com/user-attachments/assets/dd2739d1-c199-4c72-b707-ea1cee1855c1

Correct behaviour:

https://github.com/user-attachments/assets/d4611cb8-4b18-4eeb-ae61-117873cf9287