### PR TITLE
Force indirect return for structs in AArch64 FFI

### DIFF
--- a/BeefLibs/corlib/src/FFI/Function.bf
+++ b/BeefLibs/corlib/src/FFI/Function.bf
@@ -165,7 +165,7 @@ namespace System.FFI
 
 #else //!BF_PLATFORM_WINDOWS
 
-#if BF_64_BIT
+#if BF_64_BIT && !BF_MACHINE_AARCH64
 	[AllowDuplicates]
 	enum FFIABI : int32
 	{

--- a/BeefLibs/corlib/src/Reflection/MethodInfo.bf
+++ b/BeefLibs/corlib/src/Reflection/MethodInfo.bf
@@ -543,10 +543,21 @@ namespace System.Reflection
 			FFIType* ffiRetType = null;
 			if (retType.IsStruct)
 			{
+#if BF_MACHINE_AARCH64
+				let ffiRetElements = scope:: List<FFIType*>(8);
+				for (let fi in retType.GetFields(.Instance | .DeclaredOnly))
+				{
+					let ffiType = GetFFIType!::(fi.FieldType);
+					ffiRetElements.Add(ffiType);
+				}
+				ffiRetElements.Add(null);
+				ffiRetType = scope::FFIType(Math.Max(24, retType.Size), retType.Align, .Struct, ffiRetElements.Ptr); // Force use of indirect return
+#else
 				ffiRetType = &FFIType.Void;
 				ffiParamList.Add(&FFIType.Pointer);
 				ffiArgList.Add(&variantData);
 				retData = &unusedRetVal;
+#endif
 			}
 			else
 				ffiRetType = GetFFIType!::(retType);
@@ -947,10 +958,21 @@ namespace System.Reflection
 			FFIType* ffiRetType = null;
 			if (retType.IsStruct)
 			{
+#if BF_MACHINE_AARCH64
+				let ffiRetElements = scope:: List<FFIType*>(8);
+				for (let fi in retType.GetFields(.Instance | .DeclaredOnly))
+				{
+					let ffiType = GetFFIType!::(fi.FieldType);
+					ffiRetElements.Add(ffiType);
+				}
+				ffiRetElements.Add(null);
+				ffiRetType = scope::FFIType(Math.Max(24, retType.Size), retType.Align, .Struct, ffiRetElements.Ptr); // Force use of indirect return
+#else
 				ffiRetType = &FFIType.Void;
 				ffiParamList.Add(&FFIType.Pointer);
 				ffiArgList.Add(&variantData);
 				retData = &unusedRetVal;
+#endif
 			}
 			else
 				ffiRetType = GetFFIType!::(retType);


### PR DESCRIPTION
This PR fixes the issue that causes the Reflection test case to fail on AArch64 (#2381). 
- The default FFIABI for AArch64 has been adjusted to SysV like expected by libffi.
- The return behaviour when the type is a struct has been fixed for AArch64. (edited @Fusioon 's fix to force the use of the indirect value return register)

This could be improved by changing the compiler behavior in order to use direct return for structs of size <= 16.