### PR TITLE
Git dependency subfolders via ?path=

### DIFF
--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -3423,15 +3423,25 @@ namespace IDE
 			case .Git(let url, let ver):
 
 				var checkPath = scope String();
-				if (mPackMan.CheckLock(projectName, checkPath, var projectFailed))
+				String checkError = scope .();
+				if (mPackMan.CheckLock(projectName, url, checkPath, checkError, var projectFailed))
 				{
 					projectFilePath = scope:: String(checkPath);
 				}
 				else
 				{
-					if (mPackMan.GetWithVersion(projectName, url, ver) case .Err)
+					if (projectFailed)
 					{
-						Fail(scope $"Failed to initialize managed library support for project '{projectName}'");
+						Fail(checkError);
+						return .Err(.LoadFailed);
+					}
+					String versionError = scope .();
+					if (mPackMan.GetWithVersion(projectName, url, ver, versionError) case .Err)
+					{
+						if (!versionError.IsEmpty)
+							Fail(versionError);
+						else
+							Fail(scope $"Failed to initialize managed library support for project '{projectName}'");
 						return .Err(.NotFound);
 					}
 					isDeferredLoad = true;

--- a/IDE/src/IDEUtils.bf
+++ b/IDE/src/IDEUtils.bf
@@ -673,6 +673,12 @@ namespace IDE
 			}
 		}
 
+		public static bool IsHexDigit(char8 c)
+		{
+			char8 lower = (char8)((uint8)c | 0x20);
+			return ((c >= '0') && (c <= '9')) || ((lower >= 'a') && (lower <= 'f'));
+		}
+
 		static String sHexUpperChars = "0123456789ABCDEF";
 		public static void URLEncode(StringView inStr, String outStr)
 		{
@@ -691,17 +697,134 @@ namespace IDE
 			}
 		}
 
-		public static void URLDecode(StringView inStr, String outStr)
+		/// Appends decoded bytes. On error, callers must discard any partial output.
+		public static Result<void> URLDecode(StringView inStr, String outStr)
 		{
-			for (int i < inStr.Length)
+			for (int i = 0; i < inStr.Length; i++)
 			{
 				char8 c = inStr[i];
-				if ((c == '%') && (i < inStr.Length-2))
+				if (c == '%')
 				{
-					c = (.)int32.Parse(inStr.Substring(i+1, 2), .HexNumber).GetValueOrDefault();
+					if (i + 2 >= inStr.Length)
+						return .Err;
+					let hi = Try!(BitConverter.FromHex(inStr[i + 1]));
+					let lo = Try!(BitConverter.FromHex(inStr[i + 2]));
+					c = (.)((hi << 4) | lo);
 					i += 2;
 				}
 				outStr.Append(c);
+			}
+			return .Ok;
+		}
+
+		/// Normalizes a project subfolder in place: forward slashes, no empty or "." components, no leading
+		/// or trailing slash. Rejects anything that could escape the clone or fail on some platform.
+		public static bool NormalizeGitProjectSubPath(String path)
+		{
+			// Apply Windows filename restrictions on every platform for portable dependencies.
+			const String windowsReservedFileNameChars = ":*?\"<>|";
+
+			path.Replace("\\", "/");
+			String normalizedPath = scope .();
+			for (let part in path.Split('/'))
+			{
+				if ((part.IsEmpty) || (part == "."))
+					continue;
+				if ((part.EndsWith('.')) || (part.EndsWith(' ')))
+					return false;
+				for (let c in part.RawChars)
+				{
+					// Reject ASCII control bytes (including NUL) and DEL.
+					if ((c <= '\x1f') || (c == '\x7f'))
+						return false;
+					if (windowsReservedFileNameChars.Contains(c))
+						return false;
+				}
+
+				if (!normalizedPath.IsEmpty)
+					normalizedPath.Append('/');
+				normalizedPath.Append(part);
+			}
+
+			path.Set(normalizedPath);
+			return true;
+		}
+
+		/// Splits "https://host/repo.git?path=/libraryA" into the repository URL handed to Git and the
+		/// normalized project subfolder ("libraryA", empty for the root). Only the 'path' parameter is
+		/// consumed; other query parameters stay in the repository URL. Fragments and duplicate 'path'
+		/// parameters are rejected. On failure the outputs may hold partial text and must be discarded.
+		public static bool ParseGitProjectURL(StringView url, String outRepoURL, String outProjectPath)
+		{
+			outRepoURL.Clear();
+			outProjectPath.Clear();
+
+			if ((url.IsEmpty) || (url.Contains('#')))
+				return false;
+
+			int queryIdx = url.IndexOf('?');
+			if (queryIdx == -1)
+			{
+				outRepoURL.Append(url);
+				return true;
+			}
+
+			if (queryIdx == 0)
+				return false;
+			outRepoURL.Append(url.Substring(0, queryIdx));
+			StringView query = url.Substring(queryIdx + 1);
+			bool wroteParam = false;
+			bool foundPath = false;
+
+			for (let param in query.Split('&'))
+			{
+				if (param.IsEmpty)
+					continue;
+
+				StringView key = param;
+				StringView value = default;
+				int equalsIdx = param.IndexOf('=');
+				if (equalsIdx != -1)
+				{
+					key = param.Substring(0, equalsIdx);
+					value = param.Substring(equalsIdx + 1);
+				}
+
+				if (key == "path")
+				{
+					if ((foundPath) || (equalsIdx == -1))
+						return false;
+					foundPath = true;
+					if (URLDecode(value, outProjectPath) case .Err)
+						return false;
+				}
+				else
+				{
+					outRepoURL.Append(wroteParam ? '&' : '?');
+					outRepoURL.Append(param);
+					wroteParam = true;
+				}
+			}
+
+			return NormalizeGitProjectSubPath(outProjectPath);
+		}
+
+		/// Default project name for a dependency: the selected subfolder's name, or the repository name for the root.
+		public static void GetGitProjectName(StringView repoURL, StringView projectSubPath, String outName)
+		{
+			outName.Clear();
+
+			if (!projectSubPath.IsEmpty)
+				Path.GetFileName(projectSubPath, outName);
+			else
+			{
+				String repoName = scope .(repoURL);
+				int queryIdx = repoName.IndexOf('?');
+				if (queryIdx != -1)
+					repoName.RemoveToEnd(queryIdx);
+				while (repoName.EndsWith('/'))
+					repoName.RemoveFromEnd(1);
+				Path.GetFileName(repoName, outName);
 			}
 		}
 

