### PR TITLE
Fix DrawLayer::AllocateBatch minVtxCount clamp

### DIFF
--- a/BeefySysLib/gfx/DrawLayer.cpp
+++ b/BeefySysLib/gfx/DrawLayer.cpp
@@ -194,7 +194,7 @@ DrawBatch* DrawLayer::AllocateBatch(int minVtxCount, int minIdxCount)
 	int vtxSize = mRenderDevice->mCurRenderState->mShader->mVertexSize;
 
 	minIdxCount = BF_MAX(minIdxCount, 512);
-	minVtxCount = BF_MAX(minIdxCount, 512);
+	minVtxCount = BF_MAX(minVtxCount, 512);
 
 	BF_ASSERT(minIdxCount * sizeof(uint16) <= DRAWBUFFER_IDXBUFFER_SIZE);
 	BF_ASSERT(minVtxCount * vtxSize <= DRAWBUFFER_VTXBUFFER_SIZE);


### PR DESCRIPTION
## Summary
In `DrawLayer::AllocateBatch`, the minimum vertex count was clamped with `BF_MAX(minIdxCount, 512)` instead of `minVtxCount`, so the requested vertex budget could be wrong when it differed from the index budget.

## Change
- `BeefySysLib/gfx/DrawLayer.cpp`: use `BF_MAX(minVtxCount, 512)` for `minVtxCount`.