### PR TITLE
LLDB Remote implementation + fixes

### DIFF
--- a/IDE/src/Commands.bf
+++ b/IDE/src/Commands.bf
@@ -361,6 +361,7 @@ namespace IDE
 			Add("Zoom Out", new => gApp.Cmd_ZoomOut);
 			Add("Zoom Reset", new => gApp.Cmd_ZoomReset);
 			Add("Attach to Process", new => gApp.[Friend]DoAttach);
+			Add("Remote Debug", new => gApp.[Friend]DoRemoteDebug);
 			Add("Move Last Selection to Next Find Match", new => gApp.Cmd_MoveLastSelectionToNextFindMatch);
 
 			Add("Test Enable Console", new => gApp.Cmd_TestEnableConsole);

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -346,6 +346,7 @@ namespace IDE
 		public FileChangedDialog mFileChangedDialog;
 		public FindAndReplaceDialog mFindAndReplaceDialog;
 		public LaunchDialog mLaunchDialog;
+		public RemoteDebugDialog mRemoteDebugDialog;
 		public SymbolReferenceHelper mSymbolReferenceHelper;
 		public WrappedMenuValue mViewWhiteSpace = .(false);
 		public bool mEnableGCCollect = true;
@@ -5801,6 +5802,20 @@ namespace IDE
 			mLaunchDialog.mOnClosed.Add(new () => { mLaunchDialog = null; });
 		}
 
