### PR TITLE
Add an option to make autocomplete suggest unimported namespaces

### DIFF
--- a/IDE/src/Compiler/BfParser.bf
+++ b/IDE/src/Compiler/BfParser.bf
@@ -105,6 +105,7 @@ namespace IDE.Compiler
 		public int32 mTextVersion = -1;
 		public bool mIsUserRequested;
 		public bool mDoFuzzyAutoComplete;
+		public bool mShouldAutoCompleteIgnoreNamespaces;
 		public Stopwatch mStopwatch ~ delete _;
 		public ProfileInstance mProfileInstance ~ _.Dispose();
 
@@ -168,7 +169,7 @@ namespace IDE.Compiler
         static extern char8* BfParser_GetDebugExpressionAt(void* bfParser, int32 cursorIdx);
 
         [CallingConvention(.Stdcall), CLink]
-        static extern void* BfParser_CreateResolvePassData(void* bfSystem, int32 resolveType, bool doFuzzyAutoComplete);
+        static extern void* BfParser_CreateResolvePassData(void* bfSystem, int32 resolveType, bool doFuzzyAutoComplete, bool shouldAutoCompleteIgnoreNamespaces);
 
         [CallingConvention(.Stdcall), CLink]
         static extern bool BfParser_BuildDefs(void* bfParser, void* bfPassInstance, void* bfResolvePassData, bool fullRefresh);
@@ -328,10 +329,10 @@ namespace IDE.Compiler
             BfParser_GenerateAutoCompletionFrom(mNativeBfParser, srcPosition);
         }
 
-        public BfResolvePassData CreateResolvePassData(ResolveType resolveType = ResolveType.Autocomplete, bool doFuzzyAutoComplete = false)
+        public BfResolvePassData CreateResolvePassData(ResolveType resolveType = ResolveType.Autocomplete, bool doFuzzyAutoComplete = false, bool shouldAutoCompleteIgnoreNamespaces = false)
         {
             var resolvePassData = new BfResolvePassData();
-            resolvePassData.mNativeResolvePassData = BfParser_CreateResolvePassData(mNativeBfParser, (int32)resolveType, doFuzzyAutoComplete);
+            resolvePassData.mNativeResolvePassData = BfParser_CreateResolvePassData(mNativeBfParser, (int32)resolveType, doFuzzyAutoComplete, shouldAutoCompleteIgnoreNamespaces);
             return resolvePassData;
         }
 

--- a/IDE/src/Compiler/BfResolvePassData.bf
+++ b/IDE/src/Compiler/BfResolvePassData.bf
@@ -105,10 +105,10 @@ namespace IDE.Compiler
 			BfResolvePassData_SetDocumentationRequest(mNativeResolvePassData, entryName);
 		}
 
-        public static BfResolvePassData Create(ResolveType resolveType = ResolveType.Autocomplete, bool doFuzzyAutoComplete = false)
+        public static BfResolvePassData Create(ResolveType resolveType = ResolveType.Autocomplete, bool doFuzzyAutoComplete = false, bool shouldAutoCompleteIgnoreNamespaces = false)
         {
             var resolvePassData = new BfResolvePassData();
-            resolvePassData.mNativeResolvePassData = BfParser.[Friend]BfParser_CreateResolvePassData(null, (int32)resolveType, doFuzzyAutoComplete);
+            resolvePassData.mNativeResolvePassData = BfParser.[Friend]BfParser_CreateResolvePassData(null, (int32)resolveType, doFuzzyAutoComplete, shouldAutoCompleteIgnoreNamespaces);
             return resolvePassData;
         }
 

--- a/IDE/src/Settings.bf
+++ b/IDE/src/Settings.bf
@@ -729,6 +729,7 @@ namespace IDE
 			public bool mAutoCompleteOnEnter = true;
 			public bool mAutoCompleteShowDocumentation = true;
 			public bool mFuzzyAutoComplete = false;
+			public bool mShouldAutoCompleteIgnoreNamespaces = false;
 			public bool mShowLocatorAnim = true;
 			public bool mHiliteCursorReferences = true;
 			public bool mDebugMultiCursor = false;
@@ -764,6 +765,7 @@ namespace IDE
 				sd.Add("AutoCompleteOnEnter", mAutoCompleteOnEnter);
 				sd.Add("AutoCompleteShowDocumentation", mAutoCompleteShowDocumentation);
 				sd.Add("FuzzyAutoComplete", mFuzzyAutoComplete);
+				sd.Add("ShouldAutoCompleteIgnoreNamespaces", mShouldAutoCompleteIgnoreNamespaces);
 				sd.Add("ShowLocatorAnim", mShowLocatorAnim);
 				sd.Add("HiliteCursorReferences", mHiliteCursorReferences);
 				sd.Add("HiliteCurrentLine", mHiliteCurrentLine);
