### PR TITLE
Allow linking emscripten's "fetch" API when building using wasm32

### DIFF
--- a/IDE/src/BuildContext.bf
+++ b/IDE/src/BuildContext.bf
@@ -780,6 +780,9 @@ namespace IDE
 					if (!workspaceOptions.mRuntimeChecks)
 						linkLine.Append(" -s ASSERTIONS=0");
 
+					if (project.mWasmOptions.mEnableFetch)
+						linkLine.Append(" -s FETCH=1");
+
 					linkLine.Replace('\\', '/');
 
 					var targetDir = Path.GetDirectoryPath(actualTargetPath, .. scope .());
@@ -1047,6 +1050,7 @@ namespace IDE
 				cacheStr.AppendF("Options\t{}\n", project.mLinuxOptions.mOptions);
 			case .Wasm:
 				cacheStr.AppendF("EnableThreads\t{}\n", project.mWasmOptions.mEnableThreads);
+				cacheStr.AppendF("EnableFetch\t{}\n", project.mWasmOptions.mEnableFetch);
 			default:
 			}
 			if (depPaths != null)

--- a/IDE/src/Project.bf
+++ b/IDE/src/Project.bf
@@ -1077,14 +1077,19 @@ namespace IDE
 			[Reflect]
 			public bool mEnableThreads = false;
 
+			[Reflect]
+			public bool mEnableFetch = false;
+
 			public void Deserialize(StructuredData data)
 			{
 				mEnableThreads = data.GetBool("EnableThreads", false);
+				mEnableFetch = data.GetBool("EnableFetch", false);
 			}
 
 			public void Serialize(StructuredData data)
 			{
 				data.ConditionalAdd("EnableThreads", mEnableThreads, false);
+				data.ConditionalAdd("EnableFetch", mEnableFetch, false);
 			}
 		}
 

--- a/IDE/src/ui/ProjectProperties.bf
+++ b/IDE/src/ui/ProjectProperties.bf
@@ -692,6 +692,7 @@ namespace IDE.ui
 		    category.mIsBold = true;
 		    category.mTextColor = Color.Mult(DarkTheme.COLOR_TEXT, 0xFFE8E8E8);
 			AddPropertiesItem(category, "Enable Threads", "mEnableThreads");
+			AddPropertiesItem(category, "Enable Fetch", "mEnableFetch");
 		    //parent.MakeParent();
 		    category.Open(true, true);
 		}


### PR DESCRIPTION
This is just a draft for now, because I'm not sure I did this correctly.

<img width="662" height="544" alt="image" src="https://github.com/user-attachments/assets/dcaf3d3d-aafb-41e0-8784-5b45a538e8a4" />

It's self-explanatory; when using emcc to build, we toggle the "FETCH" flag if enabled. This is useful when you want to make HTTP requests in WASM or whatever. It was necessary to get [the leaderboards on this game working.](https://www.newgrounds.com/portal/view/998531)

This is probably a hack, and it doesn't even work unless you toggle it for every project in your workspace. Nevertheless, it worked for me, so this is definitely a useful feature to have.