--- a/IDE/src/Project.bf
+++ b/IDE/src/Project.bf
@@ -1647,7 +1647,9 @@ namespace IDE
 	                return false;
 
 				String managedText = scope .();
-				if (File.ReadAllText(scope $"{mProjectDir}/BeefManaged.toml", managedText) case .Ok)
+				String managedFilePath = scope .();
+				if ((gApp.mPackMan.TryGetManagedInfoPath(mProjectDir, managedFilePath)) &&
+					(File.ReadAllText(managedFilePath, managedText) case .Ok))
 				{
 					mManagedInfo = new .();
 					mManagedInfo.mInfo = new .(managedText);
@@ -1658,6 +1660,14 @@ namespace IDE
 						if (mManagedInfo.mVersion.mVersion == null)
 							mManagedInfo.mVersion.mVersion = new .();
 						msd.GetString("Version", mManagedInfo.mVersion.mVersion);
+
+						// Different tags can select projects from the same cached commit.
+						if ((gApp.mPackMan.IsPathManaged(mProjectDir)) &&
+							(gApp.mWorkspace.mProjectLockMap.TryGetValue(mProjectName, var projectLock)))
+						{
+							if (projectLock case .Git(let url, let tag, let hash))
+								mManagedInfo.mVersion.mVersion.Set(tag);
+						}
 					}
 				}
 			}

--- a/IDE/src/ui/ProjectPanel.bf
+++ b/IDE/src/ui/ProjectPanel.bf
@@ -2277,7 +2277,9 @@ namespace IDE.ui
 				StringView sv = .((.)data, size);
 				for (var line in sv.Split('\n'))
 				{
-					var uri = IDEUtils.URLDecode(line, .. scope .());
+					String uri = scope .();
+					if (IDEUtils.URLDecode(line, uri) case .Err)
+						continue;
 					if (uri.StartsWith("file:///"))
 					{
 						var srcPath = scope String()..Append(uri.Substring("file:///".Length));
@@ -2425,7 +2427,9 @@ namespace IDE.ui
 			StringView sv = .((.)data, size);
 			SrcLoop: for (var line in sv.Split('\n'))
 			{
-				var uri = IDEUtils.URLDecode(line, .. scope .());
+				String uri = scope .();
+				if (IDEUtils.URLDecode(line, uri) case .Err)
+					continue;
 				if (uri.StartsWith("file:///"))
 				{
 					var srcPath = scope String()..Append(uri.Substring("file:///".Length));

--- a/IDE/src/ui/RemoteProjectDialog.bf
+++ b/IDE/src/ui/RemoteProjectDialog.bf
@@ -54,7 +54,17 @@ namespace IDE.ui
 			    return false;
 			}
 
-			var projName = Path.GetFileName(url, .. scope .());
+			String repoURL = scope .();
+			String projectSubPath = scope .();
+			if (!IDEUtils.ParseGitProjectURL(url, repoURL, projectSubPath))
+			{
+				mURLEdit.SetFocus();
+			    app.Fail("Invalid git project path");
+			    return false;
+			}
+
+			String projName = scope .();
+			IDEUtils.GetGitProjectName(repoURL, projectSubPath, projName);
 
 			var version = mVersionEdit.GetText(.. scope .())..Trim();
 			
@@ -95,8 +105,11 @@ namespace IDE.ui
 				if ((path.EndsWith('\\')) || (path.EndsWith('/')))
 					path.RemoveFromEnd(1);
 
+				String repoURL = scope .();
+				String projectSubPath = scope .();
 				String projName = scope .();
-				Path.GetFileName(path, projName);
+				if (IDEUtils.ParseGitProjectURL(path, repoURL, projectSubPath))
+					IDEUtils.GetGitProjectName(repoURL, projectSubPath, projName);
 				mVersionEdit.SetText(projName);
 			}
 		}

--- a/IDE/src/util/PackMan.bf
+++ b/IDE/src/util/PackMan.bf
@@ -45,6 +45,7 @@ namespace IDE.util
 		public String mManagedPath ~ delete _;
 		public bool mFailed;
 		public HashSet<String> mCleanHashSet = new .() ~ DeleteContainerAndItems!(_);
+		HashSet<String> mCleanedHashSet = new .() ~ DeleteContainerAndItems!(_);
 
 		public void Fail(StringView error)
 		{
@@ -57,23 +58,45 @@ namespace IDE.util
 			}
 		}
 
+		/// True when 'path' lies inside a commit directory of the managed cache.
 		public bool IsPathManaged(StringView path)
 		{
-			if (path.IsEmpty)
-				return false;
-			if (String.IsNullOrEmpty(mManagedPath))
-				return false;
-			if (path.Length < mManagedPath.Length)
-				return false;
-			return Path.Equals(mManagedPath, path.Substring(0, mManagedPath.Length));
+			return GetManagedHash(path, scope .());
 		}
 
