### PR TITLE
Posix improvements

### DIFF
--- a/BeefLibs/corlib/src/Diagnostics/Process.bf
+++ b/BeefLibs/corlib/src/Diagnostics/Process.bf
@@ -92,6 +92,20 @@ namespace System.Diagnostics
 				});
 		}
 
+		public bool WaitFor(int waitMS = -1)
+		{
+			if (mProcess == null)
+			{
+				return true;
+			}
+
+			int code = 0;
+			Platform.BfpProcessResult processResult = 0;
+			let exited = Platform.BfpProcess_WaitFor(mProcess, waitMS, &code, &processResult);
+
+			return exited;
+		}
+
 		public static Result<void> GetProcesses(List<Process> processes)
 		{
 			let result = Platform.GetSizedHelper<Platform.BfpProcess*>(scope (outPtr, outSize, outResult) =>


### PR DESCRIPTION
tbh Mostly linux improvements
This PR implements:

- Detached process reaping 
   when  process is detached, adds SIGCHLD signal handler and spawns a thread which waits on self pipe for the signal,                  then loops over detached processes and tries to reap them

-  BfpProcess_WaitFor (linux only) & bf `Process.WaitFor`
  allows to wait for process exit, on linux the exit code is not reliable (mainly depends if the process is reaped before we check for exit code)

-   improve BfpSpawn_WaitFor (linux only)
  allow wait time other than -1 and 0

-  BfpSpawn_Kill (linux only if used with `BfpKillFlag_KillChildren`)
- BfpFile_GetAttributes
- BfpFile_SetAttributes - we can only set the permissions
- BfpFile_Rename