### PR TITLE
Fix break in nested scope inside a switch case

### DIFF
--- a/IDEHelper/Compiler/BfStmtEvaluator.cpp
+++ b/IDEHelper/Compiler/BfStmtEvaluator.cpp
@@ -5161,8 +5161,8 @@ void BfModule::Visit(BfSwitchStatement* switchStmt)
 			openedScope = false;
 			deferredLocalAssignDataVec[blockIdx].mHadReturn = hadReturn;
 			caseCount++;
-			if ((!hadReturn) &&
-				((!mCurMethodState->mDeferredLocalAssignData->mHadFallthrough) || (mCurMethodState->mDeferredLocalAssignData->mHadBreak)))
+			if (((!hadReturn) && ((!mCurMethodState->mDeferredLocalAssignData->mHadFallthrough) || (mCurMethodState->mDeferredLocalAssignData->mHadBreak))) ||
+				((mCurMethodState->mDeferredLocalAssignData->mHadBreak) && (!mCurMethodState->mDeferredLocalAssignData->mLeftBlockUncond)))
 				allHadReturns = false;
 
 			if (auto block = BfNodeDynCast<BfBlock>(switchCase->mCodeBlock))
@@ -5399,13 +5399,15 @@ void BfModule::Visit(BfSwitchStatement* switchStmt)
 			caseScopeData.mIsSharedTempBlock = true;
 			mCurMethodState->AddScope(&caseScopeData);
 			NewScopeState();
+			deferredLocalAssignDataVec[blockIdx].mScopeData = mCurMethodState->mCurScope;
 			caseScopeData.mLabel = newScope.mLabel;
 
 			bool hadReturn = false;
 			VisitCodeBlock(switchCase->mCodeBlock, BfIRBlock(), endBlock, BfIRBlock(), true, &hadReturn, switchStmt->mLabelNode);
 			deferredLocalAssignDataVec[blockIdx].mHadReturn = hadReturn;
 			caseCount++;
-			if (!hadReturn)
+			if ((!hadReturn) ||
+				((mCurMethodState->mDeferredLocalAssignData->mHadBreak) && (!mCurMethodState->mDeferredLocalAssignData->mLeftBlockUncond)))
 				allHadReturns = false;
 
 			RestoreScopeState();


### PR DESCRIPTION
Fix setting `allHadReturns = false;` when a `break;` appears in a nested scope.

I'm not very familiar with how the compiler works, so it's an attempt that I hope can save you some time.

AI used to identify and make a bad fix
Human used to improve fix and do some manuel testing.

Fixes #2479

This PR does not fix how `break;` seems to be treated differently than `return;` when it comes to unreachable code within a single switch case. Compile time known branches works differently for instance:
`if (compTimeFalseValue) { return; }` is ignored as a return, but a `break;` is seen as a possibility, as far as I can tell.