### PR TITLE
Random fixes aarch64 / macos / unix

### DIFF
--- a/BeefLibs/corlib/src/Reflection/MethodInfo.bf
+++ b/BeefLibs/corlib/src/Reflection/MethodInfo.bf
@@ -539,6 +539,7 @@ namespace System.Reflection
 			void* retData = variantData;
 
 			// Struct return? Manually add it as an arg after 'this'.  Revisit this - this is architecture-dependent.
+			#unwarn // unused in aarch64
 			int unusedRetVal;
 			FFIType* ffiRetType = null;
 			if (retType.IsStruct)
@@ -954,6 +955,7 @@ namespace System.Reflection
 			void* retData = variantData;
 
 			// Struct return? Manually add it as an arg after 'this'.  Revisit this - this is architecture-dependent.
+			#unwarn // unused in aarch64
 			int unusedRetVal;
 			FFIType* ffiRetType = null;
 			if (retType.IsStruct)

--- a/BeefTools/ImgCreate/CMakeLists.txt
+++ b/BeefTools/ImgCreate/CMakeLists.txt
@@ -119,6 +119,7 @@ if (${WIN32})
     )
 elseif (${APPLE})
     include_directories(
+        ../../BeefySysLib/platform/osx
         ../../BeefySysLib/platform/darwin
     )
     file(GLOB SRC_FILES_OS

--- a/BeefySysLib/platform/linux/LinuxCommon.cpp
+++ b/BeefySysLib/platform/linux/LinuxCommon.cpp
@@ -453,14 +453,9 @@ public:
 
 };
 
-
-FileWatchManager* FileWatchManager::Get()
+FileWatchManager* FileWatchManager::Allocate()
 {
-    if (gFileWatchManager == NULL)
-    {
-        gFileWatchManager = new InotifyFileWatchManager();
-        gFileWatchManager->Init();
-    }
-    return gFileWatchManager;
+    return new InotifyFileWatchManager();
 }
+
 #endif // BFP_HAS_FILEWATCHER

--- a/BeefySysLib/platform/posix/PosixCommon.cpp
+++ b/BeefySysLib/platform/posix/PosixCommon.cpp
@@ -105,6 +105,8 @@ public:
     virtual void Shutdown() = 0;
     virtual BfpFileWatcher* WatchDirectory(const char* path, BfpDirectoryChangeFunc callback, BfpFileWatcherFlags flags, void* userData, BfpFileResult* outResult) = 0;
     virtual void Remove(BfpFileWatcher* watcher) = 0;
+	static FileWatchManager* Allocate();
+
     static FileWatchManager* Get();
 };
 
@@ -117,16 +119,26 @@ class NullFilewatchManager : public FileWatchManager
 };
 
 #ifndef BFP_HAS_FILEWATCHER
+FileWatchManager* FileWatchManager::Allocate()
+{
+	return new NullFilewatchManager();
+}
+#endif
+
 FileWatchManager* FileWatchManager::Get()
 {
     if (gFileWatchManager == NULL)
     {
-        gFileWatchManager = new NullFilewatchManager();
+        auto fileWatcher = FileWatchManager::Allocate();
+    	if (auto prevValue = __sync_val_compare_and_swap(&gFileWatchManager, NULL, fileWatcher))
+    	{
+    		delete fileWatcher;
+    		return prevValue;
+    	}
         gFileWatchManager->Init();
     }
     return gFileWatchManager;
 }
