### PR TITLE
Fix StrEndsWith suffix pointer offset

### DIFF
--- a/BeefySysLib/Common.cpp
+++ b/BeefySysLib/Common.cpp
@@ -147,7 +147,7 @@ bool Beefy::StrEndsWith(const StringImpl& str, const StringImpl& subStr)
 	if (subStr.length() < str.length())
 		return false;
 
-	return strncmp(str.c_str() - (str.length() - subStr.length()), subStr.c_str(), subStr.length()) == 0;
+	return strncmp(str.c_str() + (str.length() - subStr.length()), subStr.c_str(), subStr.length()) == 0;
 }
 
 #ifndef BF_SMALL


### PR DESCRIPTION
## Summary
`StrEndsWith` compared the suffix using `str.c_str() - (str.length() - subStr.length())`, which walks the pointer **backward** from the start of the buffer. The correct address of the tail is `str.c_str() + (str.length() - subStr.length())`.

## Change
- `BeefySysLib/Common.cpp`: use `+` for the byte offset to the suffix.