### PR TITLE
Add BfpProcess_WaitFor for disabled RT

### DIFF
--- a/BeefLibs/corlib/src/Platform.bf
+++ b/BeefLibs/corlib/src/Platform.bf
@@ -256,7 +256,9 @@ namespace System
 		
 		public static int32 BfpProcess_GetProcessId(BfpProcess* process) => Runtime.NotImplemented();
 
-		public static int BfpSpawn_GetProcessId(BfpSpawn* spawn) => Runtime.NotImplemented();;
+		public static int BfpSpawn_GetProcessId(BfpSpawn* spawn) => Runtime.NotImplemented();
+
+		public static bool BfpProcess_WaitFor(BfpProcess* process, int waitMS, int* outExitCode, BfpProcessResult* outResult) => Runtime.NotImplemented();
 #endif
 
 		public enum BfpSpawnFlags : int32


### PR DESCRIPTION
Just adds missing `BfpProcess_WaitFor` to `corlib/src/Platform.bf` when runtime is disabled. currently we get an error due to #2356