### PR TITLE
Fix static initialization order issue in AllowFail classes

### DIFF
--- a/BeefLibs/Beefy2D/src/gfx/Font.bf
+++ b/BeefLibs/Beefy2D/src/gfx/Font.bf
@@ -263,13 +263,14 @@ namespace Beefy.gfx
 #if BF_PLATFORM_LINUX
 
 		const String FONTCONFIG_LIB = "libfontconfig.so";
-		static bool IsFontconfigAvailable { get; private set; } = true;
+		static bool IsFontconfigAvailable { get; private set; }
 
 		[AlwaysInclude, StaticInitPriority(100)]
 		private static class FontconfigAllowFail
 		{
 			static this()
 			{
+				SelfOuter.IsFontconfigAvailable = true;
 				Runtime.AddErrorHandler(new (stage, error) => {
 					if (stage == .PreFail)
 					{

--- a/BeefLibs/corlib/src/IO/FileDialog.bf
+++ b/BeefLibs/corlib/src/IO/FileDialog.bf
@@ -589,9 +589,9 @@ enum DialogResult
 
 abstract class CommonDialog
 {
-	protected Linux.DBus* mBus ~ Linux.SdBusUnref(_);
-	protected Linux.DBusMsg* mRequest ~ Linux.SdBusMessageUnref(_);
-	protected Linux.DBusErr mError ~ Linux.SdBusErrorFree(&_);
+	protected Linux.DBus* mBus ~ if (_ != null) Linux.SdBusUnref(_);
+	protected Linux.DBusMsg* mRequest ~ if (_ != null) Linux.SdBusMessageUnref(_);
+	protected Linux.DBusErr mError ~ if (_ != default) Linux.SdBusErrorFree(&_);
 	protected String mTitle ~ delete _;
 	protected String mInitialDir ~ delete _;
 	protected String[] mFileNames ~ DeleteContainerAndItems!(_);

--- a/BeefLibs/corlib/src/Linux.bf
+++ b/BeefLibs/corlib/src/Linux.bf
@@ -44,30 +44,28 @@ class Linux
 
 	public typealias DBusMsgHandler = function int32(DBusMsg *m, void *userdata, DBusErr *ret_error);
 
-	public static bool IsSystemdAvailable { get; private set; } = true;
+	public static bool IsSystemdAvailable { get; private set; }
 
 	[AlwaysInclude, StaticInitPriority(100)]
 	static class AllowFail
 	{
 		public static this()
 		{
-			Runtime.AddErrorHandler(new => Handle);
-		}
-
-		public static Runtime.ErrorHandlerResult Handle(Runtime.ErrorStage errorStage, Runtime.Error error)
-		{
-			if (errorStage == .PreFail)
-			{
-				if (var loadLibaryError = error as Runtime.LoadSharedLibraryError)
+			IsSystemdAvailable = true;
+			Runtime.AddErrorHandler(new (stage, error) => {
+				if (stage == .PreFail)
 				{
-					if (loadLibaryError.mPath == "libsystemd.so")
+					if (var loadLibaryError = error as Runtime.LoadSharedLibraryError)
 					{
-						IsSystemdAvailable = false;
-						return .Ignore;
+						if (loadLibaryError.mPath == "libsystemd.so")
+						{
+							IsSystemdAvailable = false;
+							return .Ignore;
+						}
 					}
 				}
-			}
-			return .ContinueFailure;
+				return .ContinueFailure;
+			});
 		}
 	}
 


### PR DESCRIPTION
While trying out the newly merged Linux IDE changes, I noticed the IDE was crashing because of unavailable dynamic libraries even though the `AllowFail` should set the `IsXAvailable` variable to `false` to prevent that. It turns out this was just a static initialization order issue. This PR fixes it in a way that completely avoids future static initialization order issues in these cases.