### PR TITLE
Add params ctor to Span

### DIFF
--- a/BeefLibs/corlib/src/Span.bf
+++ b/BeefLibs/corlib/src/Span.bf
@@ -62,6 +62,12 @@ namespace System
 			mLength = length;
 		}
 
+		[Inline]
+		public this(params Self span)
+		{
+			this = span;
+		}
+
 		/*public static implicit operator Span<T> (ArraySegment<T> arraySegment)
 		{
 


### PR DESCRIPTION
This allows you to do stuff like this:
```beef
Span<int> span;
{
    span = .(5, 7, 13, 19, 40);
    DoSomthing(span);
}
DoSomething(span);
DoSomething(.(7, 15, 35, 73));
```
