### PR TITLE
Filter options for errors panel

### DIFF
--- a/BeefLibs/Beefy2D/src/theme/dark/DarkButton.bf
+++ b/BeefLibs/Beefy2D/src/theme/dark/DarkButton.bf
@@ -11,6 +11,8 @@ namespace Beefy.theme.dark
     {
         public String mLabel ~ delete _;
 		public float mDrawDownPct;
+		public FontAlign mLabelAlign = .Centered;
+		public float mLabelXOfs;
 		public float mLabelYOfs;
 
         [DesignEditable(DefaultEditString=true)]
@@ -79,7 +81,7 @@ namespace Beefy.theme.dark
                 using (g.PushColor(mDisabled ? 0x80FFFFFF : Color.White))
                 {
 					using (g.PushColor(DarkTheme.COLOR_TEXT))
-						DarkTheme.DrawUnderlined(g, mLabel, GS!(2), (mHeight - GS!(20)) / 2 + mLabelYOfs, .Centered, mWidth - GS!(4), .Truncate);
+						DarkTheme.DrawUnderlined(g, mLabel, GS!(2) + mLabelXOfs, (mHeight - GS!(20)) / 2 + mLabelYOfs, mLabelAlign, mWidth - GS!(4) - mLabelXOfs, .Truncate);
                 }
             }
         }

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -7342,6 +7342,8 @@ namespace IDE
 			if ((setFocus) && (sourceViewPanel.mWidgetWindow != null))
 				sourceViewPanel.FocusEdit();
 
+			mErrorsPanel?.OnSourceViewOpened();
+
 			return (sourceViewPanel, newTabButton);
 		}
 
@@ -7655,6 +7657,8 @@ namespace IDE
 					documentTabbedView.GetActiveTab().Activate();
 				}
 			}
+
+			mErrorsPanel?.OnSourceViewClosed();
 
 			//var intDict = scope Dictionary<String, int>();
 

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -81,6 +81,63 @@ namespace IDE.ui
 			}
 		}
 
+		public class ErrorSeverityToggleButton : ToggleButton
+		{
+			private String mNounSingular ~ delete _;
+			private String mNounPlural ~ delete _;
+			public Image mIcon;
+			private int mCount;
+
+			public int Count
+			{
+				get => mCount;
+				set
+				{
+					if (value != mCount)
+					{
+						mCount = value;
+						UpdateLabel();
+					}
+				}
+			}
+
+			public StringView NounSingular
+			{
+				get => mNounSingular;
+				set => String.NewOrSet!(mNounSingular, value);
+			}
+			public StringView NounPlural
+			{
+				get => mNounPlural;
+				set => String.NewOrSet!(mNounPlural, value);
+			}
+
+			public this()
+			{
+				mLabelAlign = .Left;
+			}
+
+			public override void Draw(Graphics g)
+			{
+				if (mIcon != null)
+				{
+					mLabelXOfs = GS!(2) + mIcon.mWidth;
+					base.Draw(g);
+					g.DrawBox(mIcon, GS!(2), GS!(2), mHeight - GS!(4), mHeight - GS!(4));
+				}
+				else
+				{
+					base.Draw(g);
+				}
+			}
+
+			public void UpdateLabel()
+			{
+				var noun = (mCount == 1) ? mNounSingular : mNounPlural;
+				Label = scope $"{mCount} {noun}";
+			}
+		}
+
 		public ErrorsListView mErrorLV;
 
 		public bool mNeedsResolveAll;
@@ -94,6 +151,20 @@ namespace IDE.ui
 
 		public int mErrorCount;
 		public int mWarningCount;
+
+		public ErrorSeverityToggleButton mErrorsToggle;
+		public ErrorSeverityToggleButton mWarningsToggle;
+		
+		public bool ShowErrors
+		{
+			get => mErrorsToggle.mToggled;
+			set => mErrorsToggle.mToggled = value;
+		}
+		public bool ShowWarnings
+		{
+			get => mWarningsToggle.mToggled;
+			set => mWarningsToggle.mToggled = value;
+		}
 
 		public this()
 		{
@@ -126,6 +197,26 @@ namespace IDE.ui
 			//newItem.Label = "Hey";
 
 			AddWidget(mErrorLV);
+
+			mErrorsToggle = new ErrorSeverityToggleButton();
+			mErrorsToggle.mIcon = DarkTheme.sDarkTheme.GetImage(.CodeError);
+			mErrorsToggle.NounSingular = "Error";
+			mErrorsToggle.NounPlural = "Errors";
+			mErrorsToggle.mToggled = true;
+			mErrorsToggle.HoverText = "Toggle visibility of errors";
+			mErrorsToggle.mOnMouseDown.Add(new (evt) => { InvalidateErrorList(); });
+			mErrorsToggle.UpdateLabel();
+			AddWidget(mErrorsToggle);
+
+			mWarningsToggle = new ErrorSeverityToggleButton();
+			mWarningsToggle.mIcon = DarkTheme.sDarkTheme.GetImage(.CodeWarning);
+			mWarningsToggle.NounSingular = "Warning";
+			mWarningsToggle.NounPlural = "Warnings";
+			mWarningsToggle.mToggled = true;
+			mWarningsToggle.HoverText = "Toggle visibility of warnings";
+			mWarningsToggle.mOnMouseDown.Add(new (evt) => { InvalidateErrorList(); });
+			mWarningsToggle.UpdateLabel();
+			AddWidget(mWarningsToggle);
 		}
 
 		public ~this()
@@ -138,12 +229,38 @@ namespace IDE.ui
 		    base.Serialize(data);
 
 		    data.Add("Type", "ErrorsPanel");
+
+			data.Add("ShowErrors", ShowErrors);
+			data.Add("ShowWarnings", ShowWarnings);
+		}
+
+		public override bool Deserialize(StructuredData data)
+		{
+		    base.Deserialize(data);
+
+			ShowErrors = data.GetBool("ShowErrors", true);
+			ShowWarnings = data.GetBool("ShowWarnings", true);
+
+			return true;
 		}
 
 		public override void Resize(float x, float y, float width, float height)
 		{
 			base.Resize(x, y, width, height);
-			mErrorLV.Resize(0, 0, width, height);
+
+			float toolbarHeight = GS!(28);
+			float btnY = GS!(2);
+			float btnH = toolbarHeight - GS!(4);
+			float btnX = GS!(4);
+
+			float errW = GS!(96);
+			float warnW = GS!(112);
+
+			mErrorsToggle.Resize(btnX, btnY, errW, btnH);
+			btnX += errW + GS!(4);
+			mWarningsToggle.Resize(btnX, btnY, warnW, btnH);
+
+			mErrorLV.Resize(0, toolbarHeight, width, Math.Max(height - toolbarHeight, 0));
 		}
 
 		public enum ResolveKind
