### PR TITLE
corlib: handle comptime in the TypeInstance.GetMethod(int) override

### DIFF
--- a/BeefLibs/corlib/src/Reflection/TypeInstance.bf
+++ b/BeefLibs/corlib/src/Reflection/TypeInstance.bf
@@ -76,7 +76,7 @@ namespace System
 		{
 			if (Compiler.IsComptime)
 			{
-				int64 nativeMethod = Comptime_GetMethod((.)TypeId, (.)methodIdx);
+				int64 nativeMethod = Type.[Friend]Comptime_GetMethod((.)TypeId, (.)methodIdx);
 				if (nativeMethod == 0)
 					return .Err(.NoResults);
 
@@ -121,6 +121,18 @@ namespace System.Reflection
 
 		public override Result<MethodInfo, MethodError> GetMethod(int methodIdx)
 		{
+			// This override replaces the one on the base declaration, so the comptime
+			// case has to be handled here too. At comptime there is no runtime method
+			// table: mMethodDataCount is 0, and without this every index answers
+			// NoResults for a type whose methods are all present.
+			if (Compiler.IsComptime)
+			{
+				int64 nativeMethod = Type.[Friend]Comptime_GetMethod((.)TypeId, (.)methodIdx);
+				if (nativeMethod == 0)
+					return .Err(.NoResults);
+				return MethodInfo(this, nativeMethod);
+			}
+
 			if ((methodIdx < 0) || (methodIdx >= mMethodDataCount))
 				return .Err(.NoResults);
 			return MethodInfo(this, &mMethodDataPtr[methodIdx]);

--- a/IDEHelper/Tests/src/Comptime.bf
+++ b/IDEHelper/Tests/src/Comptime.bf
@@ -315,6 +315,42 @@ namespace Tests
 		const String cTest1 = new String('A', 12);
 		const uint8[?] cTest0Binary = Compiler.ReadBinary("Test0.txt");
 
+		class MethodSource
+		{
+			public static void Alpha() { }
+			public static void Beta() { }
+		}
+
+		// TypeInstance.GetMethod(int) is overridden by an extension that reads the
+		// runtime method table, which does not exist at comptime. Without a comptime
+		// branch in that override every index answers NoResults for a type whose
+		// methods are all present, and Comptime_GetMethodCount still reports them.
+		struct ComptimeMethodLookup
+		{
+			[OnCompile(.TypeInit), Comptime]
+			static void Generate()
+			{
+				let source = (TypeInstance)typeof(MethodSource);
+
+				int found = 0;
+				int named = 0;
+				for (int i < 64)
+				{
+					if (source.GetMethod(i) case .Ok(let method))
+					{
+						found++;
+						if ((method.Name == "Alpha") || (method.Name == "Beta"))
+							named++;
+					}
+				}
+
+				Compiler.EmitTypeBody(typeof(Self), scope $"""
+					public const int cFound = {found};
+					public const int cNamed = {named};
+					""");
+			}
+		}
+
 		class ClassB<T> where T : const int
 		{
 			public typealias TA = comptype(GetVal(10, T));
@@ -635,6 +671,9 @@ namespace Tests
 			Test.Assert(cTest1 == "AAAAAAAAAAAA");
 			Test.Assert((Object)cTest1 == (Object)"AAAAAAAAAAAA");
 			Test.Assert((cTest0Binary[0] == (.)'T') && ((cTest0Binary.Count == 6) || (cTest0Binary.Count == 7)));
+
+			Test.Assert(ComptimeMethodLookup.cFound > 0);
+			Test.Assert(ComptimeMethodLookup.cNamed == 2);
 
 			ClassB<const 3>.TA f = default;
 			Test.Assert(typeof(decltype(f)) == typeof(float));


### PR DESCRIPTION
An extension overrides GetMethod(int) with an implementation that indexes the runtime method table, which replaces the comptime branch on the base declaration rather than adding to it. At comptime mMethodDataCount is 0, so every index is NoResults for a type whose methods are all present.

Restores the comptime path in the override, so an IComptimeTypeApply attribute can walk a type's methods by index.

Test:
Adds Comptime.ComptimeMethodLookup over a class with two named static methods.

Note: The issue was debugged by and the fix created by Claude.