+		/// Extracts the commit hash directory from a path inside the managed cache.
+		/// Normalizes first: Path.Equals asserts in debug builds on forward slashes.
 		public bool GetManagedHash(StringView path, String outHash)
 		{
-			StringView subView = path.Substring(mManagedPath.Length + 1);
-			if (subView.Length < 40)
+			if (String.IsNullOrEmpty(mManagedPath))
 				return false;
-			outHash.Append(subView.Substring(0, 40));
+
+			String normalizedPath = scope .(path);
+			IDEUtils.FixFilePath(normalizedPath);
+			if (normalizedPath.Length <= mManagedPath.Length)
+				return false;
+			if (!Path.Equals(mManagedPath, normalizedPath.Substring(0, mManagedPath.Length)))
+				return false;
+			if (normalizedPath[mManagedPath.Length] != IDEUtils.cNativeSlash)
+				return false;
+
+			// The first directory below the managed cache root is the commit hash.
+			StringView hashDirectory = normalizedPath.Substring(mManagedPath.Length + 1);
+			int separatorIdx = hashDirectory.IndexOf(IDEUtils.cNativeSlash);
+			if (separatorIdx != -1)
+				hashDirectory = hashDirectory.Substring(0, separatorIdx);
+
+			// Git SHA-1 commit hashes contain exactly 40 hexadecimal digits.
+			const int gitHashLength = 40;
+			if (hashDirectory.Length != gitHashLength)
+				return false;
+			for (let c in hashDirectory.RawChars)
+			{
+				if (!IDEUtils.IsHexDigit(c))
+					return false;
+			}
+
+			outHash.Append(hashDirectory);
 			return true;
 		}
 
@@ -92,29 +115,308 @@ namespace IDE.util
 				return false;
 
 			mManagedPath = new .(gApp.mBeefConfig.mManagedLibPath);
+			IDEUtils.FixFilePath(mManagedPath);
+			while ((mManagedPath.Length > 1) && (mManagedPath.EndsWith(IDEUtils.cNativeSlash)))
+				mManagedPath.RemoveFromEnd(1);
 			mInitialized = true;
 			return true;
 		}
 