-#endif
 
 BfpTimeStamp BfpToTimeStamp(const timespec& ts)
 {

--- a/BeefySysLib/platform/sdl/SdlBFApp.cpp
+++ b/BeefySysLib/platform/sdl/SdlBFApp.cpp
@@ -129,27 +129,24 @@ struct AdjustedMonRect
 
 static int bfMouseBtnOf[4] = {0, 0, 2, 1}; // Translate SDL mouse buttons to what Beef expects.
 
-static HMODULE gSDLModule;
-static HMODULE gSDLImageModule;
+static BfpDynLib* gSDLModule;
 
-static HMODULE GetSDLModule(const StringImpl& installDir)
+static BfpDynLib* GetSDLModule(const StringImpl& installDir)
 {
 	if (gSDLModule == NULL)
 	{
-#if defined (BF_PLATFORM_WINDOWS)
-		String loadPath = installDir + "SDL3.dll";
-		gSDLModule = ::LoadLibraryA(loadPath.c_str());
-#elif defined (BF_PLATFORM_LINUX)
-		String loadPath = "libSDL3.so";
-		gSDLModule = dlopen(loadPath.c_str(), RTLD_LAZY);
+		String path = "SDL3";
+#ifdef BF_PLATFORM_WINDOWS
+		path.Insert(0, installDir);
 #endif
+		gSDLModule = BfpDynLib_Load(path.c_str());
 		if (gSDLModule == NULL)
 		{
 #ifdef BF_PLATFORM_WINDOWS
 			::MessageBoxA(NULL, "Failed to load SDL3.dll", "FATAL ERROR", MB_OK | MB_ICONERROR);
 			::ExitProcess(1);
 #endif
-			BF_FATAL("Failed to load libSDL3.so");
+			BF_FATAL("Failed to load SDL3");
 		}
 	}
 	return gSDLModule;
@@ -158,11 +155,7 @@ static HMODULE GetSDLModule(const StringImpl& installDir)
 template <typename T>
 static void BFGetSDLProc(T& proc, const char* name, const StringImpl& installDir)
 {
-#if defined (BF_PLATFORM_WINDOWS)
-	proc = (T)::GetProcAddress(GetSDLModule(installDir), name);
-#elif defined (BF_PLATFORM_LINUX)
-	proc = (T)dlsym(GetSDLModule(installDir), name);
-#endif
+	proc = (T)BfpDynLib_GetProcAddress(GetSDLModule(installDir), name);
 }
 
 #define BF_GET_SDLPROC(name) BFGetSDLProc(bf_##name, #name, mInstallDir)

--- a/IDE/dist/shaders/Std.frag
+++ b/IDE/dist/shaders/Std.frag
@@ -1,10 +1,15 @@
+#version 150 core
+
 uniform sampler2D tex;
 uniform sampler2D tex2;
-varying vec4 varying_color;
-varying vec2 varying_texCoord0;
+
+in vec4 varying_color;
+in vec2 varying_texCoord0;
+
+out vec4 fragColor;
 
 void main()
 {
-	vec4 texColor = texture2D(tex, varying_texCoord0);
-	gl_FragColor = texColor * varying_color;
+	vec4 texColor = texture(tex, varying_texCoord0);
+	fragColor = texColor * varying_color;
 }

--- a/IDE/dist/shaders/Std.vert
+++ b/IDE/dist/shaders/Std.vert
@@ -1,11 +1,13 @@
+#version 150 core
+
 uniform mat4 screenMatrix;
 
-attribute vec4 position;
-attribute vec2 texCoord0;
-attribute vec4 color;
+in vec4 position;
+in vec2 texCoord0;
+in vec4 color;
 
-varying vec4 varying_color;
-varying vec2 varying_texCoord0;
+out vec4 varying_color;
+out vec2 varying_texCoord0;
 
 void main()
 {        

--- a/IDE/dist/shaders/Std_font.frag
+++ b/IDE/dist/shaders/Std_font.frag
@@ -1,12 +1,16 @@
+#version 150 core
+
 uniform sampler2D tex;
 uniform sampler2D tex2;
-varying vec4 varying_color;
-varying vec2 varying_texCoord0;
+in vec4 varying_color;
+in vec2 varying_texCoord0;
+
+out vec4 fragColor;
 
 void main()
 {
-	vec4 texColor = texture2D(tex, varying_texCoord0);
+	vec4 texColor = texture(tex, varying_texCoord0);
 	float gray = varying_color.r * 0.299 + varying_color.g * 0.587 + varying_color.b * 0.114;
 	float a = mix(texColor.a, texColor.r, gray);
-    gl_FragColor = vec4(a, a, a, a) * varying_color;
+    fragColor = vec4(a, a, a, a) * varying_color;
 }

--- a/IDE/dist/shaders/Std_font.vert
+++ b/IDE/dist/shaders/Std_font.vert
@@ -1,11 +1,13 @@
+#version 150 core
+
 uniform mat4 screenMatrix;
 
-attribute vec4 position;
-attribute vec2 texCoord0;
-attribute vec4 color;
+in vec4 position;
+in vec2 texCoord0;
+in vec4 color;
 
-varying vec4 varying_color;
-varying vec2 varying_texCoord0;
+out vec4 varying_color;
+out vec2 varying_texCoord0;
 
 void main()
 {        


### PR DESCRIPTION
Bunch of stuff I encountered while trying to get IDE to work on macos.
List of changes:
- add `#version 150 core` (opengl 3.2) to opengl shaders and update code so that it loads (macos refuses to load shaders without #version pragma)
- Ignore unused variable in MethodInfo.bf on aarch64
- use `BfpDynLib_Load` /  `BfpDynLib_GetProcAddress` instead of platform dependent functions to load SDL3
- Add missing include dir for `ImgCreate` on macos
-  Reworked FileWatcher allocation on unix so that any new implementation just needs to implement `FileWatchManager::Allocate()` it should also fix potential double allocation in multi threaded situations.  

Now for IDE to build on macos there are 2 missing pieces, which will come in near future
- File Watcher
- File Picker dialogs