+		[IDECommand]
+		void DoRemoteDebug()
+		{
+			if (mRemoteDebugDialog != null)
+			{
+				mRemoteDebugDialog.mWidgetWindow.SetForeground();
+				return;
+			}
+
+			mRemoteDebugDialog = new RemoteDebugDialog();
+			mRemoteDebugDialog.PopupWindow(mMainWindow);
+			mRemoteDebugDialog.mOnClosed.Add(new () => { mRemoteDebugDialog = null; });
+		}
+
 		void DoProfile()
 		{
 			if (gApp.mProfilePanel.mUserProfiler != null)
@@ -6330,6 +6345,7 @@ namespace IDE
 			AddMenuItem(subMenu, "Start With&out Compiling", "Start Without Compiling", new => UpdateMenuItem_DebugStopped_HasWorkspace);
 			AddMenuItem(subMenu, "&Launch Process...", "Launch Process", new => UpdateMenuItem_DebugStopped);
 			AddMenuItem(subMenu, "&Attach to Process...", "Attach to Process", new => UpdateMenuItem_DebugStopped);
+			AddMenuItem(subMenu, "Remote &Debug...", "Remote Debug", new => UpdateMenuItem_DebugStopped);
 			AddMenuItem(subMenu, "&Stop Debugging", "Stop Debugging", new => UpdateMenuItem_DebugOrTestRunning);
 			AddMenuItem(subMenu, "Break All", "Break All", new => UpdateMenuItem_DebugNotPaused);
 			AddMenuItem(subMenu, "Remove All Breakpoints", "Remove All Breakpoints");

--- a/IDE/src/ui/RemoteDebugDialog.bf
+++ b/IDE/src/ui/RemoteDebugDialog.bf
@@ -1,0 +1,241 @@
+using System;
+using System.Collections;
+using Beefy.gfx;
+using Beefy.theme.dark;
+using Beefy.widgets;
+using System.IO;
+
+namespace IDE.ui
+{
+	public class RemoteDebugDialog : DarkDialog
+	{
+		DarkEditWidget mHostEdit;
+		DarkEditWidget mPortEdit;
+		PathComboBox mElfPathCombo;
+		PathComboBox mGdbExeCombo; // Only created when GDB is the active debugger
+		DarkCheckBox mHardwareBreakpointsCheckbox;
+
+		// The debugger is chosen globally; LLDB uses in-process liblldb (no external
+		// executable), so the GDB-executable field is only relevant for GDB.
+		bool mUseLLDB = (gApp.mSettings.mDebuggerSettings.mDebuggerKind == .LLDB);
+
+		static String sLastHost    = new String("localhost") ~ delete _;
+		static String sLastPort    = new String("3333") ~ delete _;
+		static String sLastElfPath = new String() ~ delete _;
+		static String sLastGdbExe  = new String() ~ delete _;
+		static bool   sLastHardwareBreakpoints = true;
+
+		public this()
+		{
+			Title = "Remote Debug";
+			mWindowFlags = .ClientSized | .TopMost | .Caption | .Border | .SysMenu | .PopupPosition;
+			mButtonBottomMargin = GS!(6);
+			mButtonRightMargin = GS!(6);
+
+			AddOkCancelButtons(new (evt) => { evt.mCloseDialog = false; Connect(); }, null, 0, 1);
+
+			mHostEdit = new DarkEditWidget();
+			mHostEdit.SetText(sLastHost);
+			AddWidget(mHostEdit);
+			AddEdit(mHostEdit);
+
+			mPortEdit = new DarkEditWidget();
+			mPortEdit.SetText(sLastPort);
+			AddWidget(mPortEdit);
+			AddEdit(mPortEdit);
+
+			mElfPathCombo = new PathComboBox();
+			mElfPathCombo.MakeEditable(new PathEditWidget());
+			mElfPathCombo.Label = sLastElfPath;
+			mElfPathCombo.mPopulateMenuAction.Add(new (dlg) =>
+				{
+					var item = dlg.AddItem("< Browse... >");
+					item.mOnMenuItemSelected.Add(new (selItem) => { BrowseElf(); });
+				});
+			AddWidget(mElfPathCombo);
+			AddEdit(mElfPathCombo.mEditWidget);
+
+			if (!mUseLLDB)
+			{
+				mGdbExeCombo = new PathComboBox();
+				mGdbExeCombo.MakeEditable(new PathEditWidget());
+				mGdbExeCombo.Label = sLastGdbExe;
+				mGdbExeCombo.mPopulateMenuAction.Add(new (dlg) =>
+					{
+						var item = dlg.AddItem("< Browse... >");
+						item.mOnMenuItemSelected.Add(new (selItem) => { BrowseGdbExe(); });
+					});
+				AddWidget(mGdbExeCombo);
+				AddEdit(mGdbExeCombo.mEditWidget);
+			}
+
+			mHardwareBreakpointsCheckbox = new DarkCheckBox();
+			mHardwareBreakpointsCheckbox.Label = "&Hardware Breakpoints";
+			mHardwareBreakpointsCheckbox.Checked = sLastHardwareBreakpoints;
+			AddDialogComponent(mHardwareBreakpointsCheckbox);
+		}
+
+		void BrowseElf()
+		{
+#if !CLI
+			var fileDialog = scope System.IO.OpenFileDialog();
+			fileDialog.ShowReadOnly = false;
+			fileDialog.Title = "Select ELF / Symbol File";
+			fileDialog.Multiselect = false;
+			fileDialog.ValidateNames = true;
+			fileDialog.SetFilter("ELF files (*.elf)|*.elf|All files (*.*)|*.*");
+			mWidgetWindow.PreModalChild();
+			if (fileDialog.ShowDialog(gApp.GetActiveWindow()) case .Ok)
+			{
+				var fileNames = fileDialog.FileNames;
+				if (!fileNames.IsEmpty)
+					mElfPathCombo.Label = fileNames[0];
+			}
+#endif
+		}
+
+		void BrowseGdbExe()
+		{
+#if !CLI
+			var fileDialog = scope System.IO.OpenFileDialog();
+			fileDialog.ShowReadOnly = false;
+			fileDialog.Title = "Select GDB Executable";
+			fileDialog.Multiselect = false;
+			fileDialog.ValidateNames = true;
+			fileDialog.SetFilter("Executables (*.exe)|*.exe|All files (*.*)|*.*");
+			mWidgetWindow.PreModalChild();
+			if (fileDialog.ShowDialog(gApp.GetActiveWindow()) case .Ok)
+			{
+				var fileNames = fileDialog.FileNames;
+				if (!fileNames.IsEmpty)
+					mGdbExeCombo.Label = fileNames[0];
+			}
+#endif
+		}
+
+		void Connect()
+		{
+			String host = scope String();
+			mHostEdit.GetText(host);
+			host.Trim();
+			String port = scope String();
+			mPortEdit.GetText(port);
+			port.Trim();
+			String elfPath = scope String(mElfPathCombo.Label);
+			elfPath.Trim();
+			IDEUtils.FixFilePath(elfPath);
+			String gdbExe = scope String();
+			if (mGdbExeCombo != null)
+				gdbExe.Set(mGdbExeCombo.Label);
+			gdbExe.Trim();
+
+			if (host.IsEmpty)
+			{
+				gApp.Fail("Host address cannot be empty");
+				return;
+			}
+			if (port.IsEmpty)
+			{
+				gApp.Fail("Port cannot be empty");
+				return;
+			}
+
+			if (gApp.mDebugger.mIsRunning)
+			{
+				gApp.Fail("An executable is already being debugged");
+				return;
+			}
+
+			bool useHw = mHardwareBreakpointsCheckbox.Checked;
+			bool useLLDB = mUseLLDB;
+
+			String launchPath = scope String();
+			launchPath.Append(elfPath);
+			if (useLLDB)
+				launchPath.AppendF("@{}:{}:{}", useHw ? "lldb_hw" : "lldb", host, port);
+			else
+			{
+				launchPath.AppendF("@{}:{}:{}", useHw ? "gdb_hw" : "gdb", host, port);
+				if (!gdbExe.IsEmpty)
+					launchPath.AppendF(";{}", gdbExe);
+			}
+
+			sLastHost.Set(host);
+			sLastPort.Set(port);
+			sLastElfPath.Set(elfPath);
+			sLastGdbExe.Set(gdbExe);
+			sLastHardwareBreakpoints = useHw;
+
+			gApp.[Friend]CheckDebugVisualizers();
+
+			var emptyEnv = scope List<char8>();
+			if (!gApp.mDebugger.OpenFile(launchPath, launchPath, "", "", emptyEnv, false, false, .None))
+			{
+				gApp.Fail(scope String()..AppendF("Unable to connect to remote target '{0}:{1}'", host, port));
+				return;
+			}
+
+			gApp.mDebugger.mIsRunning = true;
+			gApp.mDebugger.RehupBreakpoints(true);
+			gApp.mDebugger.Run();
+
+			Close();
+		}
+
+		public override void CalcSize()
+		{
+			mWidth = GS!(400);
+			mHeight = mUseLLDB ? GS!(180) : GS!(218);
+		}
+
+		public override void ResizeComponents()
+		{
+			base.ResizeComponents();
+
+			float curY = GS!(30);
+			float fullW = mWidth - GS!(12);
+
+			float portW = GS!(80);
+			float hostW = fullW - portW - GS!(6);
+			mHostEdit.Resize(GS!(6), curY, hostW, GS!(22));
+			mPortEdit.Resize(GS!(6) + hostW + GS!(6), curY, portW, GS!(22));
+			curY += GS!(42);
+
+			// ELF / symbol file path
+			mElfPathCombo.Resize(GS!(6), curY, fullW, GS!(22));
+			curY += GS!(38);
+
+			// GDB executable path (GDB only)
+			if (mGdbExeCombo != null)
+			{
+				mGdbExeCombo.Resize(GS!(6), curY, fullW, GS!(22));
+				curY += GS!(38);
+			}
+
+			mHardwareBreakpointsCheckbox.Resize(GS!(6), curY, mHardwareBreakpointsCheckbox.CalcWidth(), GS!(22));
+		}
+
+		public override void Draw(Graphics g)
+		{
+			base.Draw(g);
+
+			g.DrawString("Host:", GS!(6), mHostEdit.mY - GS!(18));
+			g.DrawString("Port:", mPortEdit.mX, mPortEdit.mY - GS!(18));
+			g.DrawString("ELF / Symbol File (optional):", GS!(6), mElfPathCombo.mY - GS!(18));
+			if (mGdbExeCombo != null)
+				g.DrawString("GDB Executable (optional, e.g. arm-none-eabi-gdb):", GS!(6), mGdbExeCombo.mY - GS!(18));
+		}
+
+		public override void Resize(float x, float y, float width, float height)
+		{
+			base.Resize(x, y, width, height);
+			ResizeComponents();
+		}
+
+		public override void AddedToParent()
+		{
+			base.AddedToParent();
+			mWidgetWindow.SetMinimumSize(GS!(300), mUseLLDB ? GS!(180) : GS!(218), true);
+		}
+	}
+}

--- a/IDE/src/ui/RemoteDebugDialog.bf
+++ b/IDE/src/ui/RemoteDebugDialog.bf
@@ -3,26 +3,66 @@ using System.Collections;
 using Beefy.gfx;
 using Beefy.theme.dark;
 using Beefy.widgets;
-using System.IO;
 
 namespace IDE.ui
 {
 	public class RemoteDebugDialog : DarkDialog
 	{
-		DarkEditWidget mHostEdit;
-		DarkEditWidget mPortEdit;
-		PathComboBox mElfPathCombo;
-		PathComboBox mGdbExeCombo; // Only created when GDB is the active debugger
-		DarkCheckBox mHardwareBreakpointsCheckbox;
+		// Which debugger + connection method is being configured. The remote debugger is chosen
+		// explicitly here (independent of the preferences "debugger kind", which only selects the
+		// default *native* debugger). The selected method drives both the fields shown and the
+		// "@<tag>" suffix appended to the launch path, which is what selects the backend.
+		enum ConnKind
+		{
+			LldbRemote, // <elf>@{lldb_hw|lldb}:<host>:<port>
+			GdbServer,  // <elf>@{gdb_hw|gdb}:<host>:<port>[;<gdbexe>]
+			GdbSsh      // <elf>@{gdb_ssh_hw|gdb_ssh}:<server>
+		}
 
-		// The debugger is chosen globally; LLDB uses in-process liblldb (no external
-		// executable), so the GDB-executable field is only relevant for GDB.
-		bool mUseLLDB = (gApp.mSettings.mDebuggerSettings.mDebuggerKind == .LLDB);
+		enum FieldKind
+		{
+			Host,
+			Port,
+			SshServer,
+			ElfPath,
+			GdbExe,
+			HwBreakpoints
+		}
 
-		static String sLastHost    = new String("localhost") ~ delete _;
-		static String sLastPort    = new String("3333") ~ delete _;
-		static String sLastElfPath = new String() ~ delete _;
-		static String sLastGdbExe  = new String() ~ delete _;
+		struct FieldSpec
+		{
+			public FieldKind mKind;
+			public StringView mLabel;
+			public bool mRemote; // For path fields: true = a path on the remote machine (no "..." browse)
+
+			public this(FieldKind kind, StringView label, bool remote = false)
+			{
+				mKind = kind;
+				mLabel = label;
+				mRemote = remote;
+			}
+		}
+
+		class MethodInfo
+		{
+			public String mName ~ delete _;
+			public ConnKind mConnKind;
+			public List<FieldSpec> mFields = new .() ~ delete _;
+		}
+
+		List<MethodInfo> mMethods = new .() ~ DeleteContainerAndItems!(_);
+		MethodInfo mSelectedMethod;
+
+		DarkComboBox mMethodCombo;
+		Dictionary<FieldKind, Widget> mFieldWidgets = new .() ~ delete _; // Widgets owned by the widget tree
+
+		// Remember last-used selections across opens (independent of the preferences debugger kind).
+		static String sLastMethodName = new String("LLDB - GDB Remote Protocol") ~ delete _;
+		static String sLastHost       = new String("localhost") ~ delete _;
+		static String sLastPort       = new String("3333") ~ delete _;
+		static String sLastSshServer  = new String() ~ delete _;
+		static String sLastElfPath    = new String() ~ delete _;
+		static String sLastGdbExe     = new String() ~ delete _;
 		static bool   sLastHardwareBreakpoints = true;
 
 		public this()
@@ -32,112 +72,258 @@ namespace IDE.ui
 			mButtonBottomMargin = GS!(6);
 			mButtonRightMargin = GS!(6);
 
+			BuildMethods();
+
 			AddOkCancelButtons(new (evt) => { evt.mCloseDialog = false; Connect(); }, null, 0, 1);
 
-			mHostEdit = new DarkEditWidget();
-			mHostEdit.SetText(sLastHost);
-			AddWidget(mHostEdit);
-			AddEdit(mHostEdit);
-
-			mPortEdit = new DarkEditWidget();
-			mPortEdit.SetText(sLastPort);
-			AddWidget(mPortEdit);
-			AddEdit(mPortEdit);
-
-			mElfPathCombo = new PathComboBox();
-			mElfPathCombo.MakeEditable(new PathEditWidget());
-			mElfPathCombo.Label = sLastElfPath;
-			mElfPathCombo.mPopulateMenuAction.Add(new (dlg) =>
+			mMethodCombo = new DarkComboBox();
+			mMethodCombo.mPopulateMenuAction.Add(new (menu) =>
 				{
-					var item = dlg.AddItem("< Browse... >");
-					item.mOnMenuItemSelected.Add(new (selItem) => { BrowseElf(); });
-				});
-			AddWidget(mElfPathCombo);
-			AddEdit(mElfPathCombo.mEditWidget);
-
-			if (!mUseLLDB)
-			{
-				mGdbExeCombo = new PathComboBox();
-				mGdbExeCombo.MakeEditable(new PathEditWidget());
-				mGdbExeCombo.Label = sLastGdbExe;
-				mGdbExeCombo.mPopulateMenuAction.Add(new (dlg) =>
+					for (var method in mMethods)
 					{
-						var item = dlg.AddItem("< Browse... >");
-						item.mOnMenuItemSelected.Add(new (selItem) => { BrowseGdbExe(); });
-					});
-				AddWidget(mGdbExeCombo);
-				AddEdit(mGdbExeCombo.mEditWidget);
-			}
+						var item = menu.AddItem(method.mName);
+						item.mOnMenuItemSelected.Add(new (selItem) => { SelectMethod(selItem.mLabel); });
+					}
+				});
+			AddDialogComponent(mMethodCombo);
 
-			mHardwareBreakpointsCheckbox = new DarkCheckBox();
-			mHardwareBreakpointsCheckbox.Label = "&Hardware Breakpoints";
-			mHardwareBreakpointsCheckbox.Checked = sLastHardwareBreakpoints;
-			AddDialogComponent(mHardwareBreakpointsCheckbox);
+			mSelectedMethod = FindMethod(sLastMethodName) ?? mMethods[0];
+			mMethodCombo.Label = mSelectedMethod.mName;
+
+			RebuildFields();
 		}
 
