### PR TITLE
Put workspace Projects and WorkspaceFolders entries on individual lines

### DIFF
--- a/IDE/src/Project.bf
+++ b/IDE/src/Project.bf
@@ -1680,7 +1680,7 @@ namespace IDE
 
 			if (!isDefaultDependencies)
 			{
-				using (data.CreateObject("Dependencies", true))
+				using (data.CreateObject("Dependencies"))
 				{
 				    for (var dependency in mDependencies)
 				    {

--- a/IDE/src/Workspace.bf
+++ b/IDE/src/Workspace.bf
@@ -730,7 +730,7 @@ namespace IDE
 
 			if (!mProjectSpecs.IsEmpty)
 			{
-				using (data.CreateObject("Projects", true))
+				using (data.CreateObject("Projects"))
 				{
 					for (var projSpec in mProjectSpecs)
 					{
@@ -775,7 +775,7 @@ namespace IDE
 
 			if (!mWorkspaceFolders.IsEmpty)
 			{
-			    using (data.CreateObject("WorkspaceFolders", true))
+			    using (data.CreateObject("WorkspaceFolders"))
 			    {
 					String fullPathBuffer = scope .();
 			        for (let folder in mWorkspaceFolders)

--- a/IDE/src/util/VerSpec.bf
+++ b/IDE/src/util/VerSpec.bf
@@ -112,7 +112,7 @@ namespace IDE.Util
 			{
 			case .None:
 			case .Git(var path, var ver):
-				using (data.CreateObject(name))
+				using (data.CreateObject(name, true))
 				{
 					data.Add("Git", path);
 					if ((ver != null) && (!ver.mVersion.IsEmpty))
@@ -121,7 +121,7 @@ namespace IDE.Util
 			case .SemVer(var ver):
 				data.Add(name, ver.mVersion);
 			case .Path(var path):
-				using (data.CreateObject(name))
+				using (data.CreateObject(name, true))
 				{
 					data.Add("Path", path);
 				}
@@ -240,7 +240,7 @@ namespace IDE.Util
 			{
 			case .None:
 			case .Git(var path, var ver):
-				using (data.CreateObject(name))
+				using (data.CreateObject(name, true))
 				{
 					data.Add("Git", path);
 					if (ver != null)
@@ -249,7 +249,7 @@ namespace IDE.Util
 			case .SemVer(var ver):
 				data.Add(name, ver.mVersion);
 			case .Path(var path):
-				using (data.CreateObject(name))
+				using (data.CreateObject(name, true))
 				{
 					data.Add("Path", path);
 				}


### PR DESCRIPTION
Put workspace Projects and WorkspaceFolders entries on individual lines instead of cramming everything into a single line.

This is negligible, but becomes unwieldly for larger workspaces, especially with git diffs.