### PR TITLE
Fix dtor/mixin alloca on valueless types

### DIFF
--- a/IDEHelper/Compiler/BfExprEvaluator.cpp
+++ b/IDEHelper/Compiler/BfExprEvaluator.cpp
@@ -18667,17 +18667,20 @@ void BfExprEvaluator::InjectMixin(BfAstNode* targetSrc, BfTypedValue target, boo
 				mModule->UpdateSrcPos(methodDeclaration->mNameNode);
 				mModule->SetIllegalSrcPos();
 
-				auto refType = mModule->CreateRefType(newLocalVar->mResolvedType);
-				auto allocaVal = mModule->CreateAlloca(refType);
-
-				mModule->mBfIRBuilder->CreateStore(newLocalVar->mAddr, allocaVal);
-
-				if (!mModule->mBfIRBuilder->mIgnoreWrites)
+				if (!newLocalVar->mResolvedType->IsValuelessType())
 				{
-					auto diType = mModule->mBfIRBuilder->DbgGetType(refType);
-					auto diVariable = mModule->mBfIRBuilder->DbgCreateAutoVariable(mModule->mCurMethodState->mCurScope->mDIScope,
-						newLocalVar->mName, mModule->mCurFilePosition.mFileInstance->mDIFile, mModule->mCurFilePosition.mCurLine, diType);
-					mModule->mBfIRBuilder->DbgInsertDeclare(allocaVal, diVariable);
+					auto refType = mModule->CreateRefType(newLocalVar->mResolvedType);
+					auto allocaVal = mModule->CreateAlloca(refType);
+
+					mModule->mBfIRBuilder->CreateStore(newLocalVar->mAddr, allocaVal);
+
+					if (!mModule->mBfIRBuilder->mIgnoreWrites)
+					{
+						auto diType = mModule->mBfIRBuilder->DbgGetType(refType);
+						auto diVariable = mModule->mBfIRBuilder->DbgCreateAutoVariable(mModule->mCurMethodState->mCurScope->mDIScope,
+							newLocalVar->mName, mModule->mCurFilePosition.mFileInstance->mDIFile, mModule->mCurFilePosition.mCurLine, diType);
+						mModule->mBfIRBuilder->DbgInsertDeclare(allocaVal, diVariable);
+					}
 				}
 			}
 			else if (newLocalVar->mValue)

--- a/IDEHelper/Compiler/BfModule.cpp
+++ b/IDEHelper/Compiler/BfModule.cpp
@@ -18264,7 +18264,7 @@ void BfModule::EmitDtorBody()
 					else
 					{
 						localDef->mAddr = value;
-						if ((mBfIRBuilder->DbgHasInfo()) && (!IsTargetingBeefBackend()))
+						if ((mBfIRBuilder->DbgHasInfo()) && (!IsTargetingBeefBackend()) && (!fieldInst->mResolvedType->IsValuelessType()))
 						{
 							// Create another pointer indirection, a ref to the gep
 							auto refFieldType = CreateRefType(fieldInst->mResolvedType);


### PR DESCRIPTION
Fixes #2379 and also similar issue when instead of method a mixin is used
This is achieved by adding check if type is not valueless before creating alloca