### PR TITLE
Fix Array TrimExcess condition

### DIFF
--- a/BeefySysLib/util/Array.h
+++ b/BeefySysLib/util/Array.h
@@ -878,7 +878,7 @@ public:
 
 	void TrimExcess()
 	{
-		if (this->mSize > this->mAllocSize)
+		if (this->mSize < this->mAllocSize)
 			SetBufferSize(this->mSize);
 	}
 


### PR DESCRIPTION
## Summary
`TrimExcess()` used `mSize > mAllocSize`, which does not occur for a consistent array (allocated capacity should be at least the used length). The intended check is to shrink when there is **spare** capacity: `mSize < mAllocSize`.

## Change
- `BeefySysLib/util/Array.h`: correct the condition so excess storage is actually released when appropriate.