-		void BrowseElf()
+		void BuildMethods()
 		{
-#if !CLI
-			var fileDialog = scope System.IO.OpenFileDialog();
-			fileDialog.ShowReadOnly = false;
-			fileDialog.Title = "Select ELF / Symbol File";
-			fileDialog.Multiselect = false;
-			fileDialog.ValidateNames = true;
-			fileDialog.SetFilter("ELF files (*.elf)|*.elf|All files (*.*)|*.*");
-			mWidgetWindow.PreModalChild();
-			if (fileDialog.ShowDialog(gApp.GetActiveWindow()) case .Ok)
+			MethodInfo Add(StringView name, ConnKind connKind)
 			{
-				var fileNames = fileDialog.FileNames;
-				if (!fileNames.IsEmpty)
-					mElfPathCombo.Label = fileNames[0];
+				var mi = new MethodInfo();
+				mi.mName = new String(name);
+				mi.mConnKind = connKind;
+				mMethods.Add(mi);
+				return mi;
 			}
-#endif
+
+			var lldb = Add("LLDB - GDB Remote Protocol", .LldbRemote);
+			lldb.mFields.Add(.(.Host, "Host (remote target):"));
+			lldb.mFields.Add(.(.Port, "Port:"));
+			lldb.mFields.Add(.(.ElfPath, "ELF / Symbol File (optional):"));
+			lldb.mFields.Add(.(.HwBreakpoints, "Hardware Breakpoints"));
+
+			var gdbServer = Add("GDB - gdbserver (Remote)", .GdbServer);
+			gdbServer.mFields.Add(.(.Host, "Host (remote target):"));
+			gdbServer.mFields.Add(.(.Port, "Port:"));
+			gdbServer.mFields.Add(.(.ElfPath, "ELF / Symbol File (optional):"));
+			gdbServer.mFields.Add(.(.GdbExe, "GDB Executable (e.g. arm-none-eabi-gdb):"));
+			gdbServer.mFields.Add(.(.HwBreakpoints, "Hardware Breakpoints"));
+
+			var gdbSsh = Add("GDB - SSH", .GdbSsh);
+			gdbSsh.mFields.Add(.(.SshServer, "SSH Server (e.g. user@host):"));
+			gdbSsh.mFields.Add(.(.ElfPath, "ELF / Symbol File:", true));
+			gdbSsh.mFields.Add(.(.HwBreakpoints, "Hardware Breakpoints"));
 		}
 
