### PR TITLE
Preserve sret attr in delegates

### DIFF
--- a/IDEHelper/Compiler/BfExprEvaluator.cpp
+++ b/IDEHelper/Compiler/BfExprEvaluator.cpp
@@ -7261,7 +7261,7 @@ BfTypedValue BfExprEvaluator::CreateCall(BfAstNode* targetSrc, BfMethodInstance*
 		if (methodInstance->mIsIntrinsic)
 			break;
 
-		if ((sret != NULL) && (argIdx == GetStructRetIdx(methodInstance)))
+		if (((sret != NULL) || (isDelegateThunk)) && (argIdx == GetStructRetIdx(methodInstance, ((callFlags & BfCreateCallFlags_DelegateThunkStatic) != 0))))
 		{
 			mModule->mBfIRBuilder->Call_AddAttribute(callInst, argIdx + 1, BfIRAttribute_StructRet);
 			argIdx++;


### PR DESCRIPTION
This PR allows functions calls in delegates to mark argument as sret, this fixes delegates returning struct on aarch64 (#2381)