@@ -226,6 +343,14 @@ namespace IDE.ui
 				}
 			}
 		}
+		
+		void InvalidateErrorList()
+		{
+			mErrorListId = -1;
+			// Force rebuild of error list so filter changes take effect immediately,
+			// even while the compiler is busy (which keeps mDirtyTicks > 0).
+			ProcessErrors();
+		}
 
 		public void ClearParserErrors(String filePath)
 		{
@@ -289,6 +414,9 @@ namespace IDE.ui
 					int idx = 0;
 					void HandleError(BfPassInstance.BfError error)
 					{
+						if (error.mIsWarning ? !ShowWarnings : !ShowErrors)
+							return;
+
 						ErrorsListViewItem item;
 
 						bool changed = false;
@@ -404,7 +532,10 @@ namespace IDE.ui
 		public override void Update()
 		{
 			base.Update();
-			
+
+			mErrorsToggle.Count = mErrorCount;
+			mWarningsToggle.Count = mWarningCount;
+
 			if (!mVisible)
 			{
 				// Very dirty

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -1037,6 +1037,12 @@ namespace IDE.ui
 			base.DrawAll(g);
 
 			g.Draw(DarkTheme.sDarkTheme.GetImage(.Search), mSearchEdit.mX + GS!(2), mSearchEdit.mY + GS!(1));
+
+			if (mDirtyTicks != 0)
+			{
+            	var image = DarkTheme.sDarkTheme.GetImage(DarkTheme.ImageIdx.WaitSegment);
+				IDEUtils.DrawWait(g, mWidth - image.mWidth/2, mHeight - image.mHeight/2, mDirtyTicks);
+			}
 		}
 	}
 }

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -203,7 +203,7 @@ namespace IDE.ui
 		public ErrorSeverityToggleButton mErrorsToggle;
 		public ErrorSeverityToggleButton mWarningsToggle;
 		public DarkComboBox mScopeFilterCombo;
-		public DarkComboBox mSearchTextCombo;
+		public SearchEditWidget mSearchEdit;
 		
 		public bool ShowErrors
 		{
@@ -273,13 +273,12 @@ namespace IDE.ui
 			mWarningsToggle.UpdateLabel();
 			AddWidget(mWarningsToggle);
 
-			mSearchTextCombo = new DarkComboBox();
-			mSearchTextCombo.MakeEditable();
-			mSearchTextCombo.mEditWidget.mOnContentChanged.Add(new (evt) =>
+			mSearchEdit = new SearchEditWidget();
+			mSearchEdit.mOnContentChanged.Add(new (evt) =>
 				{
 					InvalidateErrorList();
 				});
-			AddWidget(mSearchTextCombo);
+			AddWidget(mSearchEdit);
 		}
 
 		void PopulateLocationMenu(Menu menu)
@@ -348,7 +347,8 @@ namespace IDE.ui
 			float searchMinWidth = GS!(100);
 			float searchWantWidth = GS!(250);
 			float searchWidth = Math.Clamp(mWidth - curX - GS!(4), searchMinWidth, searchWantWidth);
-			mSearchTextCombo.Resize(mWidth - searchWidth, btnY, searchWidth - GS!(4), btnH);
+			float searchWidth = Math.Clamp(mWidth - curX, searchMinWidth, searchWantWidth);
+			mSearchEdit.Resize(mWidth - searchWidth, btnY, searchWidth - GS!(4), btnH);
 
 			return toolbarHeight;
 		}
@@ -562,13 +562,19 @@ namespace IDE.ui
 								}
 							});
 					}
+					
+					String searchStr = scope String();
+					if (mSearchEdit != null)
+					{
+						mSearchEdit.GetText(searchStr);
+					}
 
-					if (!mSearchTextCombo.Label.IsEmpty)
+					if (!searchStr.IsEmpty)
 					{
 						hasTextFilter = true;
 						hasFilter = true;
 						
-						textFilter = mSearchTextCombo.Label;
+						textFilter = searchStr;
 					}
 
 					if (hasFilter)
@@ -859,6 +865,13 @@ namespace IDE.ui
 			let lvItem = (ErrorsListViewItem)root.GetChildAtIndex(0);
 			lvItem.Focused = true;
 			lvItem.Goto();