-		void BrowseGdbExe()
+		MethodInfo FindMethod(StringView name)
 		{
-#if !CLI
-			var fileDialog = scope System.IO.OpenFileDialog();
-			fileDialog.ShowReadOnly = false;
-			fileDialog.Title = "Select GDB Executable";
-			fileDialog.Multiselect = false;
-			fileDialog.ValidateNames = true;
-			fileDialog.SetFilter("Executables (*.exe)|*.exe|All files (*.*)|*.*");
-			mWidgetWindow.PreModalChild();
-			if (fileDialog.ShowDialog(gApp.GetActiveWindow()) case .Ok)
+			for (var method in mMethods)
+				if (method.mName == name)
+					return method;
+			return null;
+		}
+
+		void SelectMethod(StringView name)
+		{
+			var method = FindMethod(name);
+			if ((method == null) || (method == mSelectedMethod))
+				return;
+			mSelectedMethod = method;
+			mMethodCombo.Label = method.mName;
+			sLastMethodName.Set(method.mName);
+			RebuildFields();
+		}
+
+		StringView SeedFor(FieldKind kind)
+		{
+			switch (kind)
 			{
-				var fileNames = fileDialog.FileNames;
-				if (!fileNames.IsEmpty)
-					mGdbExeCombo.Label = fileNames[0];
+			case .Host: return sLastHost;
+			case .Port: return sLastPort;
+			case .SshServer: return sLastSshServer;
+			case .ElfPath: return sLastElfPath;
+			case .GdbExe: return sLastGdbExe;
+			default: return "";
 			}
-#endif
+		}
+
+		Widget CreateFieldWidget(FieldSpec spec)
+		{
+			switch (spec.mKind)
+			{
+			case .Host, .Port, .SshServer:
+				{
+					var editWidget = new DarkEditWidget();
+					editWidget.SetText(scope String(SeedFor(spec.mKind)));
+					return editWidget;
+				}
+			case .ElfPath, .GdbExe:
+				{
+					if (spec.mRemote)
+					{
+						// Path lives on the remote machine - no local "..." browse button.
+						var editWidget = new DarkEditWidget();
+						editWidget.SetText(scope String(SeedFor(spec.mKind)));
+						return editWidget;
+					}
+
+					// Local path - PathEditWidget(.File) provides the "..." browse button.
+					var pathWidget = new PathEditWidget(.File);
+					if ((gApp.mWorkspace != null) && (gApp.mWorkspace.mDir != null))
+						pathWidget.mDefaultFolderPath = new String(gApp.mWorkspace.mDir);
+					pathWidget.SetText(scope String(SeedFor(spec.mKind)));
+					return pathWidget;
+				}
+			case .HwBreakpoints:
+				{
+					var checkbox = new DarkCheckBox();
+					checkbox.Label = "&Hardware Breakpoints";
+					checkbox.Checked = sLastHardwareBreakpoints;
+					return checkbox;
+				}
+			}
+		}
+
+		bool TryGetEditText(FieldKind kind, String outStr)
+		{
+			if (mFieldWidgets.TryGetValue(kind, let widget))
+			{
+				((EditWidget)widget).GetText(outStr);
+				return true;
+			}
+			return false;
+		}
+
+		void SaveFieldsToStatics()
+		{
+			String tmp = scope .();
+			if (TryGetEditText(.Host, tmp..Clear())) sLastHost.Set(tmp);
+			if (TryGetEditText(.Port, tmp..Clear())) sLastPort.Set(tmp);
+			if (TryGetEditText(.SshServer, tmp..Clear())) sLastSshServer.Set(tmp);
+			if (TryGetEditText(.ElfPath, tmp..Clear())) sLastElfPath.Set(tmp);
+			if (TryGetEditText(.GdbExe, tmp..Clear())) sLastGdbExe.Set(tmp);
+			if (mFieldWidgets.TryGetValue(.HwBreakpoints, let widget))
+				sLastHardwareBreakpoints = ((DarkCheckBox)widget).Checked;
+		}
+
+		void RebuildFields()
+		{
+			// Preserve current values so shared fields carry across method switches.
+			if (!mFieldWidgets.IsEmpty)
+				SaveFieldsToStatics();
+
+			// Tear down the existing field widgets.
+			for (var widget in mFieldWidgets.Values)
+			{
+				mTabWidgets.Remove(widget);
+				widget.RemoveSelf();
+				delete widget;
+			}
+			mFieldWidgets.Clear();
+			mDialogEditWidget = null;
+
+			// Build the field widgets for the selected method.
+			for (var spec in mSelectedMethod.mFields)
+			{
+				var widget = CreateFieldWidget(spec);
+				if (let checkbox = widget as DarkCheckBox)
+					AddDialogComponent(checkbox);
+				else
+					AddEdit((EditWidget)widget);
+				mFieldWidgets[spec.mKind] = widget;
+			}
+
+			ApplySize();
+			ResizeComponents();
+		}
+
+		float ComputeHeight()
+		{
+			float curY = GS!(28);
+			curY += GS!(46); // method combo
+
+			var fields = mSelectedMethod.mFields;
+			for (int i = 0; i < fields.Count; i++)
+			{
+				let kind = fields[i].mKind;
+				if (kind == .HwBreakpoints)
+					curY += GS!(28);
+				else if ((kind == .Host) && (i + 1 < fields.Count) && (fields[i + 1].mKind == .Port))
+				{
+					curY += GS!(40);
+					i++; // Host and Port share a row
+				}
+				else
+					curY += GS!(40);
+			}
+
+			curY += GS!(40); // button area
+			return curY;
+		}
+
+		void ApplySize()
+		{
+			mWidth = GS!(440);
+			mHeight = ComputeHeight();
+			if (mWidgetWindow != null)
+			{
+				mWidgetWindow.SetMinimumSize((.)GS!(320), (.)mHeight, true);
+				mWidgetWindow.ResizeClient((.)mWidth, (.)mHeight);
+			}
 		}
 
 		void Connect()
 		{
-			String host = scope String();
-			mHostEdit.GetText(host);
-			host.Trim();
-			String port = scope String();
-			mPortEdit.GetText(port);
-			port.Trim();
-			String elfPath = scope String(mElfPathCombo.Label);
-			elfPath.Trim();
-			IDEUtils.FixFilePath(elfPath);
-			String gdbExe = scope String();
-			if (mGdbExeCombo != null)
-				gdbExe.Set(mGdbExeCombo.Label);
-			gdbExe.Trim();
+			String host = scope .();
+			String port = scope .();
+			String sshServer = scope .();
+			String elfPath = scope .();
+			String gdbExe = scope .();
 
-			if (host.IsEmpty)
+			TryGetEditText(.Host, host);
+			TryGetEditText(.Port, port);
+			TryGetEditText(.SshServer, sshServer);
+			TryGetEditText(.ElfPath, elfPath);
+			TryGetEditText(.GdbExe, gdbExe);
+
+			host.Trim();
+			port.Trim();
+			sshServer.Trim();
+			elfPath.Trim();
+			gdbExe.Trim();
+			IDEUtils.FixFilePath(elfPath);
+
+			bool useHw = false;
+			if (mFieldWidgets.TryGetValue(.HwBreakpoints, let widget))
+				useHw = ((DarkCheckBox)widget).Checked;
+
+			switch (mSelectedMethod.mConnKind)
 			{
-				gApp.Fail("Host address cannot be empty");
-				return;
-			}
-			if (port.IsEmpty)
-			{
-				gApp.Fail("Port cannot be empty");
-				return;
+			case .LldbRemote, .GdbServer:
+				if (host.IsEmpty)
+				{
+					gApp.Fail("Host address cannot be empty");
+					return;
+				}
+				if (port.IsEmpty)
+				{
+					gApp.Fail("Port cannot be empty");
+					return;
+				}
+			case .GdbSsh:
+				if (sshServer.IsEmpty)
+				{
+					gApp.Fail("SSH server cannot be empty");
+					return;
+				}
 			}
 
 			if (gApp.mDebugger.mIsRunning)
@@ -146,32 +332,34 @@ namespace IDE.ui
 				return;
 			}
 
