### PR TITLE
Replaced wsock32.lib with Ws2_32.lib to be coherent, ensure using the same WinSock2 library

### DIFF
--- a/BeefLibs/corlib/src/Net/Socket.bf
+++ b/BeefLibs/corlib/src/Net/Socket.bf
@@ -6,7 +6,7 @@ namespace System.Net
 {
 	class Socket
 	{
-		const uint16 WINSOCK_VERSION = 0x101;
+		const uint16 WINSOCK_VERSION = 0x0202;
 		const int32 WSAENETRESET    = 10052;
 		const int32 WSAECONNABORTED = 10053;
 		const int32 WSAECONNRESET   = 10054;


### PR DESCRIPTION
I replaced some instances of wsock32.lib with Ws2_32.lib, so the code will be more coherent. I don't know if it makes any difference, but Ws2_32.lib should ensure that WinSock2 is used; else it might mix WinSock1 with WinSock2. There are some other externs to that probably should be marked with Ws2_32.lib instead of [CLink, CallingConvention(.Stdcall)] (native library?), to ensure usage of the same library. I have not changed it, because it appears to work right now.