+		}
+
+		public override void DrawAll(Graphics g)
+		{
+			base.DrawAll(g);
+
+			g.Draw(DarkTheme.sDarkTheme.GetImage(.Search), mSearchEdit.mX + GS!(2), mSearchEdit.mY + GS!(1));
 		}
 	}
 }

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -20,16 +20,124 @@ namespace IDE.ui
 
 		public class ErrorsListView : IDEListView
 		{
+			public enum SortOrder
+			{
+				None,
+				Forward,
+				Reverse
+			}
+
+			public struct SortKey
+			{
+				public int mColumn;
+				public SortOrder mOrder;
+
+				public this()
+				{
+					mColumn = -1;
+					mOrder = .None;
+				}
+
+				public this(int column, SortOrder order)
+				{
+					mColumn = column;
+					mOrder = order;
+				}
+			}
+			
+			public List<SortKey> mDefaultSortKeys = new .() ~ delete _;
+			public List<SortKey> mSortKeys = new .() ~ delete _;
+
+			public List<SortKey> SortKeysOrDefault
+			{
+				get
+				{
+					if (mSortKeys.Count > 0 && mSortKeys.FindIndex(scope (s) => s.mOrder != .None) != -1)
+					{
+						return mSortKeys;
+					}
+					else
+					{
+						// If we have no user set keys (or all keys are unordered) we return the default list
+						return mDefaultSortKeys;
+					}
+				}
+			}
+
 			protected override ListViewItem CreateListViewItem()
 			{
 				return new ErrorsListViewItem();
 			}
-
-			public override void ChangeSort(DarkListView.SortType sortType)
+			
+			public override void MouseDown(float x, float y, int32 btn, int32 btnCount)
 			{
-				base.ChangeSort(sortType);
-				mSortType = sortType;
-				gApp.mErrorsPanel.InvalidateErrorList();
+			    base.MouseDown(x, y, btn, btnCount);
+
+			    let (column, isSplitter) = GetColumnAt(x, y);
+				if ((column != -1) && (!isSplitter))
+				{
+					int sortKeyIdx = mSortKeys.FindIndex(scope (s) => s.mColumn == column);
+
+					SortKey sortKey = .(column, SortOrder.Forward);
+
+					if (sortKeyIdx != -1)
+					{
+						sortKey = mSortKeys[sortKeyIdx];
+
+						// Cycle through the sort orders.
+						if (sortKey.mOrder == .None)
+							sortKey.mOrder = .Forward;
+						else if (sortKey.mOrder == .Forward)
+							sortKey.mOrder = .Reverse;
+						else if (sortKey.mOrder == .Reverse)
+							sortKey.mOrder = .None;
+					}
+
+					if (mWidgetWindow.IsKeyDown(.Shift))
+					{
+						if (sortKeyIdx != -1)
+							mSortKeys[sortKeyIdx] = sortKey;
+						else
+							mSortKeys.Add(sortKey);
+					}
+					else
+					{
+						// Make the clicked column the only sorted one
+						mSortKeys.Clear();
+
+						// If no order is specified, we leave it empty so we can fall back to the default order
+						if (sortKey.mOrder != .None)
+							mSortKeys.Add(sortKey);
+					}
+
+					gApp.mErrorsPanel.InvalidateErrorList();
+				}
+			}
+
+			public override void DrawColumn(Graphics g, int32 columnIdx)
+			{
+				base.DrawColumn(g, columnIdx);
+				
+				// We don't set mSortType, so base doesn't draw any sort arrows. We do that ourselves here.
+				var column = mColumns[columnIdx];
+				float sortArrowX = g.mFont.GetWidth(column.mLabel) + DarkTheme.sUnitSize/2;
+
+				int sortKeyIdx = mSortKeys.FindIndex(scope (s) => s.mColumn == columnIdx);
+
+				if (sortKeyIdx != -1)
+				{
+					SortKey sortKey = mSortKeys[sortKeyIdx];
+
+					if (sortKey.mOrder == .Reverse)
+					{
+						using (g.PushScale(1.0f, -1.0f, column.mWidth - DarkTheme.sUnitSize, DarkTheme.sUnitSize/2))
+							g.Draw(DarkTheme.sDarkTheme.GetImage(.ListViewSortArrow), sortArrowX, 0);
+					}
+					else if (sortKey.mOrder == .Forward)
+					{
+						g.Draw(DarkTheme.sDarkTheme.GetImage(.ListViewSortArrow), sortArrowX, 0);
+					}
+				}
 			}
 		}
 
@@ -226,11 +334,8 @@ namespace IDE.ui
 		public this()
 		{
 			mErrorLV = new .();
-			//mErrorLV.mPanel = this;
-			//mErrorLV.SetShowHeader(false);
 			mErrorLV.InitScrollbars(true, true);
 			mErrorLV.mLabelX = GS!(6);
-			//mErrorLV.mOnItemMouseDown.Add(new => ItemMouseDown);
 			mErrorLV.mOnItemMouseClicked.Add(new => ListViewItemMouseClicked);
 			mErrorLV.mOnKeyDown.Add(new => ListViewKeyDown_ShowMenu);
 			mErrorLV.AddColumn(100, "Code");
@@ -250,8 +355,10 @@ namespace IDE.ui
 
 					//mErrorLV.GetRoot().SelectItemExclusively()
 				});
-			//let newItem = mErrorLV.GetRoot().CreateChildItem();
-			//newItem.Label = "Hey";
+			// Sort Project -> File -> Line by default
+			mErrorLV.mDefaultSortKeys.Add(.(2, .Forward));
+			mErrorLV.mDefaultSortKeys.Add(.(3, .Forward));
+			mErrorLV.mDefaultSortKeys.Add(.(4, .Forward));
 
 			AddWidget(mErrorLV);
 
@@ -761,23 +868,15 @@ namespace IDE.ui
 								mFilteredErrorCount += 1;
 						}
 					}
+					
+					List<BfPassInstance.BfError> sortedErrors = new:ScopedAlloc! .(mResolveErrors);
 
-					if (!mParseErrors.IsEmpty)
+					for (var errors in mParseErrors.Values)
 					{
-						List<String> paths = scope .();
-						for (var path in mParseErrors.Keys)
-							paths.Add(path);
-						paths.Sort();
-
-						for (var path in paths)
-						{
-							for (var error in mParseErrors[path])
-								HandleError(error);
-						}
+						sortedErrors.AddRange(errors);
 					}
 
-					List<BfPassInstance.BfError> sortedErrors = new:ScopedAlloc! .(mResolveErrors);
-					sortedErrors.Sort((a, b) => SortErrorEntries(mErrorLV, a, b));
+					sortedErrors.Sort((lhs, rhs) => SortErrorEntries(lhs, rhs, mErrorLV.SortKeysOrDefault));
 					
 					for (let error in sortedErrors)
 						HandleError(error);
@@ -791,56 +890,61 @@ namespace IDE.ui
 			}
 		}
 
