### PR TITLE
BeefySysLib: implement BfpFile_GetTempPath on POSIX

### DIFF
--- a/BeefySysLib/platform/posix/PosixCommon.cpp
+++ b/BeefySysLib/platform/posix/PosixCommon.cpp
@@ -3044,7 +3044,18 @@ BFP_EXPORT bool BFP_CALLTYPE BfpFile_Exists(const char* path)
 
 BFP_EXPORT void BFP_CALLTYPE BfpFile_GetTempPath(char* outPath, int* inOutPathSize, BfpFileResult* outResult)
 {
-    NOT_IMPL;
+    // TMPDIR is the POSIX spelling; /tmp is the fallback, and is already what
+    // BfpFile_GetTempFileName below assumes. The result ends with a separator, which is
+    // what the Windows implementation hands back from GetTempPathW.
+    const char* tempDir = getenv("TMPDIR");
+    if ((tempDir == NULL) || (tempDir[0] == 0))
+        tempDir = "/tmp";
+
+    String str = tempDir;
+    if ((str.GetLength() == 0) || (str[str.GetLength() - 1] != '/'))
+        str += "/";
+
+    TryStringOut(str, outPath, inOutPathSize, (BfpResult*)outResult);
 }
 
 static const char cHash64bToChar[] = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',


### PR DESCRIPTION
It was NOT_IMPL, so Path.GetTempPath returned an empty string on Linux and macOS and every caller composed a path at the filesystem root. corlib's own FileTests.WriteAll_PropagatesResult is one of them, and could not have passed on either platform.

The temp directory was already known to this file: BfpFile_GetTempFileName sits directly below and hardcodes /tmp. This reads TMPDIR first, as POSIX tools do, falls back to the same /tmp, and returns it with a trailing separator to match what the Windows implementation returns from GetTempPathW.