### PR TITLE
Surround System.gRand static initializer with #if !BF_RUNTIME_DISABLE

### DIFF
--- a/BeefLibs/corlib/src/Random.bf
+++ b/BeefLibs/corlib/src/Random.bf
@@ -306,8 +306,10 @@ namespace System
 		}
 	}
 
+#if !BF_RUNTIME_DISABLE
 	static
 	{
 		public static Random gRand = new Random() ~ delete _;
 	}
+#endif
 }


### PR DESCRIPTION
We were getting intermittent linker errors due to this static initializer in System.Random when building with runtime disabled