### PR TITLE
Compiler: populate the aliased type when resolving through a typealias

### DIFF
--- a/IDEHelper/Compiler/BfModuleTypeUtils.cpp
+++ b/IDEHelper/Compiler/BfModuleTypeUtils.cpp
@@ -10320,6 +10320,7 @@ BfType* BfModule::ResolveTypeResult(BfTypeReference* typeRef, BfType* resolvedTy
 	if ((populateType != BfPopulateType_TypeDef) && (populateType != BfPopulateType_IdentityNoRemapAlias))
 	{
 		int aliasDepth = 0;
+		bool derefedAlias = false;
 		HashSet<BfType*> seenAliases;
 
 		while ((resolvedTypeRef != NULL) && (resolvedTypeRef->IsTypeAlias()))
@@ -10346,7 +10347,16 @@ BfType* BfModule::ResolveTypeResult(BfTypeReference* typeRef, BfType* resolvedTy
 				typeInstance = resolvedTypeRef->ToTypeInstance();
 			else
 				typeInstance = NULL;
+			derefedAlias = true;
 		}
+
+		// The loop populates each alias and then steps to what that alias refers to, so
+		// the type we end up returning has only been populated incidentally. Apply the
+		// level the caller asked for. Without this, sizeof/alignof/strideof through an
+		// alias read an unpopulated type and fold to 0/1/0 with no error, unless
+		// something else in the program happened to populate that type first.
+		if ((derefedAlias) && (resolvedTypeRef != NULL) && (populateType > BfPopulateType_Identity))
+			PopulateType(resolvedTypeRef, populateType);
 	}
 
 	if (typeInstance != NULL)

--- a/IDEHelper/Tests/src/Aliases.bf
+++ b/IDEHelper/Tests/src/Aliases.bf
@@ -57,6 +57,44 @@ namespace Tests
 		    public int Member;
 		}
 
+		// A type reached only through an alias must still be populated before its size is
+		// read. These are referenced nowhere else in the suite: anything that populated
+		// them incidentally would hide a regression here.
+		struct SizedByAlias
+		{
+			public float a;
+			public float b;
+		}
+		typealias AliasSized = SizedByAlias;
+
+		struct SizedByAliasChain
+		{
+			public float a;
+			public float b;
+		}
+		typealias AliasChain0 = SizedByAliasChain;
+		typealias AliasChain1 = AliasChain0;
+
+		struct EmittedByAlias
+		{
+			[OnCompile(.TypeInit), Comptime]
+			static void Generate() => Compiler.EmitTypeBody(typeof(Self), "public float a; public float b;");
+		}
+		typealias AliasEmitted = EmittedByAlias;
+
+		[Test]
+		public static void TestAliasedTypeAttrs()
+		{
+			Test.Assert(sizeof(AliasSized) == 8);
+			Test.Assert(alignof(AliasSized) == 4);
+			Test.Assert(strideof(AliasSized) == 8);
+
+			Test.Assert(sizeof(AliasChain1) == 8);
+
+			Test.Assert(sizeof(AliasEmitted) == 8);
+			Test.Assert(offsetof(AliasEmitted, b) == 4);
+		}
+
 		[Test]
 		public static void TestBasics()
 		{


### PR DESCRIPTION
ResolveTypeResult walks a chain of aliases, populating each alias and then stepping to what it refers to, but does not apply the caller's requested populate level to the type it ends up returning. The unpopulated defaults are 0 for size and 1 for align, so the result is a silently wrong constant instead of an error.

```C#
    struct S { public float a; public float b; }
    typealias A = S;
    sizeof(A)   // 0, want 8
    alignof(A)  // 1, want 4
```

Affected, all silent: sizeof, alignof and strideof through an alias, through an alias chain, to a generic instantiation, to an alias declared inside a class, to an enum, to a tuple, to a type in another namespace, and the same read from a const initializer or a comptime block.

Not affected, because these reach the type through paths that populate it anyway: offsetof, a field or sized-array field typed by the alias, sizeof of an array of the alias, a generic parameterised by the alias, and typeof(alias).Size and .InstanceSize.

Add Aliases.TestAliasedTypeAttrs over a plain struct, an alias chain and a struct whose body is emitted at comptime.

Note: This was debugged by and the fix suggested by Claude.