-		public void GetPath(StringView url, StringView hash, String outPath)
+		/// Every dependency at the same commit shares one clone directory, whatever its ?path= selects.
+		public void GetClonePath(StringView hash, String outPath)
 		{
-			//var urlHash = SHA256.Hash(url.ToRawData()).ToString(.. scope .());
-			//outPath.AppendF($"{mManagedPath}/{urlHash}/{hash}");
 			outPath.AppendF($"{mManagedPath}/{hash}");
+			IDEUtils.FixFilePath(outPath);
+		}
+
+		/// Directory of the selected project inside the clone, or the clone root when projectSubPath is empty.
+		void GetProjectPath(StringView clonePath, StringView projectSubPath, String outPath)
+		{
+			outPath.Append(clonePath);
+
+			if (!projectSubPath.IsEmpty)
+			{
+				outPath.Append('/');
+				outPath.Append(projectSubPath);
+			}
+			IDEUtils.FixFilePath(outPath);
+		}
+
+		/// Splits a dependency URL into the repository URL handed to Git and the normalized project subfolder.
+		/// Reports a malformed URL through Fail, so load-time callers use IDEUtils.ParseGitProjectURL directly.
+		bool ParseProjectURL(StringView url, String outRepoURL, String outSubPath)
+		{
+			if (IDEUtils.ParseGitProjectURL(url, outRepoURL, outSubPath))
+				return true;
+			Fail(scope $"Invalid git project path in '{url}'");
+			return false;
+		}
+
+		bool CheckProjectPath(StringView projectName, StringView url, StringView projectPath, bool requireProjectFile, String outError)
+		{
+			if (!Directory.Exists(projectPath))
+			{
+				outError.AppendF($"Git project '{projectName}' at '{url}' does not contain subfolder '{projectPath}'");
+				return false;
+			}
+
+			if (requireProjectFile)
+			{
+				String projectFilePath = scope $"{projectPath}/BeefProj.toml";
+				if (!File.Exists(projectFilePath))
+				{
+					outError.AppendF($"Git project '{projectName}' at '{url}' does not contain BeefProj.toml at '{projectPath}'");
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		bool IsClonePendingForHash(StringView hash, WorkItem ignoreItem)
+		{
+			// The clone directory is a pure function of the commit hash,
+			// so matching hashes is equivalent to matching clone paths.
+			for (var workItem in mWorkItems)
+			{
+				if (workItem == ignoreItem)
+					continue;
+				if ((workItem.mHash == null) || (workItem.mHash != hash))
+					continue;
+
+				switch (workItem.mKind)
+				{
+				case .Checkout, .Setup:
+					return true;
+				case .Clone, .CloneShallow:
+					if (workItem.mGitInstance != null)
+						return true;
+				default:
+				}
+			}
+
+			return false;
+		}
+
+		/// Initializes one project after the clone for 'hash' exists on disk, running its Setup if needed.
+		void CompleteProjectFromClone(StringView projectName, StringView url, StringView repoURL, StringView subPath, StringView tag, StringView hash)
+		{
+			String clonePath = GetClonePath(hash, .. scope .());
+			String projectPath = GetProjectPath(clonePath, subPath, .. scope .());
+
+			StructuredData sd = scope .();
+			if (sd.Load(scope $"{clonePath}/BeefManaged.toml") case .Ok)
+			{
+				if (FindProjectEntry(sd, subPath, var setup))
+				{
+					if (!setup)
+						Fail(scope $"Project '{projectName}' previously failed setup. Clean managed cache to try again.");
+					else
+					{
+						String pathError = scope .();
+						if (!CheckProjectPath(projectName, url, projectPath, true, pathError))
+							Fail(pathError);
+						else
+						{
+							CloneCompleted(projectName, url, repoURL, subPath, tag, hash, false, true);
+							ProjectReady(projectName, projectPath);
+						}
+					}
+					return;
+				}
+			}
+
+			// No setup ran, so record nothing and let the next load re-check the folder
+			String pathError = scope .();
+			if (!CheckProjectPath(projectName, url, projectPath, false, pathError))
+			{
+				Fail(pathError);
+				return;
+			}
+
+			String setupPath = scope $"{projectPath}/Setup";
+			if (Directory.Exists(setupPath))
+			{
+				RunSetupProject(projectName, url, tag, hash, setupPath);
+				return;
+			}
+
+			if (!CheckProjectPath(projectName, url, projectPath, true, pathError))
+			{
+				Fail(pathError);
+				return;
+			}
+			if (CloneCompleted(projectName, url, repoURL, subPath, tag, hash, true, true))
+				ProjectReady(projectName, projectPath);
 		}
 
 		bool WantsHashClean(StringView hash)
 		{
 			if (mCleanHashSet.ContainsAlt(hash))
 				return true;
-			if (mCleanHashSet.Contains("*"))
+			if ((mCleanHashSet.Contains("*")) && (!mCleanedHashSet.ContainsAlt(hash)))
 				return true;
 			return false;
 		}
 
-		public bool CheckLock(StringView projectName, String outPath, out bool failed)
+		/// Looks up the recorded result for one project. Version 1 manifests predate ?path= and
+		/// describe only the root; version 2 carries one [[Projects]] entry per subfolder, "." for the root.
+		bool FindProjectEntry(StructuredData sd, StringView subPath, out bool outSetup)
+		{
+			outSetup = false;
+			if (sd.GetInt("FileVersion") == 1)
+			{
+				outSetup = sd.GetBool("Setup");
+				return (subPath.IsEmpty) && (sd.Get("Setup") != null);
+			}
+			if (sd.GetInt("FileVersion") != 2)
+				return false;
+
+			StringView entryPath = subPath.IsEmpty ? StringView(".") : subPath;
+			// Case sensitivity is a property of the file system, not the OS, and Windows 10+ can even set it
+			// per directory: https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity
+			let fsCaseMode = Environment.IsFileSystemCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+			for (sd.Enumerate("Projects"))
+			{
+				String path = scope .();
+				sd.GetString("Path", path);
+				if (path.Equals(entryPath, fsCaseMode))
+				{
+					outSetup = sd.GetBool("Setup");
+					return true;
+				}
+			}
+			return false;
+		}
+
+		public bool TryGetManagedInfoPath(StringView projectDir, String outManifestPath)
+		{
+			String hash = scope .();
+			if (!GetManagedHash(projectDir, hash))
+			{
+				var localPath = scope $"{projectDir}/BeefManaged.toml";
+				if (!File.Exists(localPath))
+					return false;
+				outManifestPath.Append(localPath);
+				return true;
+			}
+
+			String cloneRoot = scope $"{mManagedPath}/{hash}";
+			String subPath = scope .();
+			if (projectDir.Length > cloneRoot.Length)
+				subPath.Append(projectDir.Substring(cloneRoot.Length + 1));
+			if (!IDEUtils.NormalizeGitProjectSubPath(subPath))
+				return false;
+
+			var manifestPath = scope $"{cloneRoot}/BeefManaged.toml";
+			StructuredData sd = scope .();
+			if (sd.Load(manifestPath) case .Err)
+				return false;
+			if (!FindProjectEntry(sd, subPath, var setup))
+				return false;
+			outManifestPath.Append(manifestPath);
+			return true;
+		}
+
+		void WriteProjectEntry(StructuredData sd, StringView path, bool setup)
+		{
+			using (sd.CreateObject())
+			{
+				sd.Add("Path", path.IsEmpty ? StringView(".") : path);
+				sd.Add("Setup", setup);
+			}
+		}
+
+		/// In a shared clone the repository-level Version/GitTag fields describe whichever project wrote
+		/// last. Per-project state lives in [[Projects]]; Project.Load overrides the displayed version
+		/// from the workspace lock.
+		bool WriteManifestFile(StringView clonePath, StructuredData sd)
+		{
+			var manifestPath = scope $"{clonePath}/BeefManaged.toml";
+			if (File.WriteAllText(manifestPath, sd.ToTOML(.. scope .())) case .Err)
+			{
+				Fail(scope $"Failed to write managed library metadata at '{manifestPath}'");
+				return false;
+			}
+			return true;
+		}
+
+		/// A manifest with no project entries marks a completed checkout awaiting setup,
+		/// so an interrupted first setup reuses the clone instead of fetching it again.
+		bool WriteCheckoutMarker(StringView repoURL, StringView tag, StringView hash, StringView clonePath)
+		{
+			StructuredData sd = scope .();
+			sd.CreateNew();
+			sd.Add("FileVersion", 2);
+			sd.Add("Version", tag);
+			sd.Add("GitURL", repoURL);
+			sd.Add("GitTag", tag);
+			sd.Add("GitHash", hash);
+			using (sd.CreateArray("Projects"))
+			{
+			}
+
+			return WriteManifestFile(clonePath, sd);
+		}
+
+		/// Records the initialization result for one project, preserving the entries of every other
+		/// project in this clone.
+		bool WriteProjectResult(StringView repoURL, StringView subPath, StringView tag, StringView hash, StringView clonePath, bool setupComplete)
+		{
+			var manifestPath = scope $"{clonePath}/BeefManaged.toml";
+			StructuredData oldSd = scope .();
+			oldSd.Load(manifestPath).IgnoreError();
+
+			// Mirror the root entry for older readers, which only understand the
+			// top-level Setup key. They still cannot resolve subfolder dependencies.
+			bool hasRootSetup = FindProjectEntry(oldSd, "", var rootSetup);
+			if (subPath.IsEmpty)
+			{
+				hasRootSetup = true;
+				rootSetup = setupComplete;
+			}
+
+			StructuredData sd = scope .();
+			sd.CreateNew();
+			sd.Add("FileVersion", 2);
+			sd.Add("Version", tag);
+			sd.Add("GitURL", repoURL);
+			sd.Add("GitTag", tag);
+			sd.Add("GitHash", hash);
+			if (hasRootSetup)
+				sd.Add("Setup", rootSetup);
+			using (sd.CreateArray("Projects"))
+			{
+				// Preserve the migrated v1 root result when recording a subfolder.
+				// A root result replaces it with the new value below.
+				if ((oldSd.GetInt("FileVersion") == 1) && (hasRootSetup) && (!subPath.IsEmpty))
+					WriteProjectEntry(sd, ".", rootSetup);
+				if (oldSd.GetInt("FileVersion") == 2)
+				{
+					StringView entryPath = subPath.IsEmpty ? StringView(".") : subPath;
+					let fsCaseMode = Environment.IsFileSystemCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+					for (oldSd.Enumerate("Projects"))
+					{
+						String path = scope .();
+						oldSd.GetString("Path", path);
+						if (path.Equals(entryPath, fsCaseMode))
+							continue;
+						WriteProjectEntry(sd, path, oldSd.GetBool("Setup"));
+					}
+				}
+				WriteProjectEntry(sd, subPath, setupComplete);
+			}
+
+			return WriteManifestFile(clonePath, sd);
+		}
+
+		/// Fast path for a locked dependency whose commit is already cached and initialized.
+		/// Sets 'failed' and outError when the lock cannot be used, so the caller reports it
+		/// instead of this method failing synchronously inside the project loop.
+		public bool CheckLock(StringView projectName, StringView projectURL, String outPath, String outError, out bool failed)
 		{
 			failed = false;
+			outError.Clear();
 
 			if (!CheckInit())
 				return false;
@@ -131,48 +433,70 @@ namespace IDE.util
 			switch (lock)
 			{
 			case .Git(let url, let tag, let hash):
+				if (url != projectURL)
+					return false;
+
+				String projectSubPath = scope .();
+				{
+					String repoURL = scope .();
+					if (!IDEUtils.ParseGitProjectURL(url, repoURL, projectSubPath))
+					{
+						outError.AppendF($"Invalid git project path in '{url}'");
+						failed = true;
+						return false;
+					}
+				}
 				if (WantsHashClean(hash))
 					return false;
-				var path = GetPath(url, hash, .. scope .());
-				var managedFilePath = scope $"{path}/BeefManaged.toml";
-				if (File.Exists(managedFilePath))
-				{
-					StructuredData sd = scope .();
-					sd.Load(managedFilePath).IgnoreError();
-					outPath.Append(path);
-					outPath.Append("/BeefProj.toml");
 
-					if (!sd.GetBool("Setup"))
-						gApp.OutputErrorLine(scope $"Project '{projectName}' previous failed setup. Clean managed cache to try again.");
-					return true;
+				var clonePath = GetClonePath(hash, .. scope .());
+				var rootManagedFilePath = scope $"{clonePath}/BeefManaged.toml";
+				if (!File.Exists(rootManagedFilePath))
+					return false;
+
+				String projectPath = scope .();
+				GetProjectPath(clonePath, projectSubPath, projectPath);
+
+				StructuredData sd = scope .();
+				if (sd.Load(rootManagedFilePath) case .Err)
+					return false;
+
+				bool entrySetup;
+				if (!FindProjectEntry(sd, projectSubPath, out entrySetup))
+					return false;
+
+				outPath.Append(projectPath);
+				outPath.Append("/BeefProj.toml");
+
+				if (!entrySetup)
+				{
+					outError.AppendF($"Project '{projectName}' previously failed setup. Clean managed cache to try again.");
+					failed = true;
+					return false;
 				}
+				if (!CheckProjectPath(projectName, url, projectPath, true, outError))
+				{
+					failed = true;
+					return false;
+				}
+				return true;
 			default:
 			}
 
 			return false;
 		}
 
-		public void CloneCompleted(StringView projectName, StringView url, StringView tag, StringView hash, StringView path, bool writeFile, bool setupComplete)
+		/// Locks the project to this commit and, when writeFile is set, records its result in the clone's manifest.
+		bool CloneCompleted(StringView projectName, StringView url, StringView repoURL, StringView subPath, StringView tag, StringView hash, bool writeFile, bool setupComplete)
 		{
-			if (mCleanHashSet.GetAndRemoveAlt(hash) case .Ok(let val))
-				delete val;
-
-			gApp.mWorkspace.SetLock(projectName, .Git(new .(url), new .(tag), new .(hash)));
-
 			if (writeFile)
 			{
-				StructuredData sd = scope .();
-				sd.CreateNew();
-				sd.Add("FileVersion", 1);
-				sd.Add("Version", tag);
-				sd.Add("GitURL", url);
-				sd.Add("GitTag", tag);
-				sd.Add("GitHash", hash);
-				sd.Add("Setup", setupComplete);
-				var tomlText = sd.ToTOML(.. scope .());
-				var managedFilePath = scope $"{path}/BeefManaged.toml";
-				File.WriteAllText(managedFilePath, tomlText).IgnoreError();
+				String clonePath = GetClonePath(hash, .. scope .());
+				if (!WriteProjectResult(repoURL, subPath, tag, hash, clonePath, setupComplete))
+					return false;
 			}
+			gApp.mWorkspace.SetLock(projectName, .Git(new .(url), new .(tag), new .(hash)));
+			return true;
 		}
 
 		public void RunSetupProject(StringView projectName, StringView url, StringView tag, StringView hash, StringView path)
@@ -198,13 +522,9 @@ namespace IDE.util
 			workItem.mTag = new .(tag);
 			workItem.mHash = new .(hash);
 			workItem.mPath = new .(path);
+			IDEUtils.FixFilePath(workItem.mPath);
 			workItem.mExecInstance = execInst;
 			mWorkItems.Add(workItem);
-
-			/*cmd.mDoneEvent.Add(new (success) =>
-				{
-					int a = 123;
-				});*/
 		}
 
 		public void DeleteDir(StringView path)
@@ -236,49 +556,17 @@ namespace IDE.util
 				});
 		}
 
