### PR TITLE
Allow versioned .so in ImportAttribute

### DIFF
--- a/IDEHelper/Compiler/BfSystem.cpp
+++ b/IDEHelper/Compiler/BfSystem.cpp
@@ -522,14 +522,54 @@ BfMethodDef::~BfMethodDef()
 
 BfImportKind BfMethodDef::GetImportKindFromPath(const StringImpl& filePath)
 {
-	String fileExt = GetFileExtension(filePath);
-
-	if ((fileExt.Equals(".DYLIB", StringImpl::CompareKind_OrdinalIgnoreCase)) ||
-		(fileExt.Equals(".SO", StringImpl::CompareKind_OrdinalIgnoreCase)) ||
-		(fileExt.Equals(".DLL", StringImpl::CompareKind_OrdinalIgnoreCase)) ||
-		(fileExt.Equals(".EXE", StringImpl::CompareKind_OrdinalIgnoreCase)))
+	if ((filePath.EndsWith(".DYLIB", StringImpl::CompareKind_OrdinalIgnoreCase)) ||
+		(filePath.EndsWith(".SO", StringImpl::CompareKind_OrdinalIgnoreCase)) ||
+		(filePath.EndsWith(".DLL", StringImpl::CompareKind_OrdinalIgnoreCase)) ||
+		(filePath.EndsWith(".EXE", StringImpl::CompareKind_OrdinalIgnoreCase)))
 	{
 		return BfImportKind_Import_Dynamic;
+	}
+
+	if ((filePath.EndsWith(".A", StringImpl::CompareKind_OrdinalIgnoreCase)) ||
+		(filePath.EndsWith(".LIB", StringImpl::CompareKind_OrdinalIgnoreCase)))
+	{
+		return BfImportKind_Import_Static;
+	}
+
+
+	// Check for versioned .so libs
+	const int pathLength = filePath.length(); 
+	int allowedDotsRemaining = 4; // Allow 3 version numbers + .so
+	int lastDotIndex = pathLength;
+
+	for (int i = pathLength - 1; i >= 0; i--)
+	{
+		char c = filePath[i];
+		
+		if ((c == '/') || (c == '\\'))
+		{
+			break;
+		}
+
+		if ((c == '.'))
+		{
+			if ((--allowedDotsRemaining >= 0) && (i != lastDotIndex - 1))
+			{
+				lastDotIndex = i;
+				continue;
+			}
+			
+			break;
+		}
+	}
+
+	if ((lastDotIndex != pathLength)) 
+	{
+		String fileExt = filePath.Substring(lastDotIndex);
+		if ((fileExt.StartsWith(".SO.", StringImpl::CompareKind_OrdinalIgnoreCase)))
+		{
+			return BfImportKind_Import_Dynamic;
+		}
 	}
 
 	return BfImportKind_Import_Static;


### PR DESCRIPTION
Allow library names such as `libwayland-client.so.0` to be used with `ImportAttribute` and still be considered dynamic library.
Theoretically the library can be versioned with whatever so i didn't add any checks and allow almost anything after .SO