-		private static int SortErrorEntries(ErrorsListView mErrorLV, BfPassInstance.BfError a, BfPassInstance.BfError b)
+		private static int SortErrorEntries(BfPassInstance.BfError lhs, BfPassInstance.BfError rhs, List<ErrorsListView.SortKey> sortKeys)
 		{
-			int order = 0;
+			for (var sortKey in sortKeys)
+			{
+				int order = 0;
 
-			if (mErrorLV.mSortType.mColumn == 0)
-			{
-				// Sort by Error/Warning-Code
-			   	// Column contains Error/Warning + Number
-			   	if (a.mIsWarning != b.mIsWarning)
-			   	{
-					// Sort Error and Warning alphabetically
-				   	order = a.mIsWarning ? 1 : -1;
-			   	}
-			   	else
-			   	{
-					// If both are an error or both are a warning -> sort by code.
-					order = a.mCode <=> b.mCode;
-			   	}
-			}
-			if (mErrorLV.mSortType.mColumn == 1)
-			{
-				// Sort by description
-				order = a.mError <=> b.mError;
-			}
-			if (mErrorLV.mSortType.mColumn == 2)
-			{
-				// Sort by project name
-				order = a.mProject <=> b.mProject;
-			}
-			if (mErrorLV.mSortType.mColumn == 3)
-			{
-				// Sort by file name
-				// TODO: we call GetFileName like a bazillion times -> maybe prepare when the error-entry is created
-				let fileNameA = scope String(128);
-				let fileNameB = scope String(128);
-				Path.GetFileName(a.mFilePath, fileNameA);
-				Path.GetFileName(b.mFilePath, fileNameB);
+				// Nothing to do for this column
+				if (sortKey.mOrder == .None)
+					continue;
 
-				order = fileNameA <=> fileNameB;
-			}
-			if (mErrorLV.mSortType.mColumn == 4)
-			{
-				// Sort by line
-				order = a.mLine <=> b.mLine;
+				switch (sortKey.mColumn)
+				{
+				case 0:
+					// Sort by Error/Warning-Code
+					// Column contains Error/Warning + Number
+					if (lhs.mIsWarning != rhs.mIsWarning)
+					{
+						// Sort Error and Warning alphabetically
+						order = lhs.mIsWarning ? 1 : -1;
+					}
+					else
+					{
+						// If both are an error or both are a warning -> sort by code.
+						order = lhs.mCode <=> rhs.mCode;
+					}
+				case 1:
+					// Sort by description
+					order = (lhs.mError ?? "") <=> (rhs.mError ?? "");
+				case 2:
+					// Sort by project name
+					order = (lhs.mProject ?? "") <=> (rhs.mProject ?? "");
+				case 3:
+					// Sort by file name
+					// TODO: we call GetFileName like a bazillion times -> maybe prepare when the error-entry is created
+					let fileNameLhs = scope String(128);
+					let fileNameRhs = scope String(128);
+					Path.GetFileName(lhs.mFilePath, fileNameLhs);
+					Path.GetFileName(rhs.mFilePath, fileNameRhs);
+
+					order = fileNameLhs <=> fileNameRhs;
+				case 4:
+					// Sort by line
+					order = lhs.mLine <=> rhs.mLine;
+				}
+
+				if (order != 0)
+				{
+					if (sortKey.mOrder == .Reverse)
+						return -order;
+					else
+						return order;
+				}
 			}
 
-			if (mErrorLV.mSortType.mReverse)
-				return -order;
-			else
-				return order;
+			return 0;
 		}
 
 		public void UpdateAlways()

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -12,6 +12,12 @@ namespace IDE.ui
 {
 	class ErrorsPanel : Panel
 	{
+        public static String sCurrentDocument = "Current File";
+        public static String sOpenDocuments = "Open Files";
+		public static String sCurrentProject = "Current Project";
+        public static String sEntireSolution = "Entire Solution";
+		public static String[] sLocationStrings = new .(sEntireSolution, sCurrentDocument, sOpenDocuments, sCurrentProject) ~ delete _;
+
 		public class ErrorsListView : IDEListView
 		{
 			protected override ListViewItem CreateListViewItem()
@@ -86,16 +92,30 @@ namespace IDE.ui
 			private String mNounSingular ~ delete _;
 			private String mNounPlural ~ delete _;
 			public Image mIcon;
-			private int mCount;
-
-			public int Count
+			private int? mFilteredCount;
+			private int mTotalCount;
+			
+			public int? FilteredCount
 			{
-				get => mCount;
+				get => mFilteredCount;
 				set
 				{
-					if (value != mCount)
+					if (value != mFilteredCount)
 					{
-						mCount = value;
+						mFilteredCount = value;
+						UpdateLabel();
+					}
+				}
+			}
+
+			public int TotalCount
+			{
+				get => mTotalCount;
+				set
+				{
+					if (value != mTotalCount)
+					{
+						mTotalCount = value;
 						UpdateLabel();
 					}
 				}
@@ -133,8 +153,17 @@ namespace IDE.ui
 
 			public void UpdateLabel()
 			{
-				var noun = (mCount == 1) ? mNounSingular : mNounPlural;
-				Label = scope $"{mCount} {noun}";
+				var noun = (mTotalCount == 1) ? mNounSingular : mNounPlural;
+
+				if (mFilteredCount.HasValue)
+				{
+					Label = scope $"{mFilteredCount.Value} of {mTotalCount} {noun}";
+				}
+				else
+				{
+					Label = scope $"{mTotalCount} {noun}";
+				}
+
 			}
 
 			public float CalcWidth()
@@ -143,7 +172,7 @@ namespace IDE.ui
 
 				if (mIcon != null)
 				{
-					w += GS!(2) + mLabelXOfs;
+					w += GS!(2) + mIcon.mWidth;
 				}
 
 				var font = DarkTheme.sDarkTheme.mSmallFont;
@@ -168,9 +197,12 @@ namespace IDE.ui
 
 		public int mErrorCount;
 		public int mWarningCount;
+		public int? mFilteredErrorCount = null;
+		public int? mFilteredWarningCount = null;
 
 		public ErrorSeverityToggleButton mErrorsToggle;
 		public ErrorSeverityToggleButton mWarningsToggle;
+		public DarkComboBox mScopeFilterCombo;
 		
 		public bool ShowErrors
 		{
@@ -215,6 +247,11 @@ namespace IDE.ui
 
 			AddWidget(mErrorLV);
 
+			mScopeFilterCombo = new DarkComboBox();
+			mScopeFilterCombo.Label = sEntireSolution;
+			mScopeFilterCombo.mPopulateMenuAction.Add(new => PopulateLocationMenu);
+			AddWidget(mScopeFilterCombo);
+
 			mErrorsToggle = new ErrorSeverityToggleButton();
 			mErrorsToggle.mIcon = DarkTheme.sDarkTheme.GetImage(.CodeError);
 			mErrorsToggle.NounSingular = "Error";
@@ -236,6 +273,19 @@ namespace IDE.ui
 			AddWidget(mWarningsToggle);
 		}
 
+		void PopulateLocationMenu(Menu menu)
+		{
+			for (var str in sLocationStrings)
+			{
+				var item = menu.AddItem(str);
+				item.mOnMenuItemSelected.Add(new (dlg) =>
+				{
+					mScopeFilterCombo.Label = str;
+					InvalidateErrorList();
+				});
+			}
+		}
+
 		public ~this()
 		{
 			ClearParserErrors(null);
@@ -249,6 +299,7 @@ namespace IDE.ui
 
 			data.Add("ShowErrors", ShowErrors);
 			data.Add("ShowWarnings", ShowWarnings);
+			data.Add("Scope", mScopeFilterCombo.Label);
 		}
 
 		public override bool Deserialize(StructuredData data)
@@ -257,6 +308,11 @@ namespace IDE.ui
 
 			ShowErrors = data.GetBool("ShowErrors", true);
 			ShowWarnings = data.GetBool("ShowWarnings", true);
+
+			String scopeLabel = scope .();
+			data.GetString("Scope", scopeLabel);
+			if (sLocationStrings.Contains(scopeLabel))
+				mScopeFilterCombo.Label = scopeLabel;
 
 			return true;
 		}
@@ -267,6 +323,10 @@ namespace IDE.ui
 			float btnY = GS!(2);
 			float btnH = toolbarHeight - GS!(4);
 			float btnX = GS!(4);
+
+			float comboW = GS!(120);
+			mScopeFilterCombo.Resize(btnX, btnY, comboW, btnH);
+			btnX += comboW + GS!(4);
 
 			float errW = mErrorsToggle.CalcWidth();
 			mErrorsToggle.Resize(btnX, btnY, errW, btnH);
@@ -365,13 +425,31 @@ namespace IDE.ui
 				}
 			}
 		}
-		
+
+		/// Invalidates the error list and forces a rebuild,
+		/// so filter changes can take effect immediately in the next update,
+		/// even while the compiler is busy (which keeps mDirtyTicks > 0).
 		void InvalidateErrorList()
 		{
 			mErrorListId = -1;
-			// Force rebuild of error list so filter changes take effect immediately,
-			// even while the compiler is busy (which keeps mDirtyTicks > 0).
-			ProcessErrors();
+		}
+
+		public void OnActiveSourceViewChanged()
+		{
+			if (mScopeFilterCombo.Label != sEntireSolution)
+				InvalidateErrorList();
+		}
+
+		public void OnSourceViewClosed()
+		{
+			if (mScopeFilterCombo.Label == sOpenDocuments || mScopeFilterCombo.Label == sCurrentDocument)
+				InvalidateErrorList();
+		}
+
+		public void OnSourceViewOpened()
+		{
+			if (mScopeFilterCombo.Label == sOpenDocuments || mScopeFilterCombo.Label == sCurrentDocument)
+				InvalidateErrorList();
 		}
 
 		public void ClearParserErrors(String filePath)
@@ -433,11 +511,81 @@ namespace IDE.ui
 				{
 					let root = mErrorLV.GetRoot();
 
+					String activeProjectName = null;
+					List<String> openFilePaths = scope .();
+					bool hasPathFilter = false;
+					bool hasProjectFilter = false;
+					bool hasFilter = false;
+
+					switch (mScopeFilterCombo.Label)
+					{
+					case sEntireSolution:
+						// Nothing to do.
+					case sCurrentDocument:
+						hasFilter = true;
+						hasPathFilter = true;
+						var svp = gApp.GetActiveSourceViewPanel(true);
+						if (svp?.mFilePath != null)
+						{
+							openFilePaths.Add(svp.mFilePath);
+						}
+					case sCurrentProject:
+						hasFilter = true;
+						hasProjectFilter = true;
+						var svp = gApp.GetActiveSourceViewPanel(true);
+						activeProjectName = svp?.mProjectSource?.mProject?.mProjectName;
+					case sOpenDocuments:
+						hasFilter = true;
+						hasPathFilter = true;
+						gApp.WithSourceViewPanels(scope (svp) =>
+							{
+								if (svp.mFilePath != null)
+								{
+									openFilePaths.Add(svp.mFilePath);
+								}
+							});
+					}
+
+					if (hasFilter)
+					{
+						mFilteredErrorCount = 0;
+						mFilteredWarningCount = 0;
+					}
+					else
+					{
+						mFilteredErrorCount = null;
+						mFilteredWarningCount = null;
+					}
+
 					int idx = 0;
 					void HandleError(BfPassInstance.BfError error)
 					{
 						if (error.mIsWarning ? !ShowWarnings : !ShowErrors)
 							return;
+
+						if (hasProjectFilter
+							&& ((activeProjectName == null) || (error.mProject != activeProjectName)))
+						{
+							return;
+						}
+
+						if (hasPathFilter)
+						{
+							if (error.mFilePath == null)
+								return;
+
+							bool matched = false;
+							for (String openFilePath in openFilePaths)
+							{
+								if (Path.Equals(error.mFilePath, openFilePath))
+								{
+									matched = true;
+									break;
+								}
+							}
+							if (!matched)
+								return;
+						}
 
 						ErrorsListViewItem item;
 
@@ -506,6 +654,14 @@ namespace IDE.ui
 							item.Focused = false;
 
 						idx++;
+
+						if (hasFilter)
+						{
+							if (error.mIsWarning)
+								mFilteredWarningCount += 1;
+							else
+								mFilteredErrorCount += 1;
+						}
 					}
 
 					if (!mParseErrors.IsEmpty)
@@ -555,10 +711,13 @@ namespace IDE.ui
 		{
 			base.Update();
 
-			if ((mErrorsToggle.Count != mErrorCount) || (mWarningsToggle.Count != mWarningCount))
+			if ((mErrorsToggle.TotalCount != mErrorCount) || (mErrorsToggle.FilteredCount != mFilteredErrorCount)
+				 || (mWarningsToggle.TotalCount != mWarningCount) || (mWarningsToggle.FilteredCount != mFilteredWarningCount))
 			{
-				mErrorsToggle.Count = mErrorCount;
-				mWarningsToggle.Count = mWarningCount;
+				mErrorsToggle.TotalCount = mErrorCount;
+				mErrorsToggle.FilteredCount = mFilteredErrorCount;
+				mWarningsToggle.TotalCount = mWarningCount;
+				mWarningsToggle.FilteredCount = mFilteredWarningCount;
 				LayoutToolbar();
 			}
 
@@ -576,7 +735,8 @@ namespace IDE.ui
 			else
 				mDirtyTicks++;
 
-			if(mDirtyTicks==0)
+			// mErrorListId = -1 -> force processing
+			if (mErrorListId == -1 || mDirtyTicks == 0)
 				ProcessErrors();
 		}
 		

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -327,13 +327,13 @@ namespace IDE.ui
 
 		private float LayoutToolbar()
 		{
-			float toolbarHeight = GS!(28);
+			float toolbarHeight = GS!(26);
 			float btnY = GS!(2);
 			float btnH = toolbarHeight - GS!(4);
 			float curX = GS!(4);
 
 			float scopeSelectW = GS!(120);
-			mScopeFilterCombo.Resize(curX, btnY, scopeSelectW, btnH);
+			mScopeFilterCombo.Resize(curX, btnY + GS!(2), scopeSelectW, btnH);
 			curX += scopeSelectW + GS!(4);
 
 			float errW = mErrorsToggle.CalcWidth();
@@ -342,11 +342,10 @@ namespace IDE.ui
 
 			float warnW = mWarningsToggle.CalcWidth();
 			mWarningsToggle.Resize(curX, btnY, warnW, btnH);
-			curX += warnW;
+			curX += warnW + GS!(4);
 
 			float searchMinWidth = GS!(100);
 			float searchWantWidth = GS!(250);
-			float searchWidth = Math.Clamp(mWidth - curX - GS!(4), searchMinWidth, searchWantWidth);
 			float searchWidth = Math.Clamp(mWidth - curX, searchMinWidth, searchWantWidth);
 			mSearchEdit.Resize(mWidth - searchWidth, btnY, searchWidth - GS!(4), btnH);
 

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -203,6 +203,7 @@ namespace IDE.ui
 		public ErrorSeverityToggleButton mErrorsToggle;
 		public ErrorSeverityToggleButton mWarningsToggle;
 		public DarkComboBox mScopeFilterCombo;
+		public DarkComboBox mSearchTextCombo;
 		
 		public bool ShowErrors
 		{
@@ -271,6 +272,14 @@ namespace IDE.ui
 			mWarningsToggle.mOnMouseDown.Add(new (evt) => { InvalidateErrorList(); });
 			mWarningsToggle.UpdateLabel();
 			AddWidget(mWarningsToggle);
+
+			mSearchTextCombo = new DarkComboBox();
+			mSearchTextCombo.MakeEditable();
+			mSearchTextCombo.mEditWidget.mOnContentChanged.Add(new (evt) =>
+				{
+					InvalidateErrorList();
+				});
+			AddWidget(mSearchTextCombo);
 		}
 
 		void PopulateLocationMenu(Menu menu)
@@ -322,18 +331,24 @@ namespace IDE.ui
 			float toolbarHeight = GS!(28);
 			float btnY = GS!(2);
 			float btnH = toolbarHeight - GS!(4);
-			float btnX = GS!(4);
+			float curX = GS!(4);
 
-			float comboW = GS!(120);
-			mScopeFilterCombo.Resize(btnX, btnY, comboW, btnH);
-			btnX += comboW + GS!(4);
+			float scopeSelectW = GS!(120);
+			mScopeFilterCombo.Resize(curX, btnY, scopeSelectW, btnH);
+			curX += scopeSelectW + GS!(4);
 
 			float errW = mErrorsToggle.CalcWidth();
-			mErrorsToggle.Resize(btnX, btnY, errW, btnH);
-			btnX += errW + GS!(4);
+			mErrorsToggle.Resize(curX, btnY, errW, btnH);
+			curX += errW + GS!(4);
 
 			float warnW = mWarningsToggle.CalcWidth();
-			mWarningsToggle.Resize(btnX, btnY, warnW, btnH);
+			mWarningsToggle.Resize(curX, btnY, warnW, btnH);
+			curX += warnW;
+
+			float searchMinWidth = GS!(100);
+			float searchWantWidth = GS!(250);
+			float searchWidth = Math.Clamp(mWidth - curX - GS!(4), searchMinWidth, searchWantWidth);
+			mSearchTextCombo.Resize(mWidth - searchWidth, btnY, searchWidth - GS!(4), btnH);
 
 			return toolbarHeight;
 		}
@@ -511,11 +526,13 @@ namespace IDE.ui
 				{
 					let root = mErrorLV.GetRoot();
 
+					StringView textFilter = null;
 					String activeProjectName = null;
 					List<String> openFilePaths = scope .();
 					bool hasPathFilter = false;
 					bool hasProjectFilter = false;
 					bool hasFilter = false;
+					bool hasTextFilter = false;
 
 					switch (mScopeFilterCombo.Label)
 					{
@@ -544,6 +561,14 @@ namespace IDE.ui
 									openFilePaths.Add(svp.mFilePath);
 								}
 							});
+					}
+
+					if (!mSearchTextCombo.Label.IsEmpty)
+					{
+						hasTextFilter = true;
+						hasFilter = true;
+						
+						textFilter = mSearchTextCombo.Label;
 					}
 
 					if (hasFilter)