-			bool useHw = mHardwareBreakpointsCheckbox.Checked;
-			bool useLLDB = mUseLLDB;
-
-			String launchPath = scope String();
+			String launchPath = scope .();
 			launchPath.Append(elfPath);
-			if (useLLDB)
-				launchPath.AppendF("@{}:{}:{}", useHw ? "lldb_hw" : "lldb", host, port);
-			else
+			switch (mSelectedMethod.mConnKind)
 			{
+			case .LldbRemote:
+				launchPath.AppendF("@{}:{}:{}", useHw ? "lldb_hw" : "lldb", host, port);
+			case .GdbServer:
 				launchPath.AppendF("@{}:{}:{}", useHw ? "gdb_hw" : "gdb", host, port);
 				if (!gdbExe.IsEmpty)
 					launchPath.AppendF(";{}", gdbExe);
+			case .GdbSsh:
+				launchPath.AppendF("@{}:{}", useHw ? "gdb_ssh_hw" : "gdb_ssh", sshServer);
 			}
 
 			sLastHost.Set(host);
 			sLastPort.Set(port);
+			sLastSshServer.Set(sshServer);
 			sLastElfPath.Set(elfPath);
 			sLastGdbExe.Set(gdbExe);
 			sLastHardwareBreakpoints = useHw;
+			sLastMethodName.Set(mSelectedMethod.mName);
 
 			gApp.[Friend]CheckDebugVisualizers();
 
 			var emptyEnv = scope List<char8>();
 			if (!gApp.mDebugger.OpenFile(launchPath, launchPath, "", "", emptyEnv, false, false, .None))
 			{
-				gApp.Fail(scope String()..AppendF("Unable to connect to remote target '{0}:{1}'", host, port));
+				gApp.Fail("Unable to connect to remote target");
 				return;
 			}
 
@@ -184,46 +372,63 @@ namespace IDE.ui
 
 		public override void CalcSize()
 		{
-			mWidth = GS!(400);
-			mHeight = mUseLLDB ? GS!(180) : GS!(218);
+			mWidth = GS!(440);
+			mHeight = ComputeHeight();
 		}
 
 		public override void ResizeComponents()
 		{
 			base.ResizeComponents();
 
-			float curY = GS!(30);
+			float x = GS!(6);
 			float fullW = mWidth - GS!(12);
+			float curY = GS!(28);
 
-			float portW = GS!(80);
-			float hostW = fullW - portW - GS!(6);
-			mHostEdit.Resize(GS!(6), curY, hostW, GS!(22));
-			mPortEdit.Resize(GS!(6) + hostW + GS!(6), curY, portW, GS!(22));
-			curY += GS!(42);
+			mMethodCombo.Resize(x, curY, fullW, GS!(28));
+			curY += GS!(46);
 
-			// ELF / symbol file path
-			mElfPathCombo.Resize(GS!(6), curY, fullW, GS!(22));
-			curY += GS!(38);
-
-			// GDB executable path (GDB only)
-			if (mGdbExeCombo != null)
+			var fields = mSelectedMethod.mFields;
+			for (int i = 0; i < fields.Count; i++)
 			{
-				mGdbExeCombo.Resize(GS!(6), curY, fullW, GS!(22));
-				curY += GS!(38);
-			}
+				let kind = fields[i].mKind;
+				var widget = mFieldWidgets[kind];
 
-			mHardwareBreakpointsCheckbox.Resize(GS!(6), curY, mHardwareBreakpointsCheckbox.CalcWidth(), GS!(22));
+				if (kind == .HwBreakpoints)
+				{
+					var checkbox = (DarkCheckBox)widget;
+					checkbox.Resize(x, curY, checkbox.CalcWidth(), GS!(22));
+					curY += GS!(28);
+				}
+				else if ((kind == .Host) && (i + 1 < fields.Count) && (fields[i + 1].mKind == .Port))
+				{
+					float portW = GS!(80);
+					float hostW = fullW - portW - GS!(6);
+					widget.Resize(x, curY, hostW, GS!(22));
+					mFieldWidgets[.Port].Resize(x + hostW + GS!(6), curY, portW, GS!(22));
+					curY += GS!(40);
+					i++; // Host and Port share a row
+				}
+				else
+				{
+					widget.Resize(x, curY, fullW, GS!(22));
+					curY += GS!(40);
+				}
+			}
 		}
 
 		public override void Draw(Graphics g)
 		{
 			base.Draw(g);
 
-			g.DrawString("Host:", GS!(6), mHostEdit.mY - GS!(18));
-			g.DrawString("Port:", mPortEdit.mX, mPortEdit.mY - GS!(18));
-			g.DrawString("ELF / Symbol File (optional):", GS!(6), mElfPathCombo.mY - GS!(18));
-			if (mGdbExeCombo != null)
-				g.DrawString("GDB Executable (optional, e.g. arm-none-eabi-gdb):", GS!(6), mGdbExeCombo.mY - GS!(18));
+			g.DrawString("Method:", GS!(6), mMethodCombo.mY - GS!(18));
+
+			for (var spec in mSelectedMethod.mFields)
+			{
+				if (spec.mKind == .HwBreakpoints)
+					continue;
+				if (mFieldWidgets.TryGetValue(spec.mKind, let widget))
+					g.DrawString(spec.mLabel, widget.mX, widget.mY - GS!(18));
+			}
 		}
 
 		public override void Resize(float x, float y, float width, float height)