@@ -801,6 +803,7 @@ namespace IDE
 				sd.Get("AutoCompleteOnEnter", ref mAutoCompleteOnEnter);
 				sd.Get("AutoCompleteShowDocumentation", ref mAutoCompleteShowDocumentation);
 				sd.Get("FuzzyAutoComplete", ref mFuzzyAutoComplete);
+				sd.Get("ShouldAutoCompleteIgnoreNamespaces", ref mShouldAutoCompleteIgnoreNamespaces);
 				sd.Get("ShowLocatorAnim", ref mShowLocatorAnim);
 				sd.Get("HiliteCursorReferences", ref mHiliteCursorReferences);
 				sd.Get("HiliteCurrentLine", ref mHiliteCurrentLine);

--- a/IDE/src/ui/SettingsDialog.bf
+++ b/IDE/src/ui/SettingsDialog.bf
@@ -105,6 +105,7 @@ namespace IDE.ui
 			AddPropertiesItem(category, "Autocomplete on Enter", "mAutoCompleteOnEnter");
 			AddPropertiesItem(category, "Autocomplete Show Documentation", "mAutoCompleteShowDocumentation");
 			AddPropertiesItem(category, "Fuzzy Autocomplete", "mFuzzyAutoComplete");
+			AddPropertiesItem(category, "Autocomplete Ignores Namespaces", "mShouldAutoCompleteIgnoreNamespaces");
 			AddPropertiesItem(category, "Show Locator Animation", "mShowLocatorAnim");
 			AddPropertiesItem(category, "Hilite Symbol at Cursor", "mHiliteCursorReferences");
 			AddPropertiesItem(category, "Hilite Current Line", "mHiliteCurrentLine");

--- a/IDE/src/ui/SettingsDialog.bf
+++ b/IDE/src/ui/SettingsDialog.bf
@@ -105,7 +105,7 @@ namespace IDE.ui
 			AddPropertiesItem(category, "Autocomplete on Enter", "mAutoCompleteOnEnter");
 			AddPropertiesItem(category, "Autocomplete Show Documentation", "mAutoCompleteShowDocumentation");
 			AddPropertiesItem(category, "Fuzzy Autocomplete", "mFuzzyAutoComplete");
-			AddPropertiesItem(category, "Autocomplete Ignores Namespaces", "mShouldAutoCompleteIgnoreNamespaces");
+			AddPropertiesItem(category, "Autocomplete Unimported Items", "mShouldAutoCompleteIgnoreNamespaces");
 			AddPropertiesItem(category, "Show Locator Animation", "mShowLocatorAnim");
 			AddPropertiesItem(category, "Hilite Symbol at Cursor", "mHiliteCursorReferences");
 			AddPropertiesItem(category, "Hilite Current Line", "mHiliteCurrentLine");

--- a/IDE/src/ui/SourceViewPanel.bf
+++ b/IDE/src/ui/SourceViewPanel.bf
@@ -762,6 +762,7 @@ namespace IDE.ui
 				resolveParams.mProfileInstance = Profiler.StartSampling("Autocomplete").GetValueOrDefault();
 			resolveParams.mIsUserRequested = options.HasFlag(.UserRequested);
 			resolveParams.mDoFuzzyAutoComplete = gApp.mSettings.mEditorSettings.mFuzzyAutoComplete;
+			resolveParams.mShouldAutoCompleteIgnoreNamespaces = gApp.mSettings.mEditorSettings.mShouldAutoCompleteIgnoreNamespaces;
 			Classify(.Autocomplete, resolveParams);
 			if (!resolveParams.mInDeferredList)
 				delete resolveParams;
@@ -2209,8 +2210,9 @@ namespace IDE.ui
 			}
 
 			bool doFuzzyAutoComplete = resolveParams?.mDoFuzzyAutoComplete ?? false;
+			bool shouldAutoCompleteIgnoreNamespaces = resolveParams?.mShouldAutoCompleteIgnoreNamespaces ?? false;
 
