### PR TITLE
Fix Path.GetRelativePath()

### DIFF
--- a/BeefLibs/corlib/src/IO/Path.bf
+++ b/BeefLibs/corlib/src/IO/Path.bf
@@ -427,7 +427,7 @@ namespace System.IO
 		    if (curPath1.Contains(Path.AltDirectorySeparatorChar))
 		        curPath1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 		    if (curPath2.Contains(Path.AltDirectorySeparatorChar))
-		        curPath1.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+		        curPath2.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
 		    String driveString1 = scope String();
 		    GetDriveStringTo(driveString1, curPath1);


### PR DESCRIPTION
This was messing up my build system. I spent about an hour trying to figure out what was wrong before checking the actual code. Turns out this has been wrong for a while.