### PR TITLE
Add version check to shallow cloning

### DIFF
--- a/IDE/src/util/GitManager.bf
+++ b/IDE/src/util/GitManager.bf
@@ -77,30 +77,11 @@ class GitManager
 			ProcessStartInfo psi = scope ProcessStartInfo();
 
 			String gitPath = scope .();
+			GitManager.GetGitPath(gitPath);
+
 #if BF_PLATFORM_WINDOWS
-			Path.GetAbsolutePath(gApp.mInstallDir, "git/cmd/git.exe", gitPath);
-			if (!File.Exists(gitPath))
-				gitPath.Clear();
-
-			if (gitPath.IsEmpty)
-			{
-				Path.GetAbsolutePath(gApp.mInstallDir, "../../bin/git/cmd/git.exe", gitPath);
-				if (!File.Exists(gitPath))
-					gitPath.Clear();
-			}
-
-			if (gitPath.IsEmpty)
-			{
-				Path.GetAbsolutePath(gApp.mInstallDir, "../../../bin/git/cmd/git.exe", gitPath);
-				if (!File.Exists(gitPath))
-					gitPath.Clear();
-			}
-
 			psi.UseShellExecute = false;
 #endif
-			if (gitPath.IsEmpty)
-				gitPath.Set("git");
-
 			psi.SetFileName(gitPath);
 			psi.SetArguments(mArgs);
 			if (mPath != null)
@@ -348,5 +329,75 @@ class GitManager
 				gitInstance.ReleaseRef();
 			}
 		}
+	}
+
+	public static void GetGitPath(String gitPath)
+	{
+#if BF_PLATFORM_WINDOWS
+		Path.GetAbsolutePath(gApp.mInstallDir, "git/cmd/git.exe", gitPath);
+		if (!File.Exists(gitPath))
+			gitPath.Clear();
+
+		if (gitPath.IsEmpty)
+		{
+			Path.GetAbsolutePath(gApp.mInstallDir, "../../bin/git/cmd/git.exe", gitPath);
+			if (!File.Exists(gitPath))
+				gitPath.Clear();
+		}
+
+		if (gitPath.IsEmpty)
+		{
+			Path.GetAbsolutePath(gApp.mInstallDir, "../../../bin/git/cmd/git.exe", gitPath);
+			if (!File.Exists(gitPath))
+				gitPath.Clear();
+		}
+#endif
+
+		if (gitPath.IsEmpty)
+			gitPath.Set("git");
+	}
+
+	public static Result<Version> GetGitVersion()
+	{
+		static Version cache = default;
+		if (cache.Major != 0)
+			return cache;
+
+		let psi = scope ProcessStartInfo();
+
+		let gitPath = GetGitPath(.. scope .());
+		
+#if BF_PLATFORM_WINDOWS
+		psi.UseShellExecute = false;
+#endif
+		psi.SetFileName(gitPath);
+		psi.SetArguments("--version");
+		psi.RedirectStandardOutput = true;
+		psi.CreateNoWindow = true;
+
+		let process = scope SpawnedProcess();
+		if (process.Start(psi) case .Err)
+			return .Err;
+
+		let fs = scope FileStream();
+		let sr = scope StreamReader(fs);
+		process.AttachStandardOutput(fs);
+		process.WaitFor();
+
+		let output = scope String();
+		sr.ReadToEnd(output);
+
+		let prefix = "git version ";
+		int versionIdx = output.IndexOf(prefix);
+		if (versionIdx == -1)
+			return .Err;
+		output.Remove(0, versionIdx + prefix.Length);
+
+		var parts = output.Split('.');
+		let major = uint32.Parse(Try!(parts.GetNext())).GetValueOrDefault();
+		let minor = uint32.Parse(Try!(parts.GetNext())).GetValueOrDefault();
+		let build = uint32.Parse(Try!(parts.GetNext())).GetValueOrDefault();
+
+		return .Ok(cache = .(major, minor, build));
 	}
 }

--- a/IDE/src/util/PackMan.bf
+++ b/IDE/src/util/PackMan.bf
@@ -276,8 +276,12 @@ namespace IDE.util
 					gApp.OutputLine($"Git cloning library '{projectName}' tag '{tag}' at {hash.Substring(0, 7)}");
 			}
 
+			bool hasShallowClone = false;
+			if (GitManager.GetGitVersion() case .Ok(let ver))
+				hasShallowClone = ver.Major > 2 || (ver.Major == 2 && ver.Minor >= 49);
+
 			WorkItem workItem = new .();
-			workItem.mKind = .CloneShallow;
+			workItem.mKind = hasShallowClone ? .CloneShallow : .Clone;
 			workItem.mProjectName = new .(projectName);
 			workItem.mURL = new .(url);
 			workItem.mTag = new .(tag);


### PR DESCRIPTION
I suddenly couldn't clone repositories anymore, and it turns out the issue was caused by https://github.com/beefytech/Beef/pull/2301. This PR makes cloning more reliable by checking the Git version before attempting a shallow clone.