-		public void GetWithHash(StringView projectName, StringView url, StringView tag, StringView hash)
+		/// Called only after GetWithVersion has validated the URL.
+		void GetWithHash(StringView projectName, StringView url, StringView tag, StringView hash)
 		{
 			if (!CheckInit())
 				return;
 
-			String destPath = GetPath(url, hash, .. scope .());
-			var urlPath = Path.GetDirectoryPath(destPath, .. scope .());
-			Directory.CreateDirectory(urlPath).IgnoreError();
-			if (Directory.Exists(destPath))
-			{
-				if (!WantsHashClean(hash))
-				{
-					var managedFilePath = scope $"{destPath}/BeefManaged.toml";
-					if (File.Exists(managedFilePath))
-					{
-						if (gApp.mVerbosity >= .Normal)
-						{
-							if (tag.IsEmpty)
-								gApp.OutputLine($"Git selecting library '{projectName}' at {hash.Substring(0, 7)}");
-							else
-								gApp.OutputLine($"Git selecting library '{projectName}' tag '{tag}' at {hash.Substring(0, 7)}");
-						}
-
-						CloneCompleted(projectName, url, tag, hash, destPath, false, false);
-						ProjectReady(projectName, destPath);
-						return;
-					}
-				}
-
-				DeleteDir(destPath);
-			}
-
-			if (gApp.mVerbosity >= .Normal)
-			{
-				if (tag.IsEmpty)
-					gApp.OutputLine($"Git cloning library '{projectName}' at {hash.Substring(0, 7)}...");
-				else
-					gApp.OutputLine($"Git cloning library '{projectName}' tag '{tag}' at {hash.Substring(0, 7)}");
-			}
+			String destPath = GetClonePath(hash, .. scope .());
 
 			bool hasShallowClone = false;
 			if (GitManager.GetGitVersion() case .Ok(let ver))
-				hasShallowClone = ver.Major > 2 || (ver.Major == 2 && ver.Minor >= 49);
+				hasShallowClone = (ver.Major > 2) || ((ver.Major == 2) && (ver.Minor >= 49));
 
 			WorkItem workItem = new .();
 			workItem.mKind = hasShallowClone ? .CloneShallow : .Clone;
@@ -290,10 +578,19 @@ namespace IDE.util
 			mWorkItems.Add(workItem);
 		}
 
