### PR TITLE
Add -args to BeefBuild help and fix -project flag description

### DIFF
--- a/BeefBuild/src/Program.bf
+++ b/BeefBuild/src/Program.bf
@@ -25,8 +25,9 @@ namespace BeefBuild
 					    -verbosity=<verbosity>  Set verbosity level to: quiet/minimal/normal/detailed/diagnostic
 					    -version                Get version
 					    -workspace=<path>       Sets workspace path (defaults to current working directory)
-					    -project=<name>         Constrain build to a specific project within workspace");
+					    -project=<name>         Constrain build to a specific project within workspace
 					    -define=<name>          Add workspace preprocessor define
+					    -args                   Arguments to pass to the compiled program (must come after -run, all following args are passed through)
 					""");
 				return 0;
 			}


### PR DESCRIPTION
The -args wasn't documented in help and -project looked to have an incorrect attempt close the multi-line text in its description.