### PR TITLE
Fix MiniZ HuffDecode in tinfl_decompress

### DIFF
--- a/BeefLibs/MiniZ/src/Zip.bf
+++ b/BeefLibs/MiniZ/src/Zip.bf
@@ -1143,7 +1143,7 @@ namespace MiniZ
 								code_len = TINFL_FAST_LOOKUP_BITS;
 								repeat
 								{
-									temp = (uint16)pHuff.m_tree[~temp + (int32)((bit_buf >> code_len++) & 1)];
+									temp = pHuff.m_tree[~temp + (int32)((bit_buf >> code_len++) & 1)];
 								}
 								while ((temp < 0) && (num_bits >= (code_len + 1)));
 								if (temp >= 0)


### PR DESCRIPTION
Recently noticed that some archived files report error on decompression with `tinfl_decompress` returning  `HasMoreOutput` but the extracted data would be valid. This PR fixes that by removing the cast to uint16 since the values  in `m_tree` can be negative