@@ -587,6 +612,67 @@ namespace IDE.ui
 								return;
 						}
 
+						int codeDigitStartIdx = int32.MaxValue;
+						String codeStr = scope String(32);
+						char8[5] codeColorRaw = Font.EncodeColor(error.mIsWarning ? 0xFFFFFF80 : 0xFFFF8080);
+						StringView encodedCodeColor = StringView(&codeColorRaw, codeColorRaw.Count);
+						codeStr.AppendF(error.mIsWarning ? "{}Warning" : "{}Error", encodedCodeColor);
+						if (error.mCode != 0)
+						{
+							// + 1: we add a space before code
+							codeDigitStartIdx = codeStr.Length + 1;
+							codeStr.AppendF(" {}", error.mCode);
+						}
+						codeStr.AppendF("{}", Font.EncodePopColor());
+
+						// Copy project name to allow marking the matched filter.
+						let projectName = error.mProject == null ? null : scope String(error.mProject);
+
+						let fileName = scope String(128);
+						Path.GetFileName(error.mFilePath, fileName);
+						
+						char8[5] matchColorRaw = Font.EncodeColor(DarkTheme.COLOR_MENU_FOCUSED);
+						StringView encodedMatchColor = StringView(&matchColorRaw, matchColorRaw.Count);
+
+						int errorDescMatchIdx = -1;
+
+						if (hasTextFilter)
+						{
+							errorDescMatchIdx = error.mError.IndexOf(textFilter, true);
+							int fileNameIdx = fileName.IndexOf(textFilter, true);
+							int projectNameIdx = projectName?.IndexOf(textFilter, true) ?? -1;
+							int codeMatchIdx = codeStr.IndexOf(textFilter, codeDigitStartIdx);
+
+							if (errorDescMatchIdx == -1 &&
+								fileNameIdx == -1 &&
+								projectNameIdx == -1 &&
+								codeMatchIdx == -1)
+							{
+								return;
+							}
+							
+							// Mark the matched text
+
+							if (fileNameIdx != -1)
+							{
+								fileName.Insert(fileNameIdx + textFilter.Length, Font.EncodePopColor());
+								fileName.Insert(fileNameIdx, encodedMatchColor);
+							}
+							if (projectNameIdx != -1)
+							{
+								projectName.Insert(projectNameIdx + textFilter.Length, Font.EncodePopColor());
+								projectName.Insert(projectNameIdx, encodedMatchColor);
+							}
+							if (codeMatchIdx != -1)
+							{
+								// If we don't match the digits until the end, reapply color for code
+								if (codeMatchIdx + textFilter.Length < codeStr.Length - 1)
+									codeStr.Insert(codeMatchIdx + textFilter.Length, encodedCodeColor);
+
+								codeStr.Insert(codeMatchIdx, encodedMatchColor);
+							}
+						}
+
 						ErrorsListViewItem item;
 
 						bool changed = false;
