### PR TITLE
Fix CeFunctionKind_Double_Strtod

### DIFF
--- a/IDEHelper/Compiler/CeMachine.cpp
+++ b/IDEHelper/Compiler/CeMachine.cpp
@@ -7183,7 +7183,7 @@ bool CeContext::Execute(CeFunction* startFunction, uint8* startStackPtr, uint8* 
 				if (endAddr != 0)
 				{
 					CE_CHECKADDR(endAddr, ptrSize);
-					CeSetAddrVal(endPtr, (uint8*)endPtr - memStart, ptrSize);
+					CeSetAddrVal(endPtr, (uint8*)*endPtr - memStart, ptrSize);
 				}
 			}
 			else if (checkFunction->mFunctionKind == CeFunctionKind_Double_Ftoa)


### PR DESCRIPTION
This PR fixes `strtod` at compile time. The issue was that the code stored the address in `endPtr` instead of the value that `strtod` wrote to the location it points to (`*endPtr`).