### PR TITLE
Relaxed const value check for attributes

### DIFF
--- a/IDEHelper/Compiler/BfConstResolver.cpp
+++ b/IDEHelper/Compiler/BfConstResolver.cpp
@@ -424,10 +424,14 @@ bool BfConstResolver::PrepareMethodArguments(BfAstNode* targetSrc, BfMethodMatch
 			bool requiresConst = false;
 			if ((mModule->mCurMethodInstance == NULL) || (mModule->mCurMethodInstance->mMethodDef->mMethodType != BfMethodType_Mixin))
 				requiresConst = true;
-
-			if ((requiresConst) && (!mModule->mBfIRBuilder->IsConstValue(argValue.mValue)) && (!argValue.mType->IsValuelessType()))
+			
+			if ((requiresConst) && (!argValue.mType->IsValuelessType()))
 			{
-				mModule->Fail("Expression does not evaluate to a constant value", argExpr);
+				auto constant = mModule->mBfIRBuilder->GetConstant(argValue.mValue);
+				if ((constant == NULL) || ((!mModule->mBfIRBuilder->IsConstValue(argValue.mValue)) && (constant->mConstType != BfConstType_Undef)))
+				{
+					mModule->Fail("Expression does not evaluate to a constant value", argExpr);
+				}
 			}
 
 			if (!argValue.mType->IsVar())

--- a/IDEHelper/Compiler/BfExprEvaluator.cpp
+++ b/IDEHelper/Compiler/BfExprEvaluator.cpp
@@ -17359,7 +17359,7 @@ void BfExprEvaluator::ResolveAllocTarget(BfAllocTarget& allocTarget, BfAstNode* 
 					{
 						BfIRConstHolder* constHolder = mModule->mCurTypeInstance->mConstHolder;
 						auto constant = constHolder->GetConstant(attrib.mCtorArgs[0]);
-						if (constant != NULL)
+						if ((constant != NULL) && (constant->mConstType != BfConstType_Undef))
 						{
 							int alignOverride = (int)BF_MAX(1, constant->mInt64);
 							if ((alignOverride & (alignOverride - 1)) == 0)

--- a/IDEHelper/Compiler/BfModule.cpp
+++ b/IDEHelper/Compiler/BfModule.cpp
@@ -13205,11 +13205,14 @@ void BfModule::ProcessTypeInstCustomAttributes(int& packing, bool& isUnion, bool
 				{
 					auto alignConstant = mCurTypeInstance->mConstHolder->GetConstant(customAttribute.mCtorArgs[0]);
 
-					int checkPacking = alignConstant->mInt32;
-					if (((checkPacking & (checkPacking - 1)) == 0) && (packing > 0) && (packing < 256))
-						packing = checkPacking;
-					else
-						Fail("Packing must be a power of 2", customAttribute.GetRefNode());
+					if ((alignConstant != NULL) && (alignConstant->mConstType != BfConstType_Undef))
+					{
+						int checkPacking = alignConstant->mInt32;
+						if (((checkPacking & (checkPacking - 1)) == 0) && (packing > 0) && (packing < 256))
+							packing = checkPacking;
+						else
+							Fail("Packing must be a power of 2", customAttribute.GetRefNode());
+					}
 				}
 			}
 			else if (typeName == "System.UnionAttribute")
@@ -13251,12 +13254,14 @@ void BfModule::ProcessTypeInstCustomAttributes(int& packing, bool& isUnion, bool
 				if (customAttribute.mCtorArgs.size() >= 1)
 				{
 					auto alignConstant = mCurTypeInstance->mConstHolder->GetConstant(customAttribute.mCtorArgs[0]);
-
-					int checkAlign = alignConstant->mInt32;
-					if ((checkAlign & (checkAlign - 1)) == 0)
-						alignOverride = checkAlign;
-					else
-						Fail("Alignment must be a power of 2", customAttribute.GetRefNode());
+					if ((alignConstant != NULL) && (alignConstant->mConstType != BfConstType_Undef))
+					{
+						int checkAlign = alignConstant->mInt32;
+						if ((checkAlign & (checkAlign - 1)) == 0)
+							alignOverride = checkAlign;
+						else
+							Fail("Alignment must be a power of 2", customAttribute.GetRefNode());
+					}
 				}
 			}
 			else if (typeName == "System.UnderlyingArrayAttribute")
@@ -13265,7 +13270,7 @@ void BfModule::ProcessTypeInstCustomAttributes(int& packing, bool& isUnion, bool
 				{
 					auto typeConstant = mCurTypeInstance->mConstHolder->GetConstant(customAttribute.mCtorArgs[0]);
 					auto sizeConstant = mCurTypeInstance->mConstHolder->GetConstant(customAttribute.mCtorArgs[1]);
-					if ((typeConstant != NULL) && (sizeConstant != NULL) && (typeConstant->mConstType == BfConstType_TypeOf))
+					if ((typeConstant != NULL) && (sizeConstant != NULL) && (typeConstant->mConstType == BfConstType_TypeOf) && (sizeConstant->mConstType != BfConstType_Undef))
 					{
 						underlyingArrayType = (BfType*)(intptr)typeConstant->mInt64;
 						underlyingArraySize = sizeConstant->mInt32;

--- a/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfResolvedTypeUtils.cpp
@@ -632,7 +632,7 @@ int BfFieldInstance::GetAlign(int packing)
 				{
 					BfIRConstHolder* constHolder = module->mCurTypeInstance->mConstHolder;
 					auto constant = constHolder->GetConstant(attrib.mCtorArgs[0]);
-					if (constant != NULL)
+					if ((constant != NULL) && (constant->mConstType != BfConstType_Undef))
 					{
 						int alignOverride = (int)BF_MAX(1, constant->mInt64);
 						if ((alignOverride & (alignOverride - 1)) == 0)

--- a/IDEHelper/Tests/src/Structs.bf
+++ b/IDEHelper/Tests/src/Structs.bf
@@ -265,6 +265,19 @@ namespace Tests
 			int32 mB;
 		}
 
+		[Align(alignof(T))]
+		struct StructG<T>
+		{
+			int8 mA;
+		}
+
+		[Align(CVal)]
+		struct StructV<CVal> where CVal : const int
+		{
+			int8 mA;
+		}
+		
+
 		[Test]
 		static void TestLayouts()
 		{
@@ -311,6 +324,15 @@ namespace Tests
 			Test.Assert(sizeof(StructR) == 6);
 			Test.Assert(alignof(StructR) == 2);
 			Test.Assert(strideof(StructR) == 6);
+
+			Test.Assert(sizeof(StructG<int32>) == 1);
+			Test.Assert(alignof(StructG<int32>) == 4);
+			Test.Assert(strideof(StructG<int32>) == 4);
+
+			Test.Assert(sizeof(StructV<const 16>) == 1);
+			Test.Assert(alignof(StructV<const 16>) == 16);
+			Test.Assert(strideof(StructV<const 16>) == 16);
+
 		}
 
 		public int Test<T>(T val)


### PR DESCRIPTION
Fixes #2360 + adds test case
The problem is that on unspecialized generic types the values returned from `sizeof`,  `alignof`, `strideof` are undefined constants (guessing that the same  applies to generic const  parameters) . This PR tries to solve this by allowing constant values marked as undefined to not trigger error in `BfConstResolver` then it adds checks before reading the value for the attribute, this applies to: `Packed`, `Align`, `UnderlyingArray` attributes. Hopefully this won't cause any unforeseen issues down the line