@@ -616,11 +702,6 @@ namespace IDE.ui
 						item.mLine = error.mLine;
 						item.mColumn = error.mColumn;
 
-						String codeStr = scope String(32);
-						codeStr.AppendF(error.mIsWarning ? "{}Warning" : "{}Error", Font.EncodeColor(error.mIsWarning ? 0xFFFFFF80 : 0xFFFF8080));
-						if (error.mCode != 0)
-							codeStr.AppendF(" {}", error.mCode);
-						codeStr.AppendF("{}", Font.EncodePopColor());
 						SetLabel(item, codeStr);
 
 						let descItem = item.GetSubItem(1);
@@ -635,14 +716,19 @@ namespace IDE.ui
 							errStr.Append(error.mError);
 						errStr.Replace('\n', ' ');
 
+						// Mark the matched text in the error description.
+						if (errorDescMatchIdx != -1 && errorDescMatchIdx < errStr.Length)
+						{
+							errStr.Insert(Math.Min(errorDescMatchIdx + textFilter.Length, errStr.Length), Font.EncodePopColor());
+							errStr.Insert(errorDescMatchIdx, encodedMatchColor);
+						}
+
 						SetLabel(descItem, errStr);
 
 						let projectItem = item.GetSubItem(2);
-						SetLabel(projectItem, error.mProject);
+						SetLabel(projectItem, projectName);
 
 						let fileNameItem = item.GetSubItem(3);
