### PR TITLE
Use .config for mutable data for linux packaged build

### DIFF
--- a/IDE/src/BeefConfig.bf
+++ b/IDE/src/BeefConfig.bf
@@ -225,9 +225,13 @@ namespace IDE
 			data.GetString("ManagedLibDir", mManagedLibPath);
 			if ((mManagedLibPath.IsEmpty) && (!mLibDirectories.IsEmpty))
 			{
+#if BF_PLATFORM_LINUX && LINUX_PACKAGE
+				var managedPath = Path.GetAbsolutePath("BeefManaged", gApp.mUserDataDir, .. scope .());
+#else
 				var libPath = Path.GetAbsolutePath(mLibDirectories[0].mPath, gApp.mInstallDir, .. scope .());
 				var managedPath = Path.GetAbsolutePath("../BeefManaged", libPath, .. scope .());
-				if (Directory.Exists(managedPath))
+#endif
+				if (Directory.CreateDirectory(managedPath) case .Ok)
 					mManagedLibPath.Set(managedPath);
 			}
 

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -12923,6 +12923,10 @@ namespace IDE
 #if BF_PLATFORM_LINUX
 			let icon = (Span<uint8>)cAppIcon;
 			BFApp_RegisterAppIcon(icon.Ptr, icon.Length);
+
+#if LINUX_PACKAGE
+			mUserDataDir = new $"{Environment.GetEnvironmentVariable("HOME", .. scope .())}/.config/beeflang/";
+#endif
 #endif
 
 			//Yoop();

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -544,7 +544,7 @@ namespace IDE
 
 				for (let theme in mTheme)
 				{
-					String relPath = scope .()..Append(gApp.mInstallDir, "themes/");
+					String relPath = scope .()..Append(gApp.mUserDataDir, "themes/");
 					String absPath = scope .();
 					Path.GetAbsolutePath(theme, relPath, absPath);
 
@@ -1249,7 +1249,7 @@ namespace IDE
 
 		void GetSettingsPath(String outPath)
 		{
-			outPath.Append(gApp.mInstallDir, "/BeefSettings.toml");
+			outPath.Append(gApp.mUserDataDir, "/BeefSettings.toml");
 		}
 
 		public void Save()

--- a/IDE/src/SpellChecker.bf
+++ b/IDE/src/SpellChecker.bf
@@ -84,7 +84,7 @@ namespace IDE
 
         static void GetUserDirectFileName(String path)
         {
-            path.Append(IDEApp.sApp.mInstallDir, "userdict.txt");
+            path.Append(IDEApp.sApp.mUserDataDir, "userdict.txt");
         }
 
 		public static void ResetWordList()

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -22,6 +22,11 @@ do
 		BUILD_IDE=1
 	fi
 
+	if [[ $i == "package" ]]; then
+		echo "Building for packaging"
+		PACKAGE_DEFINE="-define=LINUX_PACKAGE"
+	fi
+
 	if [[ $i == "no_ffi" ]]; then
 		echo "Disabling FFI"
 		USE_FFI="-DBF_DISABLE_FFI=1"
@@ -149,7 +154,7 @@ ln -s -f $ROOTPATH/jbuild/Release/bin/libIDEHelper.a ../../BeefLibs/Beefy2D/dist
 echo Building BeefBuild_bootd
 ../../jbuild_d/Debug/bin/BeefBoot --out="BeefBuild_bootd" --src=../src --src=../../BeefBuild/src --src=../../BeefLibs/corlib/src --src=../../BeefLibs/Beefy2D/src --define=CLI --define=DEBUG --startup=BeefBuild.Program --linkparams="./libBeefRT_d.a ./libIDEHelper_d.a ./libBeefySysLib_d.a ./libhunspell.$LIBEXT $(< ../../IDE/dist/IDEHelper_libs_d.txt) $LINKOPTS"
 echo Building BeefBuild_d
-./BeefBuild_bootd -clean -proddir=../../BeefBuild -config=Debug
+./BeefBuild_bootd -clean -proddir=../../BeefBuild -config=Debug $PACKAGE_DEFINE
 echo Testing IDEHelper/Tests in BeefBuild_d
 ./BeefBuild_d -proddir=../../IDEHelper/Tests -test
 
@@ -158,7 +163,7 @@ echo Testing IDEHelper/Tests in BeefBuild_d
 echo Building BeefBuild_boot
 ../../jbuild/Release/bin/BeefBoot --out="BeefBuild_boot" --src=../src --src=../../BeefBuild/src --src=../../BeefLibs/corlib/src --src=../../BeefLibs/Beefy2D/src --define=CLI --startup=BeefBuild.Program --linkparams="./libBeefRT.a ./libIDEHelper.a ./libBeefySysLib.a ./libhunspell.$LIBEXT $(< ../../IDE/dist/IDEHelper_libs.txt) $LINKOPTS"
 echo Building BeefBuild
-./BeefBuild_boot -clean -proddir=../../BeefBuild -config=Release
+./BeefBuild_boot -clean -proddir=../../BeefBuild -config=Release $PACKAGE_DEFINE
 echo Testing IDEHelper/Tests in BeefBuild
 ./BeefBuild -proddir=../../IDEHelper/Tests -test
 
@@ -166,8 +171,8 @@ echo Testing IDEHelper/Tests in BeefBuild
 if [ -n "$BUILD_IDE" ]; then
 
 	echo Building BeefIDE_d
-	./BeefBuild -clean -proddir=../ -config=Debug
+	./BeefBuild -clean -proddir=../ -config=Debug $PACKAGE_DEFINE
 	echo Building BeefIDE
-	./BeefBuild -clean -proddir=../ -config=Release
+	./BeefBuild -clean -proddir=../ -config=Release $PACKAGE_DEFINE
 
 fi


### PR DESCRIPTION
This PR moves 'BeefSettings.toml' 'themes/' 'userdict.txt' and 'BeefManaged/' to ~/.config/beeflang when building for linux packaging. This ensures that this data is in a writable (and expected) folder once installed.