### PR TITLE
Disallow recursive typealiases

### DIFF
--- a/IDEHelper/Compiler/BfModule.cpp
+++ b/IDEHelper/Compiler/BfModule.cpp
@@ -3919,7 +3919,7 @@ void BfModule::AddDependency(BfType* usedType, BfType* userType, BfDependencyMap
 					return; // Circular!
 			}
 
-			AddDependency(underlyingType, userType, depFlag);
+			AddDependency(underlyingType, userType, depFlag, depContext);
 		}
 	}
 	else if (!usedType->IsGenericTypeInstance())


### PR DESCRIPTION
Fixes #1751, #2354 and hopefully makes recursive typealiases less problematic 
Achieved by adding check in`DoPopulateType_TypeAlias` and when recursion is detected it sets the alias to NULL + generates an error. 
I'm unsure if there are some adverse side effects due to this, tests are passing and in my limited testing this change seems to makes the IDE immune to hangs from typealias recursion.