-			var resolvePassData = parser.CreateResolvePassData(resolveType, doFuzzyAutoComplete);
+			var resolvePassData = parser.CreateResolvePassData(resolveType, doFuzzyAutoComplete, shouldAutoCompleteIgnoreNamespaces);
 			if (resolveParams != null)
 			{
 			    if (resolveParams.mLocalId != -1)

--- a/IDEHelper/Compiler/BfAutoComplete.cpp
+++ b/IDEHelper/Compiler/BfAutoComplete.cpp
@@ -184,7 +184,7 @@ void AutoCompleteBase::Clear()
 
 //////////////////////////////////////////////////////////////////////////
 
-BfAutoComplete::BfAutoComplete(BfResolveType resolveType, bool doFuzzyAutoComplete)
+BfAutoComplete::BfAutoComplete(BfResolveType resolveType, bool doFuzzyAutoComplete, bool shouldAutoCompleteIgnoreNamespaces)
 {
 	mResolveType = resolveType;
 	mModule = NULL;
@@ -202,6 +202,7 @@ BfAutoComplete::BfAutoComplete(BfResolveType resolveType, bool doFuzzyAutoComple
 	mIsAutoComplete = (resolveType == BfResolveType_Autocomplete);
 
 	mDoFuzzyAutoComplete = doFuzzyAutoComplete;
+	mShouldAutoCompleteIgnoreNamespaces = shouldAutoCompleteIgnoreNamespaces;
 
 	mGetDefinitionNode = NULL;
 	mShowAttributeProperties = NULL;
@@ -1475,7 +1476,8 @@ void BfAutoComplete::AddTopLevelNamespaces(BfAstNode* identifierNode)
 		for (auto namespacePair : project->mNamespaces)
 		{
 			const BfAtomComposite& namespaceComposite = namespacePair.mKey;
-			if (namespaceComposite.GetPartsCount() == 1)
+			if ((mShouldAutoCompleteIgnoreNamespaces) ||
+				(namespaceComposite.GetPartsCount() == 1))
 			{
 				AddEntry(AutoCompleteEntry("namespace", namespaceComposite.ToString()), filter);
 			}
@@ -1587,7 +1589,8 @@ void BfAutoComplete::AddTopLevelTypes(BfAstNode* identifierNode, bool onlyAttrib
 				bool matches = false;
 				if (typeDef->mOuterType == NULL)
 				{
-					if (((typeDef->mNamespace.IsEmpty()) ||
+					if ((mShouldAutoCompleteIgnoreNamespaces) ||
+						((typeDef->mNamespace.IsEmpty()) ||
 						(namespaceSearch.Contains(typeDef->mNamespace))))
 						matches = true;
 				}

--- a/IDEHelper/Compiler/BfAutoComplete.h
+++ b/IDEHelper/Compiler/BfAutoComplete.h
@@ -112,6 +112,7 @@ public:
 	bool mIsGetDefinition;
 	bool mIsAutoComplete;
 	bool mDoFuzzyAutoComplete;
+	bool mShouldAutoCompleteIgnoreNamespaces;
 	int mInsertStartIdx;
 	int mInsertEndIdx;
 
@@ -248,7 +249,7 @@ public:
 	String ConstantToString(BfIRConstHolder* constHolder, BfTypedValue typedValue);
 
 public:
-	BfAutoComplete(BfResolveType resolveType = BfResolveType_Autocomplete, bool doFuzzyAutoComplete = false);
+	BfAutoComplete(BfResolveType resolveType = BfResolveType_Autocomplete, bool doFuzzyAutoComplete = false, bool shouldAutoCompleteIgnoreNamespaces = false);
 	~BfAutoComplete();
 
 	void SetModule(BfModule* module);

--- a/IDEHelper/Compiler/BfParser.cpp
+++ b/IDEHelper/Compiler/BfParser.cpp
@@ -4252,14 +4252,14 @@ BF_EXPORT const char* BF_CALLTYPE BfParser_GetDebugExpressionAt(BfParser* bfPars
 	return outString.c_str();
 }
 
-BF_EXPORT BfResolvePassData* BF_CALLTYPE BfParser_CreateResolvePassData(BfParser* bfParser, BfResolveType resolveType, bool doFuzzyAutoComplete)
+BF_EXPORT BfResolvePassData* BF_CALLTYPE BfParser_CreateResolvePassData(BfParser* bfParser, BfResolveType resolveType, bool doFuzzyAutoComplete, bool shouldAutoCompleteIgnoreNamespaces)
 {
 	auto bfResolvePassData = new BfResolvePassData();
 	bfResolvePassData->mResolveType = resolveType;
 	if (bfParser != NULL)
 		bfResolvePassData->mParsers.Add(bfParser);
 	if ((bfParser != NULL) && ((bfParser->mParserFlags & ParserFlag_Autocomplete) != 0))
-		bfResolvePassData->mAutoComplete = new BfAutoComplete(resolveType, doFuzzyAutoComplete);
+		bfResolvePassData->mAutoComplete = new BfAutoComplete(resolveType, doFuzzyAutoComplete, shouldAutoCompleteIgnoreNamespaces);
 	return bfResolvePassData;
 }
 


### PR DESCRIPTION
I have not fully tested this.

All this PR does is add a setting in the menu ("Autocomplete Ignores Namespaces", defaulting to off) that disables the namespace checks in the autocomplete engine. Anything completed using this will show up as an error, because it doesn't add the correct using statement.

I'm not sure what the best way to make it add a using statement would be. My first thought would be to add a step after the completion that checks for and adds a missing using statement, but it would also probably be possible to leech off of Fixit.