### PR TITLE
Fix ArrayBase::operator!= for equal arrays

### DIFF
--- a/BeefySysLib/util/Array.h
+++ b/BeefySysLib/util/Array.h
@@ -285,7 +285,7 @@ public:
 		for (intptr i = 0; i < mSize; i++)
 			if (mVals[i] != arrB.mVals[i])
 				return true;
-		return true;
+		return false;
 	}
 
 	const_iterator begin() const


### PR DESCRIPTION
## Summary
`ArrayBase::operator!=` returned `true` in the success path when both arrays had the same size and elements. The final `return` should be `false` when all pairs match.

## Change
- `BeefySysLib/util/Array.h`: last branch of `operator!=` now returns `false` when contents are equal.

Matches the same logic as `operator==` (equal sequences are not unequal).