### PR TITLE
Fix wasm build

### DIFF
--- a/BeefySysLib/platform/posix/PosixCommon.cpp
+++ b/BeefySysLib/platform/posix/PosixCommon.cpp
@@ -961,7 +961,7 @@ BFP_EXPORT void BFP_CALLTYPE BfpProcess_GetProcessName(BfpProcess* process, char
         if (len != -1)
         {
             name_buf[len] = '\0';
-            process->mImageName.Append(basename(name_buf));
+            process->mImageName.Append(GetFileName(name_buf));
         }
         else
         {


### PR DESCRIPTION
This PR fixes the wasm build. It looks like the only thing missing from the Emscripten compiler was the `basename` method.