### PR TITLE
void* VarArgs on aarch64 macOS

### DIFF
--- a/BeefLibs/corlib/src/Internal.bf
+++ b/BeefLibs/corlib/src/Internal.bf
@@ -32,7 +32,7 @@ namespace System
 	[CRepr]
 	struct VarArgs
 	{
-#if BF_PLATFORM_WINDOWS || BF_PLATFORM_WASM
+#if BF_PLATFORM_WINDOWS || BF_PLATFORM_WASM || (BF_PLATFORM_MACOS && BF_MACHINE_AARCH64)
 		void* mVAList;
 #else
 		int[5] mVAList; // Conservative size for va_list
@@ -67,7 +67,7 @@ namespace System
 
 		public void* ToVAList() mut
 		{
-#if BF_PLATFORM_WINDOWS || BF_PLATFORM_WASM
+#if BF_PLATFORM_WINDOWS || BF_PLATFORM_WASM || (BF_PLATFORM_MACOS && BF_MACHINE_AARCH64)
 			return mVAList;
 #else
 			return &mVAList;


### PR DESCRIPTION
This PR fixes an issue in varargs handling on aarch64 macOS that caused a test to fail (#2381). 