### PR TITLE
Add shallow-cloning to PackMan

### DIFF
--- a/IDE/src/util/GitManager.bf
+++ b/IDE/src/util/GitManager.bf
@@ -315,6 +315,11 @@ class GitManager
 		return StartGit(scope $"clone -v --progress --recurse-submodules {url} \"{path}\"");
 	}
 
+	public GitInstance CloneShallow(StringView url, StringView path, StringView hash)
+	{
+		return StartGit(scope $"clone -v --progress --recurse-submodules --shallow-submodules --revision={hash} --depth 1 {url} \"{path}\"");
+	}
+
 	public GitInstance Checkout(StringView path, StringView hash)
 	{
 		return StartGit(scope $"checkout -b BeefManaged {hash}", path);

--- a/IDE/src/util/PackMan.bf
+++ b/IDE/src/util/PackMan.bf
@@ -19,6 +19,7 @@ namespace IDE.util
 				None,
 				FindVersion,
 				Clone,
+				CloneShallow,
 				Checkout,
 				Setup
 			}
@@ -276,7 +277,7 @@ namespace IDE.util
 			}
 
 			WorkItem workItem = new .();
-			workItem.mKind = .Clone;
+			workItem.mKind = .CloneShallow;
 			workItem.mProjectName = new .(projectName);
 			workItem.mURL = new .(url);
 			workItem.mTag = new .(tag);
@@ -452,7 +453,7 @@ namespace IDE.util
 						}
 					case .Clone:
 						Checkout(workItem.mProjectName, workItem.mURL, workItem.mPath, workItem.mTag, workItem.mHash);
-					case .Checkout:
+					case .Checkout, .CloneShallow:
 						if (gApp.mVerbosity >= .Normal)
 							gApp.OutputLine($"Git cloning library '{workItem.mProjectName}' done.");
 
@@ -505,6 +506,8 @@ namespace IDE.util
 						workItem.mGitInstance = gApp.mGitManager.Checkout(workItem.mPath, workItem.mHash)..AddRef();
 					case .Clone:
 						workItem.mGitInstance = gApp.mGitManager.Clone(workItem.mURL, workItem.mPath)..AddRef();
+					case .CloneShallow:
+						workItem.mGitInstance = gApp.mGitManager.CloneShallow(workItem.mURL, workItem.mPath, workItem.mHash)..AddRef();
 					default:
 					}
 				}


### PR DESCRIPTION
Adds an additional function to shallow clone a specific revision of a remote dependency. 

As of Git v2.49.0 `git clone` support the `--revision` option. Together with the `--depth 1` option this allows for shallow clones at specific commits/references. This helps reduce download times by excluding irrelevant history.

I measured the time it took to clone imgui-beef using Add remote dependency:
Full download time: `20s` (normal clone) -> `15s` (shallow clone)
Excluding the cimgui submodule: `14s` -> `3s`

Of course, this will mostly be noticeable for larger repositories or extensive dependency trees.