-		public Result<void> GetWithVersion(StringView projectName, StringView url, SemVer semVer)
+		public Result<void> GetWithVersion(StringView projectName, StringView url, SemVer semVer, String outError)
 		{
 			if (!CheckInit())
 				return .Err;
+			{
+				String repoURL = scope .();
+				String projectSubPath = scope .();
+				if (!IDEUtils.ParseGitProjectURL(url, repoURL, projectSubPath))
+				{
+					outError.AppendF($"Invalid git project path in '{url}'");
+					return .Err;
+				}
+			}
 
 			bool ignoreLock = false;
 			if (gApp.mWantUpdateVersionLocks != null)
@@ -308,8 +605,10 @@ namespace IDE.util
 				{
 				case .Git(let checkURL, let tag, let hash):
 					if (checkURL == url)
+					{
 						GetWithHash(projectName, url, tag, hash);
-					return .Ok;
+						return .Ok;
+					}
 				default:
 				}
 			}
@@ -381,14 +680,29 @@ namespace IDE.util
 					case .Setup:
 						if ((workItem.mExecInstance == null) || (workItem.mExecInstance.mDone))
 						{
-							bool success = workItem.mExecInstance?.mExitCode == 0;
-							String projPath = Path.GetAbsolutePath("../", workItem.mPath, .. scope .());
-							CloneCompleted(workItem.mProjectName, workItem.mURL, workItem.mTag, workItem.mHash, projPath, true, success);
-							if (success)
-								ProjectReady(workItem.mProjectName, projPath);
-							else
-								gApp.OutputErrorLine(scope $"Failed to setup project '{workItem.mProjectName}' located at '{projPath}'");
 							removeItem = true;
+
+							String repoURL = scope .();
+							String subPath = scope .();
+							if (!ParseProjectURL(workItem.mURL, repoURL, subPath))
+								break;
+
+							String clonePath = GetClonePath(workItem.mHash, .. scope .());
+							String projPath = GetProjectPath(clonePath, subPath, .. scope .());
+							bool success = workItem.mExecInstance?.mExitCode == 0;
+							String setupError = scope .();
+							if (success)
+								success = CheckProjectPath(workItem.mProjectName, workItem.mURL, projPath, true, setupError);
+							else
+								setupError.AppendF($"Failed to setup project '{workItem.mProjectName}' located at '{projPath}'");
+							// Record the result and lock before Fail can flush deferred loads.
+							if (CloneCompleted(workItem.mProjectName, workItem.mURL, repoURL, subPath, workItem.mTag, workItem.mHash, true, success))
+							{
+								if (success)
+									ProjectReady(workItem.mProjectName, projPath);
+								else
+									Fail(setupError);
+							}
 						}
 					default:
 					}
@@ -462,21 +776,12 @@ namespace IDE.util
 						if (gApp.mVerbosity >= .Normal)
 							gApp.OutputLine($"Git cloning library '{workItem.mProjectName}' done.");
 
-						String setupPath = scope $"{workItem.mPath}/Setup";
-
-						/*if (workItem.mProjectName == "BeefProj0")
+						String repoURL = scope .();
+						String subPath = scope .();
+						if ((ParseProjectURL(workItem.mURL, repoURL, subPath)) &&
+							(WriteCheckoutMarker(repoURL, workItem.mTag, workItem.mHash, workItem.mPath)))
 						{
-							setupPath.Set("C:/proj/BeefProj0/Setup");
-						}*/
-
-						if (Directory.Exists(setupPath))
-						{
-							RunSetupProject(workItem.mProjectName, workItem.mURL, workItem.mTag, workItem.mHash, setupPath);
-						}
-						else
-						{
-							CloneCompleted(workItem.mProjectName, workItem.mURL, workItem.mTag, workItem.mHash, workItem.mPath, true, true);
-							ProjectReady(workItem.mProjectName, workItem.mPath);
+							CompleteProjectFromClone(workItem.mProjectName, workItem.mURL, repoURL, subPath, workItem.mTag, workItem.mHash);
 						}
 					default:
 					}