-						let fileName = scope String(128);
-						Path.GetFileName(error.mFilePath, fileName);
 						SetLabel(fileNameItem, fileName);
 						let lineNumberItem = item.GetSubItem(4);
 						if (error.mLine != -1)
@@ -719,6 +805,7 @@ namespace IDE.ui
 				mWarningsToggle.TotalCount = mWarningCount;
 				mWarningsToggle.FilteredCount = mFilteredWarningCount;
 				LayoutToolbar();
+				MarkDirty();
 			}
 
 			if (!mVisible)

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -123,7 +123,7 @@ namespace IDE.ui
 				{
 					mLabelXOfs = GS!(2) + mIcon.mWidth;
 					base.Draw(g);
-					g.DrawBox(mIcon, GS!(2), GS!(2), mHeight - GS!(4), mHeight - GS!(4));
+					g.Draw(mIcon, GS!(2), (mHeight - mIcon.mHeight) / 2);
 				}
 				else
 				{
@@ -135,6 +135,23 @@ namespace IDE.ui
 			{
 				var noun = (mCount == 1) ? mNounSingular : mNounPlural;
 				Label = scope $"{mCount} {noun}";
+			}
+
+			public float CalcWidth()
+			{
+				float w = GS!(2);
+
+				if (mIcon != null)
+				{
+					w += GS!(2) + mLabelXOfs;
+				}
+
+				var font = DarkTheme.sDarkTheme.mSmallFont;
+				if (mLabel != null)
+					w += font.GetWidth(mLabel);
+
+				w += GS!(6);
+				return w;
 			}
 		}
 
@@ -244,22 +261,27 @@ namespace IDE.ui
 			return true;
 		}
 
-		public override void Resize(float x, float y, float width, float height)
+		private float LayoutToolbar()
 		{
-			base.Resize(x, y, width, height);
-
 			float toolbarHeight = GS!(28);
 			float btnY = GS!(2);
 			float btnH = toolbarHeight - GS!(4);
 			float btnX = GS!(4);
 
-			float errW = GS!(96);
-			float warnW = GS!(112);
-
+			float errW = mErrorsToggle.CalcWidth();
 			mErrorsToggle.Resize(btnX, btnY, errW, btnH);
 			btnX += errW + GS!(4);
+
+			float warnW = mWarningsToggle.CalcWidth();
 			mWarningsToggle.Resize(btnX, btnY, warnW, btnH);
 
+			return toolbarHeight;
+		}
+
+		public override void Resize(float x, float y, float width, float height)
+		{
+			base.Resize(x, y, width, height);
+			float toolbarHeight = LayoutToolbar();
 			mErrorLV.Resize(0, toolbarHeight, width, Math.Max(height - toolbarHeight, 0));
 		}
 
@@ -533,8 +555,12 @@ namespace IDE.ui
 		{
 			base.Update();
 
-			mErrorsToggle.Count = mErrorCount;
-			mWarningsToggle.Count = mWarningCount;
+			if ((mErrorsToggle.Count != mErrorCount) || (mWarningsToggle.Count != mWarningCount))
+			{
+				mErrorsToggle.Count = mErrorCount;
+				mWarningsToggle.Count = mWarningCount;
+				LayoutToolbar();
+			}
 
 			if (!mVisible)
 			{

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -15,7 +15,7 @@ namespace IDE.ui
         public static String sCurrentDocument = "Current File";
         public static String sOpenDocuments = "Open Files";
 		public static String sCurrentProject = "Current Project";
-        public static String sEntireSolution = "Entire Solution";
+        public static String sEntireSolution = "Entire Workspace";
 		public static String[] sLocationStrings = new .(sEntireSolution, sCurrentDocument, sOpenDocuments, sCurrentProject) ~ delete _;
 
 		public class ErrorsListView : IDEListView
@@ -446,7 +446,7 @@ namespace IDE.ui
 			float btnH = toolbarHeight - GS!(4);
 			float curX = GS!(4);
 
-			float scopeSelectW = GS!(120);
+			float scopeSelectW = GS!(140);
 			mScopeFilterCombo.Resize(curX, btnY + GS!(2), scopeSelectW, btnH);
 			curX += scopeSelectW + GS!(4);
 

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -923,7 +923,6 @@ namespace IDE.ui
 					order = (lhs.mProject ?? "") <=> (rhs.mProject ?? "");
 				case 3:
 					// Sort by file name
-					// TODO: we call GetFileName like a bazillion times -> maybe prepare when the error-entry is created
 					let fileNameLhs = scope String(128);
 					let fileNameRhs = scope String(128);
 					Path.GetFileName(lhs.mFilePath, fileNameLhs);

--- a/IDE/src/ui/ErrorsPanel.bf
+++ b/IDE/src/ui/ErrorsPanel.bf
@@ -24,6 +24,13 @@ namespace IDE.ui
 			{
 				return new ErrorsListViewItem();
 			}
+
+			public override void ChangeSort(DarkListView.SortType sortType)
+			{
+				base.ChangeSort(sortType);
+				mSortType = sortType;
+				gApp.mErrorsPanel.InvalidateErrorList();
+			}
 		}
 
 		public class ErrorsListViewItem : IDEListViewItem
@@ -769,7 +776,10 @@ namespace IDE.ui
 						}
 					}
 
