### PR TITLE
Fix linux beefbuild indefinite hang on some environments.

### DIFF
--- a/BeefBuild/src/BuildApp.bf
+++ b/BeefBuild/src/BuildApp.bf
@@ -84,6 +84,7 @@ namespace BeefBuild
 				Fail("Platform not specified");
 
 			base.Init();
+			InitUserDataDir();
 
 			mSettings.Load();
 			mSettings.Apply();

--- a/IDE/src/BeefConfig.bf
+++ b/IDE/src/BeefConfig.bf
@@ -233,6 +233,8 @@ namespace IDE
 #endif
 				if (Directory.CreateDirectory(managedPath) case .Ok)
 					mManagedLibPath.Set(managedPath);
+				else
+					gApp.OutputErrorLine("Failed to create managed library directory '{0}'", managedPath);
 			}
 
 			mConfigFiles.Add(configFile);

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -3372,7 +3372,11 @@ namespace IDE
 				}
 				else
 				{
-					mPackMan.GetWithVersion(projectName, url, ver);
+					if (mPackMan.GetWithVersion(projectName, url, ver) case .Err)
+					{
+						Fail(scope $"Failed to initialize managed library support for project '{projectName}'");
+						return .Err(.NotFound);
+					}
 					isDeferredLoad = true;
 				}
 			default:
@@ -13081,6 +13085,14 @@ namespace IDE
 			return mVersionInfo;
 		}
 
+		protected void InitUserDataDir()
+		{
+#if BF_PLATFORM_LINUX && LINUX_PACKAGE
+			delete mUserDataDir;
+			mUserDataDir = new $"{Environment.GetEnvironmentVariable("HOME", .. scope .())}/.config/beeflang/";
+#endif
+		}
+
 #if !CLI
 		public override void Init()
 		{
@@ -13110,10 +13122,7 @@ namespace IDE
 			mSettings.Apply();
 
 			mGitManager.Init();
-
-#if BF_PLATFORM_LINUX && LINUX_PACKAGE
-			mUserDataDir = new $"{Environment.GetEnvironmentVariable("HOME", .. scope .())}/.config/beeflang/";
-#endif
+			InitUserDataDir();
 
 			//Yoop();
 

--- a/IDE/src/util/PackMan.bf
+++ b/IDE/src/util/PackMan.bf
@@ -290,10 +290,10 @@ namespace IDE.util
 			mWorkItems.Add(workItem);
 		}
 
-		public void GetWithVersion(StringView projectName, StringView url, SemVer semVer)
+		public Result<void> GetWithVersion(StringView projectName, StringView url, SemVer semVer)
 		{
 			if (!CheckInit())
-				return;
+				return .Err;
 
 			bool ignoreLock = false;
 			if (gApp.mWantUpdateVersionLocks != null)
@@ -309,7 +309,7 @@ namespace IDE.util
 				case .Git(let checkURL, let tag, let hash):
 					if (checkURL == url)
 						GetWithHash(projectName, url, tag, hash);
-					return;
+					return .Ok;
 				default:
 				}
 			}
@@ -324,6 +324,7 @@ namespace IDE.util
 			if (semVer?.IsEmpty == false)
 				workItem.mConstraints = new .() { new String(semVer.mVersion) };
 			mWorkItems.Add(workItem);
+			return .Ok;
 		}
 
 		public void UpdateGitConstraint(StringView url, SemVer semVer)


### PR DESCRIPTION
I noticed that beefbuild when installed into a system location that is inaccessible to writes runs into a permission issue with builds since the previous behavior was to create the BeefManaged folder relative to the bin/ location instead of the location the ide currently does which is in `~/.config/beeflang/BeefManaged`

So with that said this PR makes the following changes:
Initialize the packaged Linux user data directory the same way for BeefIDE and BeefBuild so that they both store  managed libraries under the user's config directory instead of the installation directory.

I've also made some additional changes to surface errors like this quicker in the future instead of having silently failing build command that seems to never exit.

As such now if there is any similar permissions issues in the future it will output something like this and exit instead of the hang:

```
$ beefbuild
ERROR: Failed to create managed library directory '/opt/BeefLang/bin/BeefManaged'
ERROR: Failed to initialize managed library support for project 'SDL3-Beef.git'
```

 