### PR TITLE
Fix compiling on WSL

### DIFF
--- a/BeefLibs/MiniZ/src/Zip.bf
+++ b/BeefLibs/MiniZ/src/Zip.bf
@@ -2929,7 +2929,7 @@ namespace MiniZ
 
 		[CallingConvention(.Stdcall), CLink]
 		static extern int32 _fseeki64(FILE* stream, int64 offset, int32 origin);
-		[CallingConvention(.Stdcall), CLink]
+		[CallingConvention(.Cdecl), CLink]
 		static extern int32 fseeko(FILE* stream, int64 offset, int32 origin);
 
 		[CallingConvention(.Stdcall), CLink]


### PR DESCRIPTION
I was compiling on a Ubuntu WSL and ran into this:
```
/usr/bin/ld: /root/Beef/BeefBuild/build/Debug_Linux64/MiniZ/MiniZ_MiniZ.o: in function `bf::MiniZ::MiniZ::ftell64(bf::MiniZ::MiniZ::FILE*)':
/root/Beef/BeefLibs/MiniZ/src/Zip.bf:2910: undefined reference to `_ftelli64'
/usr/bin/ld: /root/Beef/BeefBuild/build/Debug_Linux64/MiniZ/MiniZ_MiniZ.o: in function `bf::MiniZ::MiniZ::fseek64(bf::MiniZ::MiniZ::FILE*, long, int)':
/root/Beef/BeefLibs/MiniZ/src/Zip.bf:2924: undefined reference to `_fseeki64'
```