-					for (let error in mResolveErrors)
+					List<BfPassInstance.BfError> sortedErrors = new:ScopedAlloc! .(mResolveErrors);
+					sortedErrors.Sort((a, b) => SortErrorEntries(mErrorLV, a, b));
+					
+					for (let error in sortedErrors)
 						HandleError(error);
 
 					while (root.GetChildCount() > idx)
@@ -779,6 +789,58 @@ namespace IDE.ui
 					MarkDirty();
 				}
 			}
+		}
+
+		private static int SortErrorEntries(ErrorsListView mErrorLV, BfPassInstance.BfError a, BfPassInstance.BfError b)
+		{
+			int order = 0;
+
+			if (mErrorLV.mSortType.mColumn == 0)
+			{
+				// Sort by Error/Warning-Code
+			   	// Column contains Error/Warning + Number
+			   	if (a.mIsWarning != b.mIsWarning)
+			   	{
+					// Sort Error and Warning alphabetically
+				   	order = a.mIsWarning ? 1 : -1;
+			   	}
+			   	else
+			   	{
+					// If both are an error or both are a warning -> sort by code.
+					order = a.mCode <=> b.mCode;
+			   	}
+			}
+			if (mErrorLV.mSortType.mColumn == 1)
+			{
+				// Sort by description
+				order = a.mError <=> b.mError;
+			}
+			if (mErrorLV.mSortType.mColumn == 2)
+			{
+				// Sort by project name
+				order = a.mProject <=> b.mProject;
+			}
+			if (mErrorLV.mSortType.mColumn == 3)
+			{
+				// Sort by file name
+				// TODO: we call GetFileName like a bazillion times -> maybe prepare when the error-entry is created
+				let fileNameA = scope String(128);
+				let fileNameB = scope String(128);
+				Path.GetFileName(a.mFilePath, fileNameA);
+				Path.GetFileName(b.mFilePath, fileNameB);
+
+				order = fileNameA <=> fileNameB;
+			}
+			if (mErrorLV.mSortType.mColumn == 4)
+			{
+				// Sort by line
+				order = a.mLine <=> b.mLine;
+			}
+
+			if (mErrorLV.mSortType.mReverse)
+				return -order;
+			else
+				return order;
 		}
 
 		public void UpdateAlways()

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -2967,6 +2967,8 @@ namespace IDE.ui
 				{
 					SyncWithWorkspacePanel();
 				}
+
+				gApp.mErrorsPanel?.OnActiveSourceViewChanged();
 			}
         }
 


### PR DESCRIPTION
This has been on my wishlist for ages, and I finally found some time to make it happen.

This PR adds several filter options to the errors panel that you usually find in other IDEs.

The following filter options were added:
1. A drop-down to select the scope of errors:
	- __Entire Workspace__: Shows all errors
	- __Current File__: Only shows errors for the document that is currently focused
	- __Current Project__: Only shows errors for the project that the "current file" belongs to
	- __Open Files__: Only shows errors for all documents that are currently opened
2. Toggle buttons to show or hide errors or warnings
   These buttons also show how many errors and warnings the entire workspace has, as well as how many match the current filter settings.
3. Search box to filter error messages by text. This will match:
	- Description
	- Project name
	- File name
	- The number in the error-code column
4. Allow sorting the error list by clicking the column-headers
	- Shift-clicking allows sorting by multiple columns at the same time
	- implemented default order: Project -> File -> Line (which is the default for Visual Studio)

# Images:
Here are some images:
<img width="1203" height="463" alt="ErrorsPanel" src="https://github.com/user-attachments/assets/4795d34b-439a-46f0-a436-abaf33ab7a35" />

__Only show errors:__
<img width="1203" height="463" alt="ErrorsPanel_onlyErrors" src="https://github.com/user-attachments/assets/ff6deb3d-d8f2-46bb-ac9b-d7ccfe78586e" />

__Text search:__
<img width="1203" height="463" alt="ErrorsPanel_textSearch" src="https://github.com/user-attachments/assets/23542dd3-9ec6-48ce-8671-5ce73e12f9f2" />

__Error code search:__
<img width="1203" height="463" alt="ErrorsPanel_searchCode" src="https://github.com/user-attachments/assets/01ac8e1d-2240-43b1-b120-35a5325f6372" />


# Open Questions:
1. I have a question about the `SearchEditWidget`: It has a hard-coded content shift to make space for the search icon. However the icon is rendered "manually" in `PropertiesDialog.DrawAll`:
https://github.com/beefytech/Beef/blob/8aeb8602bb4f2875401fa9b8e63fb0b364c068b0/IDE/src/ui/PropertiesDialog.bf#L2116-L2119 I mimicked this behavior in ErrorsPanel.DrawAll. I was wondering, if there was a reason to not override the `Draw`-Method for `SearchEditWidget` and render the icon in there?
2. I merged parse and resolve errors into a single sorted list before generating the list view items. Previously, parse errors always appeared above the resolve errors. Was that original top-ordering intentional? If so, I can restore it for the default sort order. https://github.com/beefytech/Beef/blob/8aeb8602bb4f2875401fa9b8e63fb0b364c068b0/IDE/src/ui/ErrorsPanel.bf#L361-L376