@@ -497,23 +802,95 @@ namespace IDE.util
 
 			if (!executingGit)
 			{
-				// First handle active git items
+				// Start queued work after active Git operations finish.
 				for (var workItem in mWorkItems)
 				{
 					if (workItem.mGitInstance != null)
 						continue;
 
+					// After any failure, drop queued work that has not started so one broken
+					// dependency does not start a cascade of new clones. An already-running
+					// Setup still completes and records its own result above.
+					if ((mFailed) && (workItem.mKind != .Setup))
+					{
+						@workItem.Remove();
+						delete workItem;
+						continue;
+					}
+					bool removeItem = false;
 					switch (workItem.mKind)
 					{
 					case .FindVersion:
-						workItem.mGitInstance = gApp.mGitManager.GetTags(workItem.mURL)..AddRef();
+						String repoURL = scope .();
+						if (ParseProjectURL(workItem.mURL, repoURL, scope .()))
+							workItem.mGitInstance = gApp.mGitManager.GetTags(repoURL)..AddRef();
+						else
+							removeItem = true;
 					case .Checkout:
 						workItem.mGitInstance = gApp.mGitManager.Checkout(workItem.mPath, workItem.mHash)..AddRef();
-					case .Clone:
-						workItem.mGitInstance = gApp.mGitManager.Clone(workItem.mURL, workItem.mPath)..AddRef();
-					case .CloneShallow:
-						workItem.mGitInstance = gApp.mGitManager.CloneShallow(workItem.mURL, workItem.mPath, workItem.mHash)..AddRef();
+					case .Clone, .CloneShallow:
+						// Several dependencies can select the same commit. Only one clones it;
+						// the others wait here until that clone and any setup in it finish.
+						if (IsClonePendingForHash(workItem.mHash, workItem))
+							continue;
+
+						String repoURL = scope .();
+						String subPath = scope .();
+						if (!ParseProjectURL(workItem.mURL, repoURL, subPath))
+						{
+							removeItem = true;
+							break;
+						}
+
+						String manifestPath = scope $"{workItem.mPath}/BeefManaged.toml";
+						bool canReuseClone = false;
+						if (!WantsHashClean(workItem.mHash))
+						{
+							StructuredData sd = scope .();
+							if (sd.Load(manifestPath) case .Ok)
+							{
+								int fileVersion = sd.GetInt("FileVersion");
+								canReuseClone = (fileVersion == 1) || (fileVersion == 2);
+								if ((!canReuseClone) && (gApp.mVerbosity >= .Normal))
+									gApp.OutputLine($"Unsupported managed metadata (FileVersion {fileVersion}) at '{manifestPath}', rebuilding");
+							}
+							else if ((File.Exists(manifestPath)) && (gApp.mVerbosity >= .Normal))
+								gApp.OutputLine($"Unreadable managed metadata at '{manifestPath}', rebuilding");
+						}
+
+						if (canReuseClone)
+						{
+							CompleteProjectFromClone(workItem.mProjectName, workItem.mURL, repoURL, subPath, workItem.mTag, workItem.mHash);
+							removeItem = true;
+						}
+						else
+						{
+							// No usable metadata: the directory is missing, an interrupted checkout,
+							// explicitly cleaned, or written in a format this build does not read.
+							if (Directory.Exists(workItem.mPath))
+								DeleteDir(workItem.mPath);
+							if (mFailed)
+								continue;
+							if (mCleanHashSet.GetAndRemoveAlt(workItem.mHash) case .Ok(let val))
+								delete val;
+							if (mCleanedHashSet.TryAddAlt(workItem.mHash, var entryPtr))
+								*entryPtr = new .(workItem.mHash);
+							Directory.CreateDirectory(mManagedPath).IgnoreError();
+							if (gApp.mVerbosity >= .Normal)
+								gApp.OutputLine($"Git cloning library '{workItem.mProjectName}' at {workItem.mHash.Substring(0, 7)}...");
+							if (workItem.mKind == .CloneShallow)
+								workItem.mGitInstance = gApp.mGitManager.CloneShallow(repoURL, workItem.mPath, workItem.mHash)..AddRef();
+							else
+								workItem.mGitInstance = gApp.mGitManager.Clone(repoURL, workItem.mPath)..AddRef();
+						}
+
 					default:
+					}
+
+					if (removeItem)
+					{
+						@workItem.Remove();
+						delete workItem;
 					}
 				}
 			}
@@ -521,19 +898,7 @@ namespace IDE.util
 
 		public void GetHashFromFilePath(StringView filePath, String path)
 		{
-			if (mManagedPath == null)
-				return;
-
-			if (!filePath.StartsWith(mManagedPath))
-				return;
-
-			StringView hashPart = filePath.Substring(mManagedPath.Length);
-			if (hashPart.Length < 42)
-				return;
-
-			hashPart.RemoveFromStart(1);
-			hashPart.Length = 40;
-			path.Append(hashPart);
+			GetManagedHash(filePath, path);
 		}
 
 		public void CancelAll()


### PR DESCRIPTION
I've been working on issue #2453 on and off since i made the issue, but finally decided to get it polished up this weekend.

Since I didn't get any specific feedback the preferred approach, I've kept with the overall design i outlined in the issue.

This pull request introduces a Version 2 BeefManaged.toml file with a very similar format to the original but with the addition of a `[[Projects]]` array added. Which allows multiple projects within a given cloned repo to be tracked for a beef project.

This implementation will only clone any given repo once for a given commit hash, if 2 dependencies in the same repo resolve to different commit hashes there will still be 2 copies of the repo.

Setup remains project-local. Previously, the project root was always the repository root. With this change, setup runs from the selected project’s Setup/ directory. Existing root-level dependencies retain their behavior; selecting a subfolder does not automatically run the repository-root setup.

This is the new behavior:
```
  BeefManaged/<commit-hash>/
    BeefManaged.toml
    Setup/             <-- runs when the root project is selected
    libraryA/
      Setup/           <-- runs when libraryA is selected
    libraryB/
      Setup/           <-- runs when libraryB is selected
```

Previously, Beef ran one Setup/ per managed Git dependency, located at the repository root:

```
  BeefManaged/<commit-hash>/
    BeefProj.toml
    Setup/
```

Here is the toml produced for the case above where the root project, libraryA, and libraryB are all initialized:

```toml
FileVersion = 2
Version = "v1.1.0"
GitURL = "https://github.com/user/proj.git"
GitTag = "v1.1.0"
GitHash = "0e86f98bc7436544c68bf9ff6dbe8103606912a5"
Setup = true

[[Projects]]
Path = "."
Setup = true

[[Projects]]
Path = "libraryA"
Setup = true

[[Projects]]
Path = "libraryB"
Setup = true
```

The top-level Setup key mirrors the Path = "." entry for compatibility: any Beef build prior to this PR reads only that key and never checks FileVersion. This allows root-only libraries to continue loading when a managed cache is shared between such a build and one with this change.

If no workspaces have initialized the root level project in this cached clone no top-level Setup key will exist:
```toml
FileVersion = 2
Version = "v1.1.0"
GitURL = "https://github.com/user/proj.git"
GitTag = "v1.1.0"
GitHash = "0e86f98bc7436544c68bf9ff6dbe8103606912a5"

[[Projects]]
Path = "libraryA"
Setup = true

[[Projects]]
Path = "libraryB"
Setup = true
```

Existing version 1 caches remain readable and are not rewritten by a root-only dependency. The first time a subfolder is initialized for that clone, the root's Setup key is copied to a Path = "." entry and the file is rewritten as version 2.

It's worth explicitly noting here that Setup = true on an entry means the project initialized successfully (whether or not it had a Setup folder), false means its setup attempted to run but did not complete successfully, and a missing entry means it has not been initialized yet.

The syntax for selecting projects is based on a url query parameter that is parsed by beef, as mentioned in the issue.

`https://github.com/user/proj.git?path=/libraryA`
`https://github.com/user/proj.git?path=/libraryB`

This design is based on what unity does for it's git based package manager which i've found over the years works very well in my projects.

The workspace lock file will store the full dependency URL including `?path=`, so two projects from one repository
are locked independently:

```toml
FileVersion = 1

[Locks.LibraryA.Git]
URL = "https://github.com/user/proj.git?path=/libraryA"
Tag = "v1.1.0"
Hash = "0e86f98bc7436544c68bf9ff6dbe8103606912a5"

[Locks.LibraryB.Git]
URL = "https://github.com/user/proj.git?path=/libraryB"
Tag = "v1.1.0"
Hash = "0e86f98bc7436544c68bf9ff6dbe8103606912a5"

[Locks.Root.Git]
URL = "https://github.com/user/proj.git"
Tag = "v1.1.0"
Hash = "0e86f98bc7436544c68bf9ff6dbe8103606912a5"
```

Other changes in this PR as found by claude:

- Plain Git URLs are now validated. A URL containing `#` or starting with `?` is rejected with `Invalid git project path`. Only the `path` query parameter is consumed; anything else in the query string is passed through to Git unchanged.
- A workspace lock is only used when its URL matches the dependency exactly. Changing the `?path=` on a dependency re-resolves the version and writes a new lock.
- A dependency whose selected folder or `BeefProj.toml` is missing records nothing in the manifest, so every load reports that specific error instead of a cached "previously failed setup". A setup that exits successfully but leaves no `BeefProj.toml` is recorded as failed.
- A failed setup now fails the workspace load. Previously it only logged an error and the workspace stayed in the preparing state.
- After the first failure, queued Git work that hasn't started yet is dropped, since the workspace load has already failed and those clones would be wasted. A setup that is already running still finishes and records its result.
- Fixed `GetWithVersion` returning success without doing anything when a lock existed with a different URL. It now re-resolves the dependency.
- A cache whose `BeefManaged.toml` can't be parsed or has a `FileVersion` other than 1 or 2 is deleted and cloned again. The reason is printed at normal verbosity, e.g. `Unsupported managed metadata (FileVersion 3) at '<path>', rebuilding`.
- `-cleancache` and **Clear Managed Cache** clean the whole commit's clone, which affects every project sharing it. Each hash is rebuilt once per run even when several projects select it.
- `IDEUtils.URLDecode` now returns a `Result` and rejects incomplete or non-hex escapes (`%2`, `%GG`, `%+1`). Previously a bad escape decoded to a NUL byte. The two clipboard file-URI callers in the project panel skip malformed lines; valid encoded paths are unaffected.
- Lock and load-time failures are reported by the project loader and the affected project fails to load, instead of the package manager failing synchronously inside the workspace project loop.

Something else i wanted to bring up is for path case handling (which i also left a comment about in the code):
The manifest entry paths are matched with `Environment.IsFileSystemCaseSensitive`, this same approach is also used elsewhere in the IDE and corelib. This is not entirely a correct implementation in all edge cases because case sensitivity generally is a property of the file system rather than the OS. PLUS Windows 10+ can change case sensitivity per directory (https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity), so a global flag is an approximation. It is usually fine but longer-term there is room for improvements across the code to handle this more correctly. This PR makes no attempt to improve these edge cases, but i did want to at least note that this is a potential issue more generally as it was something i noticed going through the code.

And finally one thing to note about compatibility with versions prior to this change:

Workspaces that use ?path= require a build with this change. Verified against a build from current master: root-only workspaces load in both directions without re-running setup thanks to the mirrored top-level Setup key. A pre-PR build given a ?path= workspace either fails to resolve the dependency (cold cache), reports "previous failed setup" (subfolder-only cache), or, if the root is also a dependency and the cache is warm, silently loads the repository root in place of the selected subfolder. During testing running prior builds without -cleancache left manifest and lock files contents unchanged, so switching back to a newer build recovers without intervention.

So overall this is quite a large rework of how the PackMan class works generally due to the additional complexity of this feature. But i do think the end result is worth having.

For transparency this work was llm assisted, i have heavily verified through testing and review of the code(and through the use of multiple models for finding edge cases and issues) prior to commit.