### PR TITLE
Allow 'none' compilation target

### DIFF
--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -12220,6 +12220,8 @@ namespace IDE
 					canCompile = true; // Use WSL
 			case .Wasm:
 				canCompile = true;
+			case .None:
+				canCompile = true;
 			default:
 			}
 

--- a/IDE/src/Workspace.bf
+++ b/IDE/src/Workspace.bf
@@ -110,6 +110,7 @@ namespace IDE
 			case iOS;
 			case Android;
 			case Wasm;
+			case None; //Bare-metal
 			
 			public static PlatformType GetFromName(StringView name, StringView targetTriple = default)
 			{
@@ -123,6 +124,7 @@ namespace IDE
 				case "macOS": return .macOS;
 				case "iOS": return .iOS;
 				case "wasm32", "wasm64": return .Wasm;
+				case "none": return .None;
 				default:
 					return TargetTriple.GetPlatformType(name);
 				}

--- a/IDE/src/util/TargetTriple.bf
+++ b/IDE/src/util/TargetTriple.bf
@@ -47,6 +47,8 @@ namespace IDE.Util
 				case "wasm32",
 					 "wasm64":
 					return .Wasm;
+				case "none":
+					return .None;
 				}
 			}
 


### PR DESCRIPTION
Support 'none' target for bare-metal compilation (e.g. thumbv8m.main-none-eabi)