@@ -235,7 +440,7 @@ namespace IDE.ui
 		public override void AddedToParent()
 		{
 			base.AddedToParent();
-			mWidgetWindow.SetMinimumSize(GS!(300), mUseLLDB ? GS!(180) : GS!(218), true);
+			mWidgetWindow.SetMinimumSize((.)GS!(320), (.)mHeight, true);
 		}
 	}
 }

--- a/IDEHelper/GDBDebugger.cpp
+++ b/IDEHelper/GDBDebugger.cpp
@@ -435,6 +435,7 @@ GDBDebugger::GDBDebugger(DebugManager* debugManager)
 	mHotSwapEnabled = false;
 	mOpenFileFlags = DbgOpenFileFlag_None;
 	mLaunchMode = GDBLaunchMode_Local;
+	mUseHardwareBreakpoints = false;
 	mGDBReady = false;
 	mRunning = false;
 	mNeedsExecRun = false;
@@ -747,6 +748,11 @@ void GDBDebugger::HandleStoppedRecord(GDBMIRecord* rec)
 			{
 				GDBBreakpoint* bp = NULL;
 				mBreakpointNumMap.TryGetValue(bpNum, &bp);
+				if (bp != NULL)
+				{
+					Breakpoint* head = (bp->mHead != NULL) ? bp->mHead : bp;
+					head->mHitCount++;
+				}
 				mActiveBreakpoint = bp;
 
 				// Record resolved address from the frame
@@ -860,8 +866,12 @@ void GDBDebugger::OpenFile(const StringImpl& launchPath, const StringImpl& targe
 	//   gdb_wsl          — run "wsl gdb"; paths converted to WSL /mnt/ form
 	//   gdb_ssh:server   — run "ssh <server> gdb"; path is already a remote path
 	//   gdb:host:port    — run GDB locally; connect to gdbserver on <host:port>
+	// The host portion may carry an optional GDB executable override after a ';':
+	//   gdb:host:port;arm-none-eabi-gdb   — use a specific (cross) GDB binary
 	mLaunchMode = GDBLaunchMode_Local;
 	mGDBServerHost = "";
+	mGDBExe = "";
+	mUseHardwareBreakpoints = false;
 
 	const char* rawPath = launchPath.c_str();
 	const char* atSign = strchr(rawPath, '@');
@@ -878,10 +888,24 @@ void GDBDebugger::OpenFile(const StringImpl& launchPath, const StringImpl& targe
 			mLaunchMode = GDBLaunchMode_SSH;
 			mGDBServerHost = location + 8;
 		}
+		else if (strncmp(location, "gdb_hw:", 7) == 0)
+		{
+			mLaunchMode = GDBLaunchMode_GDBServer;
+			mGDBServerHost = location + 7;
+			mUseHardwareBreakpoints = true;
+		}
 		else if (strncmp(location, "gdb:", 4) == 0)
 		{
 			mLaunchMode = GDBLaunchMode_GDBServer;
 			mGDBServerHost = location + 4;
+		}
+
+		// Split off an optional ";<gdbExe>" override from the host portion.
+		int semiPos = (int)mGDBServerHost.IndexOf(';');
+		if (semiPos >= 0)
+		{
+			mGDBExe = mGDBServerHost.Substring(semiPos + 1);
+			mGDBServerHost.RemoveToEnd(semiPos);
 		}
 
 		mLaunchPath = String(rawPath, (int)(atSign - rawPath));
@@ -918,7 +942,11 @@ void GDBDebugger::DoLaunch()
 	{
 	case GDBLaunchMode_Local:
 	case GDBLaunchMode_GDBServer:
-		gdbExe = "gdb";
+		// Use the override (e.g. "arm-none-eabi-gdb" for embedded ARM targets) when set,
+		// otherwise the default "gdb" on PATH. A target-specific GDB is required for
+		// remote embedded debugging so it correctly recognizes the architecture
+		// (e.g. Cortex-M / Thumb) instead of falling back to generic ARM.
+		gdbExe = mGDBExe.IsEmpty() ? "gdb" : mGDBExe;
 		gdbBaseArgs = "--interpreter=mi2 --nx";
 		break;
 	case GDBLaunchMode_WSL:
@@ -935,6 +963,8 @@ void GDBDebugger::DoLaunch()
 
 	// For WSL mode, convert both the executable path and working directory to
 	// WSL /mnt/... paths before passing them to GDB inside WSL.
+	// For all other modes, replace backslashes with forward slashes so that
+	// the path is safe inside a GDB/MI C-string (backslashes are escape chars there).
 	String launchPathForGDB = mLaunchPath;
 	String workingDirForGDB = mWorkingDir;
 	if (mLaunchMode == GDBLaunchMode_WSL)
@@ -942,6 +972,15 @@ void GDBDebugger::DoLaunch()
 		launchPathForGDB = ConvertToWSLPath(mLaunchPath);
 		if (!mWorkingDir.IsEmpty())
 			workingDirForGDB = ConvertToWSLPath(mWorkingDir);
+	}
+	else
+	{
+		for (int i = 0; i < (int)launchPathForGDB.length(); i++)
+			if (launchPathForGDB[i] == '\\')
+				launchPathForGDB[i] = '/';
+		for (int i = 0; i < (int)workingDirForGDB.length(); i++)
+			if (workingDirForGDB[i] == '\\')
+				workingDirForGDB[i] = '/';
 	}
 
 	GDBLog("Launching GDB with exe='%s' args='%s'\n", gdbExe.c_str(), gdbBaseArgs.c_str());
@@ -1563,22 +1602,31 @@ String GDBDebugger::FixBeefName(const char* name)
 
 GDBMIRecord* GDBDebugger::InsertBreakpointByLocation(const char* file, int lineNum1Based)
 {
-	String wslPath;
+	String fixedPath;
 	if (mLaunchMode == GDBLaunchMode_WSL)
 	{
-		wslPath = ConvertToWSLPath(file);
-		file = wslPath.c_str();
+		fixedPath = ConvertToWSLPath(file);
+		file = fixedPath.c_str();
+	}
+	else if (mLaunchMode == GDBLaunchMode_GDBServer)
+	{
+		// Cross-compilers store source paths with forward slashes in DWARF even on
+		// Windows. Convert so GDB can match the path against its source table.
+		fixedPath = file;
+		for (int i = 0; i < (int)fixedPath.length(); i++)
+			if (fixedPath[i] == '\\') fixedPath[i] = '/';
+		file = fixedPath.c_str();
 	}
 
-	// -break-insert "file:line"
-	//String cmd = StrFormat("-break-insert -f \"%s:%d\"", file, lineNum1Based);
-	String cmd = StrFormat("-break-insert -f %s:%d", file, lineNum1Based);
+	const char* hwFlag = mUseHardwareBreakpoints ? "-h " : "";
+	String cmd = StrFormat("-break-insert %s-f %s:%d", hwFlag, file, lineNum1Based);
 	return SendSync(cmd.c_str());
 }
 
 GDBMIRecord* GDBDebugger::InsertBreakpointByName(const char* sym, bool mainModuleOnly)
 {
-	String cmd = StrFormat("-break-insert \"%s\"", sym);
+	const char* hwFlag = mUseHardwareBreakpoints ? "-h " : "";
+	String cmd = StrFormat("-break-insert %s\"%s\"", hwFlag, sym);
 	return SendSync(cmd.c_str());
 }
 
@@ -1685,7 +1733,8 @@ Breakpoint* GDBDebugger::CreateAddressBreakpoint(intptr address)
 
 	if (mGDBReady)
 	{
-		String cmd = StrFormat("-break-insert *0x%llX", (uint64)address);
+		const char* hwFlag = mUseHardwareBreakpoints ? "-h " : "";
+		String cmd = StrFormat("-break-insert %s*0x%llX", hwFlag, (uint64)address);
 		GDBMIRecord* rec = SendSync(cmd.c_str());
 		BindBreakpointFromResult(bp, rec);
 		delete rec;
@@ -1720,7 +1769,8 @@ void GDBDebugger::DoCheckBreakpoint(Breakpoint* checkBreakpoint, bool force)
 		}
 		else if (bp->mResolvedAddr != 0)
 		{
-			String cmd = StrFormat("-break-insert *0x%llX", (uint64)bp->mResolvedAddr);
+			const char* hwFlag = mUseHardwareBreakpoints ? "-h " : "";
+			String cmd = StrFormat("-break-insert %s*0x%llX", hwFlag, (uint64)bp->mResolvedAddr);
 			rec = SendSync(cmd.c_str());
 		}
 
@@ -3069,6 +3119,7 @@ void GDBDebugger::Detach()
 	mAutoStepRemaining = 0;
 	mLaunchMode = GDBLaunchMode_Local;
 	mGDBServerHost = "";
+	mGDBExe = "";
 	mGDBReady = false;
 	mRunning = false;
 	mNeedsExecRun = false;

--- a/IDEHelper/GDBDebugger.cpp
+++ b/IDEHelper/GDBDebugger.cpp
@@ -863,9 +863,11 @@ void GDBDebugger::OpenFile(const StringImpl& launchPath, const StringImpl& targe
 
 	// Parse optional "path@location" syntax.
 	// Recognised location tags:
-	//   gdb_wsl          — run "wsl gdb"; paths converted to WSL /mnt/ form
-	//   gdb_ssh:server   — run "ssh <server> gdb"; path is already a remote path
-	//   gdb:host:port    — run GDB locally; connect to gdbserver on <host:port>
+	//   gdb_wsl            — run "wsl gdb"; paths converted to WSL /mnt/ form
+	//   gdb_ssh:server     — run "ssh <server> gdb"; path is already a remote path
+	//   gdb_ssh_hw:server  — as gdb_ssh, but use hardware breakpoints
+	//   gdb:host:port      — run GDB locally; connect to gdbserver on <host:port>
+	//   gdb_hw:host:port   — as gdb, but use hardware breakpoints
 	// The host portion may carry an optional GDB executable override after a ';':
 	//   gdb:host:port;arm-none-eabi-gdb   — use a specific (cross) GDB binary
 	mLaunchMode = GDBLaunchMode_Local;
@@ -882,6 +884,12 @@ void GDBDebugger::OpenFile(const StringImpl& launchPath, const StringImpl& targe
 		if (strcmp(location, "gdb_wsl") == 0)
 		{
 			mLaunchMode = GDBLaunchMode_WSL;
+		}
+		else if (strncmp(location, "gdb_ssh_hw:", 11) == 0)
+		{
+			mLaunchMode = GDBLaunchMode_SSH;
+			mGDBServerHost = location + 11;
+			mUseHardwareBreakpoints = true;
 		}
 		else if (strncmp(location, "gdb_ssh:", 8) == 0)
 		{

--- a/IDEHelper/GDBDebugger.h
+++ b/IDEHelper/GDBDebugger.h
@@ -191,6 +191,11 @@ protected:
 	GDBLaunchMode mLaunchMode;
 	// Remote host for SSH and gdbserver modes (e.g. "user@host" or "host:1234")
 	String mGDBServerHost;
+	// Optional GDB executable override (e.g. "arm-none-eabi-gdb" for embedded targets).
+	// Empty = use the default "gdb" on PATH.
+	String mGDBExe;
+	// When true, all -break-insert commands get the -h (hardware breakpoint) flag
+	bool mUseHardwareBreakpoints;
 
 	// Whether GDB has been launched and is ready
 	bool mGDBReady;

--- a/IDEHelper/LLDBDebugger.cpp
+++ b/IDEHelper/LLDBDebugger.cpp
@@ -130,6 +130,8 @@ LLDBDebugger::LLDBDebugger(DebugManager* debugManager)
 	mExceptionCode = 0;
 	mHotSwapEnabled = false;
 	mOpenFileFlags = DbgOpenFileFlag_None;
+	mLaunchMode = LLDBLaunchMode_Local;
+	mUseHardwareBreakpoints = false;
 	mLaunchThread = NULL;
 }
 
@@ -248,18 +250,29 @@ void LLDBDebugger::OpenFile(const StringImpl& launchPath, const StringImpl& targ
 {
 	LLDBLog("OpenFile\n");
 
+	mLaunchMode = LLDBLaunchMode_Local;
+	mRemoteHost = "";
+	mUseHardwareBreakpoints = false;
+
 	const char* rawPath = launchPath.c_str();
 	const char* atSign = strchr(rawPath, '@');
 	if (atSign != NULL)
 	{
 		const char* location = atSign + 1;
 
-		if (strncmp(location, "lldb:", 4) == 0)
-		{			
-			//TODO: mLLDBServerHost = location + 5;
-		}		
-		
-		mLaunchPath = String(rawPath, (int)(atSign - rawPath));		
+		if (strncmp(location, "lldb_hw:", 8) == 0)
+		{
+			mRemoteHost = location + 8;
+			mLaunchMode = LLDBLaunchMode_Remote;
+			mUseHardwareBreakpoints = true;
+		}
+		else if (strncmp(location, "lldb:", 5) == 0)
+		{
+			mRemoteHost = location + 5;
+			mLaunchMode = LLDBLaunchMode_Remote;
+		}
+
+		mLaunchPath = String(rawPath, (int)(atSign - rawPath));
 	}
 	else
 	{
@@ -282,6 +295,58 @@ void LLDBDebugger::DoLaunch()
 
 	lldb::SBDebugger debugger = lldb::SBDebugger::Create(/*source_init_files=*/false);
 	debugger.SetAsync(true);
+
+	if (mLaunchMode == LLDBLaunchMode_Remote)
+	{
+		//ELF path is optional
+		lldb::SBError targetError;
+		lldb::SBTarget target = debugger.CreateTarget(
+			mLaunchPath.IsEmpty() ? "" : mLaunchPath.c_str(),
+			NULL, NULL, /*add_dependent_modules=*/true, targetError);
+
+		if (mUseHardwareBreakpoints)
+		{
+			// Force all breakpoints to be set as hardware breakpoints.
+			lldb::SBCommandReturnObject res;
+			debugger.GetCommandInterpreter().HandleCommand(
+				"settings set target.require-hardware-breakpoint true", res);
+		}
+
+		// "connect://" with the "gdb-remote" plugin speaks GDB Remote Serial Protocol.
+		lldb::SBListener listener = debugger.GetListener();
+		String connectUrl = StrFormat("connect://%s", mRemoteHost.c_str());
+		lldb::SBError connErr;
+		lldb::SBProcess process = target.ConnectRemote(
+			listener, connectUrl.c_str(), "gdb-remote", connErr);
+
+		if ((!process.IsValid()) || connErr.Fail())
+		{
+			String msg = "LLDB: Failed to connect to '";
+			msg += mRemoteHost;
+			msg += "'";
+			if (connErr.IsValid())
+			{
+				msg += ": ";
+				msg += connErr.GetCString();
+			}
+			msg += "\n";
+			OutputMessage(msg);
+			lldb::SBDebugger::Destroy(debugger);
+			lldb::SBDebugger::Terminate();
+			AutoCrit autoCrit(mDebugManager->mCritSect);
+			mRunState = RunState_Terminated;
+			return;
+		}
+
+		AutoCrit autoCrit(mDebugManager->mCritSect);
+		mLLDBDebugger = debugger;
+		mLLDBTarget = target;
+		mLLDBProcess = process;
+		mProcessId = (int)process.GetProcessID();
+		mNeedBreakpointRebind = true;
+		mRunState = RunState_Running;
+		return;
+	}
 
 	// Create a target from the executable path.
 	lldb::SBError targetError;
@@ -525,6 +590,11 @@ void LLDBDebugger::HandleProcessEvent(lldb::StateType state)
 				lldb::break_id_t bpId = (lldb::break_id_t)thread.GetStopReasonDataAtIndex(0);
 				LLDBBreakpoint* bp = NULL;
 				mBreakpointIdMap.TryGetValue((int)bpId, &bp);
+				if (bp != NULL)
+				{
+					Breakpoint* head = (bp->mHead != NULL) ? bp->mHead : bp;
+					head->mHitCount++;
+				}
 				mActiveBreakpoint = bp;
 
 				// Record the resolved load address from the PC if not yet known

--- a/IDEHelper/LLDBDebugger.h
+++ b/IDEHelper/LLDBDebugger.h
@@ -19,6 +19,12 @@
 
 NS_BF_BEGIN
 
+enum LLDBLaunchMode
+{
+	LLDBLaunchMode_Local,
+	LLDBLaunchMode_Remote   // GDB RSP over TCP (compatible with OpenOCD, lldb-server --gdbserver)
+};
+
 class LLDBBreakpoint : public Breakpoint
 {
 public:
@@ -69,6 +75,11 @@ public:
 	Array<uint8> mEnvBlock;
 	DbgOpenFileFlags mOpenFileFlags;
 	bool mHotSwapEnabled;
+
+	// Remote debugging
+	LLDBLaunchMode mLaunchMode;
+	String mRemoteHost;            // "host:port" for LLDBLaunchMode_Remote
+	bool mUseHardwareBreakpoints;  // when true, require-hardware-breakpoint setting is applied
 
 	// Background launch thread
 	BfpThread* mLaunchThread;


### PR DESCRIPTION
Adds remote debugging functionality to LLDB backend similar to existing GDB implementation.
Adds Remote debugging UI that contains the following:

- IP and port fields
- Optional ELF/Symbol file field
- **(On GDB only)** Optional GDB Executable field
- Hardware breakpoint checkbox.

The GDB executable field is required, because unlike lldb, gdb might require a different executable to debug certain targets. e.g arm-none-eab-gdb. Without this, breakpoint size might be wrong, and it will attempt to read invalid memory regions.

There is also a fix in here for incrementing breakpoint counters on both LLDB and GDB backend. 
Also contains a file path fix for windows/windows remote debugging.

Remote debug was tested on both backends against a Raspberry Pi Pico 2W through OpenOCD.

<img width="423" height="272" alt="image" src="https://github.com/user-attachments/assets/8120093b-e170-43a0-a0c8-e977ab9e181f" />
